### PR TITLE
Add multi-format import/export with full round-trip test coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # linXiv
+#todo: create table of contents
 
 A Python application for discovering, managing, and visualizing academic papers from arXiv. Combines a local SQLite database, OPTIONAL AI-powered tagging, Obsidian vault integration, and an interactive D3.js network graph, wrapped in a PyQt6 GUI.
 

--- a/formats/__init__.py
+++ b/formats/__init__.py
@@ -1,0 +1,40 @@
+"""File-format registry for paper import/export.
+
+Usage
+-----
+from formats import registry, format_for_extension
+
+fmt = format_for_extension(".bib")   # -> BibTeXFormat instance
+papers = fmt.import_file("refs.bib") # -> list[PaperMetadata]
+
+Adding a new format
+-------------------
+1. Create formats/<name>.py implementing PaperFileFormat (see formats/base.py).
+2. Import and register it here.
+"""
+
+from __future__ import annotations
+
+from formats.base import PaperFileFormat
+from formats.json_fmt import JSONFormat
+from formats.csv_fmt import CSVFormat, TSVFormat
+from formats.bibtex import BibTeXFormat
+
+registry: dict[str, PaperFileFormat] = {
+    "json":   JSONFormat(),
+    "csv":    CSVFormat(),
+    "tsv":    TSVFormat(),
+    "bibtex": BibTeXFormat(),
+}
+
+
+def format_for_extension(ext: str) -> PaperFileFormat | None:
+    """Return the format handler for a file extension (e.g. '.bib'), or None."""
+    ext = ext.lower()
+    for fmt in registry.values():
+        if ext in fmt.extensions:
+            return fmt
+    return None
+
+
+__all__ = ["PaperFileFormat", "registry", "format_for_extension"]

--- a/formats/__init__.py
+++ b/formats/__init__.py
@@ -19,12 +19,15 @@ from formats.base import PaperFileFormat
 from formats.json_fmt import JSONFormat
 from formats.csv_fmt import CSVFormat, TSVFormat
 from formats.bibtex import BibTeXFormat
+from formats.markdown import MarkdownFormat, ObsidianFormat
 
 registry: dict[str, PaperFileFormat] = {
-    "json":   JSONFormat(),
-    "csv":    CSVFormat(),
-    "tsv":    TSVFormat(),
-    "bibtex": BibTeXFormat(),
+    "json":     JSONFormat(),
+    "csv":      CSVFormat(),
+    "tsv":      TSVFormat(),
+    "bibtex":   BibTeXFormat(),
+    "markdown": MarkdownFormat(),
+    "obsidian": ObsidianFormat(),
 }
 
 

--- a/formats/base.py
+++ b/formats/base.py
@@ -1,0 +1,26 @@
+"""Base protocol for file-based paper import/export formats.
+
+File formats (JSON, CSV, BibTeX, …) live here.
+Source formats (arXiv, OpenAlex, …) use sources.base.PaperSource — both
+converge on PaperMetadata so the DB layer treats them identically.
+"""
+
+from __future__ import annotations
+
+from typing import Protocol, runtime_checkable
+
+from sources.base import PaperMetadata
+
+
+@runtime_checkable
+class PaperFileFormat(Protocol):
+    format_name: str       # e.g. "json", "csv", "bibtex"
+    extensions: list[str]  # e.g. [".json"], [".bib"]
+
+    def import_file(self, path: str) -> list[PaperMetadata]:
+        """Parse a file and return PaperMetadata records."""
+        ...
+
+    def export_papers(self, papers: list[dict]) -> str:
+        """Serialize paper dicts to a string in this format."""
+        ...

--- a/formats/bibtex.py
+++ b/formats/bibtex.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import datetime
 
-from pybtex.database import parse_file, BibliographyData, Entry  # type: ignore[import-untyped]
+from pybtex.database import parse_file, parse_string, BibliographyData, Entry  # type: ignore[import-untyped]
 
 from sources.base import PaperMetadata
 
@@ -19,30 +19,36 @@ def _parse_year(fields: dict) -> datetime.date:
         return _FALLBACK_DATE
 
 
+def _bib_to_metadata(bib) -> list[PaperMetadata]:
+    results: list[PaperMetadata] = []
+    for key, entry in bib.entries.items():
+        f = entry.fields
+        authors = [str(p) for p in entry.persons.get("author", [])]
+        doi = f.get("doi") or None
+        results.append(PaperMetadata(
+            paper_id    = doi or key,
+            version     = 1,
+            title       = f.get("title", key),
+            authors     = authors,
+            published   = _parse_year(f),
+            summary     = f.get("abstract", ""),
+            doi         = doi,
+            journal_ref = f.get("journal") or f.get("booktitle") or None,
+            url         = f.get("url") or None,
+            source      = "bibtex",
+        ))
+    return results
+
+
 class BibTeXFormat:
     format_name = "bibtex"
     extensions = [".bib"]
 
     def import_file(self, path: str) -> list[PaperMetadata]:
-        bib = parse_file(path)
-        results: list[PaperMetadata] = []
-        for key, entry in bib.entries.items():
-            f = entry.fields
-            authors = [str(p) for p in entry.persons.get("author", [])]
-            doi = f.get("doi") or None
-            results.append(PaperMetadata(
-                paper_id    = doi or key,
-                version     = 1,
-                title       = f.get("title", key),
-                authors     = authors,
-                published   = _parse_year(f),
-                summary     = f.get("abstract", ""),
-                doi         = doi,
-                journal_ref = f.get("journal") or f.get("booktitle") or None,
-                url         = f.get("url") or None,
-                source      = "bibtex",
-            ))
-        return results
+        return _bib_to_metadata(parse_file(path))
+
+    def import_string(self, text: str) -> list[PaperMetadata]:
+        return _bib_to_metadata(parse_string(text, bib_format="bibtex"))
 
     def export_papers(self, papers: list[dict]) -> str:
         bib = BibliographyData()

--- a/formats/bibtex.py
+++ b/formats/bibtex.py
@@ -1,0 +1,65 @@
+"""BibTeX import/export via pybtex."""
+
+from __future__ import annotations
+
+import datetime
+
+from pybtex.database import parse_file, BibliographyData, Entry  # type: ignore[import-untyped]
+
+from sources.base import PaperMetadata
+
+_FALLBACK_DATE = datetime.date(1900, 1, 1)
+
+
+def _parse_year(fields: dict) -> datetime.date:
+    raw = fields.get("year", "")
+    try:
+        return datetime.date(int(raw), 1, 1)
+    except (ValueError, TypeError):
+        return _FALLBACK_DATE
+
+
+class BibTeXFormat:
+    format_name = "bibtex"
+    extensions = [".bib"]
+
+    def import_file(self, path: str) -> list[PaperMetadata]:
+        bib = parse_file(path)
+        results: list[PaperMetadata] = []
+        for key, entry in bib.entries.items():
+            f = entry.fields
+            authors = [str(p) for p in entry.persons.get("author", [])]
+            doi = f.get("doi") or None
+            results.append(PaperMetadata(
+                paper_id    = doi or key,
+                version     = 1,
+                title       = f.get("title", key),
+                authors     = authors,
+                published   = _parse_year(f),
+                summary     = f.get("abstract", ""),
+                doi         = doi,
+                journal_ref = f.get("journal") or f.get("booktitle") or None,
+                url         = f.get("url") or None,
+                source      = "bibtex",
+            ))
+        return results
+
+    def export_papers(self, papers: list[dict]) -> str:
+        bib = BibliographyData()
+        for p in papers:
+            key = (p.get("paper_id") or "unknown").replace("/", "_").replace(".", "_")
+            pub = p.get("published", "")
+            year = pub.isoformat()[:4] if isinstance(pub, (datetime.date, datetime.datetime)) else str(pub)[:4]
+            fields: dict[str, str] = {
+                "title":    p.get("title", ""),
+                "year":     year,
+                "abstract": p.get("summary", ""),
+            }
+            if p.get("doi"):
+                fields["doi"] = p["doi"]
+            if p.get("journal_ref"):
+                fields["journal"] = p["journal_ref"]
+            if p.get("url"):
+                fields["url"] = p["url"]
+            bib.entries[key] = Entry("article", fields=fields)
+        return bib.to_string("bibtex")

--- a/formats/csv_fmt.py
+++ b/formats/csv_fmt.py
@@ -1,0 +1,85 @@
+"""CSV/TSV import/export — mirrors the graph page's 'Export as CSV' output.
+
+Column order: paper_id, title, authors, category, tags, published, has_pdf
+- authors: semicolon-separated
+- tags:    comma-separated
+- has_pdf: "Y" / "N"
+"""
+
+from __future__ import annotations
+
+import csv
+import datetime
+import io
+
+from sources.base import PaperMetadata
+
+_FALLBACK_DATE = datetime.date(1900, 1, 1)
+_FIELDS = ["paper_id", "title", "authors", "category", "tags", "published", "has_pdf"]
+
+
+def _parse_date(val: str) -> datetime.date:
+    if val:
+        try:
+            return datetime.date.fromisoformat(val[:10])
+        except ValueError:
+            pass
+    return _FALLBACK_DATE
+
+
+class CSVFormat:
+    format_name = "csv"
+    extensions = [".csv"]
+    _delimiter = ","
+
+    def import_file(self, path: str) -> list[PaperMetadata]:
+        results: list[PaperMetadata] = []
+        with open(path, encoding="utf-8", newline="") as f:
+            reader = csv.DictReader(f, delimiter=self._delimiter)
+            for row in reader:
+                paper_id = row.get("paper_id", "").strip()
+                if not paper_id:
+                    continue
+                authors_raw = row.get("authors", "")
+                authors = [a.strip() for a in authors_raw.split(";") if a.strip()]
+                tags_raw = row.get("tags", "")
+                tags = [t.strip() for t in tags_raw.split(",") if t.strip()]
+                results.append(PaperMetadata(
+                    paper_id  = paper_id,
+                    version   = 1,
+                    title     = row.get("title", ""),
+                    authors   = authors,
+                    published = _parse_date(row.get("published", "")),
+                    summary   = "",
+                    category  = row.get("category") or None,
+                    tags      = tags or None,
+                    source    = "import",
+                ))
+        return results
+
+    def export_papers(self, papers: list[dict]) -> str:
+        buf = io.StringIO()
+        writer = csv.DictWriter(
+            buf, fieldnames=_FIELDS, extrasaction="ignore", delimiter=self._delimiter
+        )
+        writer.writeheader()
+        for p in papers:
+            pub = p.get("published", "")
+            if isinstance(pub, (datetime.date, datetime.datetime)):
+                pub = pub.isoformat()
+            writer.writerow({
+                "paper_id":  p.get("paper_id", ""),
+                "title":     p.get("title", ""),
+                "authors":   "; ".join(p.get("authors") or []),
+                "category":  p.get("category", ""),
+                "tags":      ", ".join(p.get("tags") or []),
+                "published": pub,
+                "has_pdf":   "Y" if p.get("has_pdf") else "N",
+            })
+        return buf.getvalue()
+
+
+class TSVFormat(CSVFormat):
+    format_name = "tsv"
+    extensions = [".tsv"]
+    _delimiter = "\t"

--- a/formats/json_fmt.py
+++ b/formats/json_fmt.py
@@ -1,0 +1,71 @@
+"""JSON import/export — mirrors the graph page's 'Export as JSON' output."""
+
+from __future__ import annotations
+
+import datetime
+import json
+
+from sources.base import PaperMetadata
+
+_FALLBACK_DATE = datetime.date(1900, 1, 1)
+
+
+def _parse_date(val: object) -> datetime.date:
+    if isinstance(val, datetime.date):
+        return val
+    if isinstance(val, str) and val:
+        try:
+            return datetime.date.fromisoformat(val[:10])
+        except ValueError:
+            pass
+    return _FALLBACK_DATE
+
+
+def _parse_list(val: object, sep: str = ";") -> list[str]:
+    if isinstance(val, list):
+        return [str(v) for v in val]
+    if isinstance(val, str) and val:
+        return [v.strip() for v in val.split(sep) if v.strip()]
+    return []
+
+
+class JSONFormat:
+    format_name = "json"
+    extensions = [".json"]
+
+    def import_file(self, path: str) -> list[PaperMetadata]:
+        with open(path, encoding="utf-8") as f:
+            data = json.load(f)
+        raw: list[dict] = data.get("papers", data) if isinstance(data, dict) else data
+        results: list[PaperMetadata] = []
+        for p in raw:
+            tags = _parse_list(p.get("tags"), sep=",")
+            results.append(PaperMetadata(
+                paper_id    = p["paper_id"],
+                version     = int(p.get("version", 1)),
+                title       = p.get("title", ""),
+                authors     = _parse_list(p.get("authors"), sep=";"),
+                published   = _parse_date(p.get("published")),
+                updated     = _parse_date(p.get("updated")) if p.get("updated") else None,
+                summary     = p.get("summary", ""),
+                category    = p.get("category") or None,
+                categories  = p.get("categories") or None,
+                doi         = p.get("doi") or None,
+                journal_ref = p.get("journal_ref") or None,
+                comment     = p.get("comment") or None,
+                url         = p.get("url") or None,
+                tags        = tags or None,
+                source      = p.get("source", "import"),
+            ))
+        return results
+
+    def export_papers(self, papers: list[dict]) -> str:
+        out = []
+        for p in papers:
+            entry = dict(p)
+            if isinstance(entry.get("published"), (datetime.date, datetime.datetime)):
+                entry["published"] = entry["published"].isoformat()
+            if isinstance(entry.get("updated"), (datetime.date, datetime.datetime)):
+                entry["updated"] = entry["updated"].isoformat()
+            out.append(entry)
+        return json.dumps({"papers": out}, indent=2, ensure_ascii=False)

--- a/formats/markdown.py
+++ b/formats/markdown.py
@@ -8,8 +8,9 @@ import re
 from sources.base import PaperMetadata
 
 _FALLBACK_DATE = datetime.date(1900, 1, 1)
-_ARXIV_URL_RE = re.compile(r"https?://arxiv\.org/abs/([^\s\)]+)")
-_MD_LINK_RE   = re.compile(r"\[([^\]]+)\]\(([^\)]+)\)")
+_ARXIV_URL_RE  = re.compile(r"https?://arxiv\.org/abs/([^\s\)]+)")
+_ARXIV_ID_RE   = re.compile(r"^\d{4}\.\d{4,5}(v\d+)?$|^[a-z-]+/\d{7}$")
+_MD_LINK_RE    = re.compile(r"\[([^\]]+)\]\(([^\)]*)\)")
 
 
 def _parse_date(val: str) -> datetime.date:
@@ -19,6 +20,19 @@ def _parse_date(val: str) -> datetime.date:
         except ValueError:
             pass
     return _FALLBACK_DATE
+
+
+def _is_arxiv_id(pid: str) -> bool:
+    return bool(_ARXIV_ID_RE.match(pid))
+
+
+def _paper_url(pid: str, stored_url: str | None) -> str:
+    """Best URL for a paper: stored url > arXiv abs link > empty."""
+    if stored_url:
+        return stored_url
+    if _is_arxiv_id(pid):
+        return f"https://arxiv.org/abs/{pid}"
+    return ""
 
 
 def _paper_id_from_url(url: str) -> str:
@@ -39,11 +53,13 @@ class MarkdownFormat:
     def export_papers(self, papers: list[dict]) -> str:
         lines = ["# Selected Papers\n"]
         for p in papers:
-            pid    = p.get("paper_id", "")
-            title  = p.get("title", pid)
+            pid     = p.get("paper_id", "")
+            title   = p.get("title", pid)
             authors = ", ".join(p.get("authors") or [])
-            url    = f"https://arxiv.org/abs/{pid}"
+            url     = _paper_url(pid, p.get("url"))
             lines.append(f"- **[{title}]({url})**")
+            if not _is_arxiv_id(pid):
+                lines.append(f"  - Paper-ID: {pid}")
             if authors:
                 lines.append(f"  - Authors: {authors}")
             cat = p.get("category", "")
@@ -88,7 +104,9 @@ class MarkdownFormat:
                 continue
 
             # Sub-bullets: '  - Key: value'
-            if line.startswith("- Authors: "):
+            if line.startswith("- Paper-ID: "):
+                current["paper_id"] = line[12:].strip()
+            elif line.startswith("- Authors: "):
                 current["authors"] = [a.strip() for a in line[11:].split(",") if a.strip()]
             elif line.startswith("- Category: "):
                 current["category"] = line[12:].strip()
@@ -124,12 +142,14 @@ class ObsidianFormat:
         lines += ["---", "", "# Selected Papers", ""]
 
         for p in papers:
-            pid    = p.get("paper_id", "")
-            title  = p.get("title", pid)
+            pid     = p.get("paper_id", "")
+            title   = p.get("title", pid)
             authors = ", ".join(p.get("authors") or [])
-            url    = f"https://arxiv.org/abs/{pid}"
+            url     = _paper_url(pid, p.get("url"))
             lines.append(f"## [{title}]({url})")
             lines.append("")
+            if not _is_arxiv_id(pid):
+                lines.append(f"**Paper-ID:** {pid}")
             if authors:
                 lines.append(f"**Authors:** {authors}")
             cat = p.get("category", "")
@@ -180,7 +200,9 @@ class ObsidianFormat:
             if current is None:
                 continue
 
-            if line.startswith("**Authors:**"):
+            if line.startswith("**Paper-ID:**"):
+                current["paper_id"] = line[13:].strip()
+            elif line.startswith("**Authors:**"):
                 current["authors"] = [a.strip() for a in line[12:].split(",") if a.strip()]
             elif line.startswith("**Category:**"):
                 current["category"] = line[13:].strip()

--- a/formats/markdown.py
+++ b/formats/markdown.py
@@ -1,0 +1,209 @@
+"""Markdown and Obsidian import/export."""
+
+from __future__ import annotations
+
+import datetime
+import re
+
+from sources.base import PaperMetadata
+
+_FALLBACK_DATE = datetime.date(1900, 1, 1)
+_ARXIV_URL_RE = re.compile(r"https?://arxiv\.org/abs/([^\s\)]+)")
+_MD_LINK_RE   = re.compile(r"\[([^\]]+)\]\(([^\)]+)\)")
+
+
+def _parse_date(val: str) -> datetime.date:
+    if val:
+        try:
+            return datetime.date.fromisoformat(val[:10])
+        except ValueError:
+            pass
+    return _FALLBACK_DATE
+
+
+def _paper_id_from_url(url: str) -> str:
+    m = _ARXIV_URL_RE.match(url)
+    return m.group(1) if m else url
+
+
+# ── Markdown ──────────────────────────────────────────────────────────────────
+
+class MarkdownFormat:
+    """Flat bullet-list Markdown, one paper per item."""
+
+    format_name = "markdown"
+    extensions  = [".md"]
+
+    # ── export ────────────────────────────────────────────────────────────────
+
+    def export_papers(self, papers: list[dict]) -> str:
+        lines = ["# Selected Papers\n"]
+        for p in papers:
+            pid    = p.get("paper_id", "")
+            title  = p.get("title", pid)
+            authors = ", ".join(p.get("authors") or [])
+            url    = f"https://arxiv.org/abs/{pid}"
+            lines.append(f"- **[{title}]({url})**")
+            if authors:
+                lines.append(f"  - Authors: {authors}")
+            cat = p.get("category", "")
+            if cat:
+                lines.append(f"  - Category: {cat}")
+            tags = p.get("tags") or []
+            if tags:
+                lines.append(f"  - Tags: {', '.join(tags)}")
+            lines.append("")
+        return "\n".join(lines)
+
+    # ── import ────────────────────────────────────────────────────────────────
+
+    def import_file(self, path: str) -> list[PaperMetadata]:
+        with open(path, encoding="utf-8") as f:
+            return self._parse(f.read())
+
+    def import_string(self, text: str) -> list[PaperMetadata]:
+        return self._parse(text)
+
+    def _parse(self, text: str) -> list[PaperMetadata]:
+        results: list[PaperMetadata] = []
+        current: dict | None = None
+
+        for raw in text.splitlines():
+            line = raw.strip()
+
+            # Top-level bullet: - **[title](url)**
+            if line.startswith("- **") and line.endswith("**"):
+                if current is not None:
+                    results.append(_dict_to_metadata(current))
+                inner = line[4:-2]  # strip '- **' and '**'
+                m = _MD_LINK_RE.match(inner)
+                if m:
+                    current = {"title": m.group(1), "url": m.group(2),
+                               "paper_id": _paper_id_from_url(m.group(2))}
+                else:
+                    current = {"title": inner, "url": "", "paper_id": inner}
+                continue
+
+            if current is None:
+                continue
+
+            # Sub-bullets: '  - Key: value'
+            if line.startswith("- Authors: "):
+                current["authors"] = [a.strip() for a in line[11:].split(",") if a.strip()]
+            elif line.startswith("- Category: "):
+                current["category"] = line[12:].strip()
+            elif line.startswith("- Tags: "):
+                current["tags"] = [t.strip() for t in line[8:].split(",") if t.strip()]
+
+        if current is not None:
+            results.append(_dict_to_metadata(current))
+        return results
+
+
+# ── Obsidian ──────────────────────────────────────────────────────────────────
+
+class ObsidianFormat:
+    """Obsidian-flavoured Markdown with YAML frontmatter, one section per paper."""
+
+    format_name = "obsidian"
+    extensions  = [".md"]
+
+    # ── export ────────────────────────────────────────────────────────────────
+
+    def export_papers(self, papers: list[dict]) -> str:
+        all_tags: list[str] = []
+        for p in papers:
+            all_tags.extend(p.get("tags") or [])
+        unique_tags = sorted(set(all_tags))
+
+        lines = ["---", f"papers: {len(papers)}"]
+        if unique_tags:
+            lines.append("tags:")
+            for t in unique_tags:
+                lines.append(f"  - {t}")
+        lines += ["---", "", "# Selected Papers", ""]
+
+        for p in papers:
+            pid    = p.get("paper_id", "")
+            title  = p.get("title", pid)
+            authors = ", ".join(p.get("authors") or [])
+            url    = f"https://arxiv.org/abs/{pid}"
+            lines.append(f"## [{title}]({url})")
+            lines.append("")
+            if authors:
+                lines.append(f"**Authors:** {authors}")
+            cat = p.get("category", "")
+            if cat:
+                lines.append(f"**Category:** {cat}")
+            tags = p.get("tags") or []
+            if tags:
+                lines.append(f"**Tags:** {', '.join(tags)}")
+            lines.append("")
+
+        return "\n".join(lines)
+
+    # ── import ────────────────────────────────────────────────────────────────
+
+    def import_file(self, path: str) -> list[PaperMetadata]:
+        with open(path, encoding="utf-8") as f:
+            return self._parse(f.read())
+
+    def import_string(self, text: str) -> list[PaperMetadata]:
+        return self._parse(text)
+
+    def _parse(self, text: str) -> list[PaperMetadata]:
+        # Strip YAML frontmatter
+        if text.startswith("---"):
+            end = text.find("\n---", 3)
+            if end != -1:
+                text = text[end + 4:]
+
+        results: list[PaperMetadata] = []
+        current: dict | None = None
+
+        for raw in text.splitlines():
+            line = raw.strip()
+
+            # Section header: ## [title](url)
+            if line.startswith("## "):
+                if current is not None:
+                    results.append(_dict_to_metadata(current))
+                m = _MD_LINK_RE.match(line[3:])
+                if m:
+                    current = {"title": m.group(1), "url": m.group(2),
+                               "paper_id": _paper_id_from_url(m.group(2))}
+                else:
+                    label = line[3:].strip()
+                    current = {"title": label, "url": "", "paper_id": label}
+                continue
+
+            if current is None:
+                continue
+
+            if line.startswith("**Authors:**"):
+                current["authors"] = [a.strip() for a in line[12:].split(",") if a.strip()]
+            elif line.startswith("**Category:**"):
+                current["category"] = line[13:].strip()
+            elif line.startswith("**Tags:**"):
+                current["tags"] = [t.strip() for t in line[9:].split(",") if t.strip()]
+
+        if current is not None:
+            results.append(_dict_to_metadata(current))
+        return results
+
+
+# ── shared helper ─────────────────────────────────────────────────────────────
+
+def _dict_to_metadata(d: dict) -> PaperMetadata:
+    return PaperMetadata(
+        paper_id  = d.get("paper_id", ""),
+        version   = 1,
+        title     = d.get("title", ""),
+        authors   = d.get("authors", []),
+        published = _parse_date(d.get("published", "")),
+        summary   = "",
+        category  = d.get("category") or None,
+        tags      = d.get("tags") or None,
+        url       = d.get("url") or None,
+        source    = "import",
+    )

--- a/gui/graph/page.py
+++ b/gui/graph/page.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import datetime
-import json
 
 from PyQt6.QtCore import Qt, QTimer, pyqtSignal
 from PyQt6.QtWidgets import (
@@ -21,6 +20,7 @@ from PyQt6.QtWidgets import (
 from .view import GraphView
 from formats.bibtex import BibTeXFormat
 from formats.csv_fmt import CSVFormat
+from formats.json_fmt import JSONFormat
 from formats.markdown import MarkdownFormat, ObsidianFormat
 from gui.theme import FONT_SECONDARY, FONT_TERTIARY, SPACE_XS, SPACE_SM
 from storage.db import get_categories, get_graph_data, get_tags, list_papers
@@ -29,7 +29,7 @@ _bibtex_fmt   = BibTeXFormat()
 _csv_fmt      = CSVFormat()
 _markdown_fmt = MarkdownFormat()
 _obsidian_fmt = ObsidianFormat()
-
+_json_fmt     = JSONFormat()
 
 # ── Helpers ───────────────────────────────────────────────────────────────────
 # TODO: Break down into smaller chunks
@@ -366,7 +366,7 @@ class GraphPage(QWidget):
         if not path:
             return
         with open(path, "w", encoding="utf-8") as f:
-            json.dump(data, f, indent=2, ensure_ascii=False)
+            f.write(_json_fmt.export_papers(data.get("papers", [])))
 
     def _export_csv(self) -> None:
         self._graph_view.get_selected_paper_data(self._save_csv)

--- a/gui/graph/page.py
+++ b/gui/graph/page.py
@@ -1,8 +1,6 @@
 from __future__ import annotations
 
-import csv
 import datetime
-import io
 import json
 
 from PyQt6.QtCore import Qt, QTimer, pyqtSignal
@@ -22,10 +20,15 @@ from PyQt6.QtWidgets import (
 
 from .view import GraphView
 from formats.bibtex import BibTeXFormat
+from formats.csv_fmt import CSVFormat
+from formats.markdown import MarkdownFormat, ObsidianFormat
 from gui.theme import FONT_SECONDARY, FONT_TERTIARY, SPACE_XS, SPACE_SM
 from storage.db import get_categories, get_graph_data, get_tags, list_papers
 
-_bibtex_fmt = BibTeXFormat()
+_bibtex_fmt   = BibTeXFormat()
+_csv_fmt      = CSVFormat()
+_markdown_fmt = MarkdownFormat()
+_obsidian_fmt = ObsidianFormat()
 
 
 # ── Helpers ───────────────────────────────────────────────────────────────────
@@ -372,22 +375,8 @@ class GraphPage(QWidget):
         path, _ = QFileDialog.getSaveFileName(self, "Export CSV", "selected_papers.csv", "CSV (*.csv)")
         if not path:
             return
-        papers = data.get("papers", [])
-        buf = io.StringIO()
-        writer = csv.writer(buf)
-        writer.writerow(["paper_id", "title", "authors", "category", "tags", "published", "has_pdf"])
-        for p in papers:
-            writer.writerow([
-                p.get("paper_id", ""),
-                p.get("title", ""),
-                "; ".join(p.get("authors", [])),
-                p.get("category", ""),
-                ", ".join(p.get("tags", [])),
-                p.get("published", ""),
-                "Y" if p.get("has_pdf") else "N",
-            ])
         with open(path, "w", encoding="utf-8", newline="") as f:
-            f.write(buf.getvalue())
+            f.write(_csv_fmt.export_papers(data.get("papers", [])))
 
     def _export_bibtex(self) -> None:
         self._graph_view.get_selected_paper_data(self._save_bibtex)
@@ -407,25 +396,8 @@ class GraphPage(QWidget):
         path, _ = QFileDialog.getSaveFileName(self, "Export Markdown", "selected_papers.md", "Markdown (*.md)")
         if not path:
             return
-        papers = data.get("papers", [])
-        lines = ["# Selected Papers\n"]
-        for p in papers:
-            pid = p.get("paper_id", "")
-            title = p.get("title", pid)
-            authors = ", ".join(p.get("authors", []))
-            url = f"https://arxiv.org/abs/{pid}"
-            lines.append(f"- **[{title}]({url})**")
-            if authors:
-                lines.append(f"  - Authors: {authors}")
-            cat = p.get("category", "")
-            if cat:
-                lines.append(f"  - Category: {cat}")
-            tags = p.get("tags", [])
-            if tags:
-                lines.append(f"  - Tags: {', '.join(tags)}")
-            lines.append("")
         with open(path, "w", encoding="utf-8") as f:
-            f.write("\n".join(lines))
+            f.write(_markdown_fmt.export_papers(data.get("papers", [])))
 
     def _export_obsidian(self) -> None:
         self._graph_view.get_selected_paper_data(self._save_obsidian)
@@ -434,37 +406,5 @@ class GraphPage(QWidget):
         path, _ = QFileDialog.getSaveFileName(self, "Export Obsidian", "selected_papers.md", "Markdown (*.md)")
         if not path:
             return
-        papers = data.get("papers", [])
-        all_tags: list[str] = []
-        for p in papers:
-            all_tags.extend(p.get("tags", []))
-        unique_tags = sorted(set(all_tags))
-
-        lines = ["---"]
-        lines.append(f"papers: {len(papers)}")
-        if unique_tags:
-            lines.append("tags:")
-            for t in unique_tags:
-                lines.append(f"  - {t}")
-        lines.append("---")
-        lines.append("")
-        lines.append("# Selected Papers")
-        lines.append("")
-        for p in papers:
-            pid = p.get("paper_id", "")
-            title = p.get("title", pid)
-            authors = ", ".join(p.get("authors", []))
-            url = f"https://arxiv.org/abs/{pid}"
-            lines.append(f"## [{title}]({url})")
-            lines.append("")
-            if authors:
-                lines.append(f"**Authors:** {authors}")
-            cat = p.get("category", "")
-            if cat:
-                lines.append(f"**Category:** {cat}")
-            tags = p.get("tags", [])
-            if tags:
-                lines.append(f"**Tags:** {', '.join(tags)}")
-            lines.append("")
         with open(path, "w", encoding="utf-8") as f:
-            f.write("\n".join(lines))
+            f.write(_obsidian_fmt.export_papers(data.get("papers", [])))

--- a/gui/graph/page.py
+++ b/gui/graph/page.py
@@ -21,8 +21,11 @@ from PyQt6.QtWidgets import (
 )
 
 from .view import GraphView
+from formats.bibtex import BibTeXFormat
 from gui.theme import FONT_SECONDARY, FONT_TERTIARY, SPACE_XS, SPACE_SM
 from storage.db import get_categories, get_graph_data, get_tags, list_papers
+
+_bibtex_fmt = BibTeXFormat()
 
 
 # ── Helpers ───────────────────────────────────────────────────────────────────
@@ -346,6 +349,8 @@ class GraphPage(QWidget):
         menu = QMenu(self)
         menu.addAction("Export as JSON", self._export_json)
         menu.addAction("Export as CSV", self._export_csv)
+        menu.addAction("Export as BibTeX", self._export_bibtex)
+        menu.addSeparator()
         menu.addAction("Export as Markdown", self._export_markdown)
         menu.addAction("Export as Obsidian", self._export_obsidian)
         menu.exec(self._export_btn.mapToGlobal(self._export_btn.rect().bottomLeft()))
@@ -383,6 +388,17 @@ class GraphPage(QWidget):
             ])
         with open(path, "w", encoding="utf-8", newline="") as f:
             f.write(buf.getvalue())
+
+    def _export_bibtex(self) -> None:
+        self._graph_view.get_selected_paper_data(self._save_bibtex)
+
+    def _save_bibtex(self, data: dict) -> None:
+        path, _ = QFileDialog.getSaveFileName(self, "Export BibTeX", "selected_papers.bib", "BibTeX (*.bib)")
+        if not path:
+            return
+        content = _bibtex_fmt.export_papers(data.get("papers", []))
+        with open(path, "w", encoding="utf-8") as f:
+            f.write(content)
 
     def _export_markdown(self) -> None:
         self._graph_view.get_selected_paper_data(self._save_markdown)

--- a/gui/graph/web/graph.js
+++ b/gui/graph/web/graph.js
@@ -737,6 +737,9 @@ function getSelectedPaperData() {
             has_pdf:   d.has_pdf || false,
             published: d.published || '',
             authors:   authors,
+            url:       d.url || null,
+            doi:       d.doi || null,
+            summary:   d.summary || '',
         });
     });
     cy.edges().forEach(e => {

--- a/gui/library/page.py
+++ b/gui/library/page.py
@@ -22,9 +22,16 @@ from PyQt6.QtWidgets import (
 )
 
 from formats.bibtex import BibTeXFormat
+from formats.csv_fmt import CSVFormat
+from formats.json_fmt import JSONFormat
+from formats.markdown import MarkdownFormat, ObsidianFormat
 from storage.db import list_papers, save_papers_metadata, set_has_pdf, set_pdf_path
 
-_bibtex_fmt = BibTeXFormat()
+_bibtex_fmt   = BibTeXFormat()
+_csv_fmt      = CSVFormat()
+_json_fmt     = JSONFormat()
+_markdown_fmt = MarkdownFormat()
+_obsidian_fmt = ObsidianFormat()
 from gui.theme import BG as _BG, PANEL as _PANEL, BORDER as _BORDER
 from gui.theme import ACCENT as _ACCENT, TEXT as _TEXT, MUTED as _MUTED
 from gui.theme import (
@@ -897,8 +904,12 @@ class LibraryPage(QWidget):
 
     def _show_import_menu(self) -> None:
         menu = QMenu(self)
-        menu.addAction("BibTeX file…",        self._import_bibtex_file)
+        menu.addAction("BibTeX file…",           self._import_bibtex_file)
         menu.addAction("Paste BibTeX citation…", self._import_bibtex_paste)
+        menu.addAction("JSON file…",             self._import_json_file)
+        menu.addAction("CSV file…",              self._import_csv_file)
+        menu.addAction("Markdown file…",         self._import_markdown_file)
+        menu.addAction("Obsidian file…",         self._import_obsidian_file)
         menu.addSeparator()
         menu.addAction("PDF…",    self._import_not_implemented)
         menu.addAction("Folder…", self._import_not_implemented)
@@ -957,6 +968,54 @@ class LibraryPage(QWidget):
             return
         try:
             papers = _bibtex_fmt.import_string(text)
+        except Exception as e:
+            from PyQt6.QtWidgets import QMessageBox
+            QMessageBox.critical(self, "Import Failed", str(e))
+            return
+        self._finish_import(papers)
+
+    def _import_json_file(self) -> None:
+        path, _ = QFileDialog.getOpenFileName(self, "Import JSON", "", "JSON (*.json)")
+        if not path:
+            return
+        try:
+            papers = _json_fmt.import_file(path)
+        except Exception as e:
+            from PyQt6.QtWidgets import QMessageBox
+            QMessageBox.critical(self, "Import Failed", str(e))
+            return
+        self._finish_import(papers)
+
+    def _import_csv_file(self) -> None:
+        path, _ = QFileDialog.getOpenFileName(self, "Import CSV", "", "CSV (*.csv)")
+        if not path:
+            return
+        try:
+            papers = _csv_fmt.import_file(path)
+        except Exception as e:
+            from PyQt6.QtWidgets import QMessageBox
+            QMessageBox.critical(self, "Import Failed", str(e))
+            return
+        self._finish_import(papers)
+
+    def _import_markdown_file(self) -> None:
+        path, _ = QFileDialog.getOpenFileName(self, "Import Markdown", "", "Markdown (*.md)")
+        if not path:
+            return
+        try:
+            papers = _markdown_fmt.import_file(path)
+        except Exception as e:
+            from PyQt6.QtWidgets import QMessageBox
+            QMessageBox.critical(self, "Import Failed", str(e))
+            return
+        self._finish_import(papers)
+
+    def _import_obsidian_file(self) -> None:
+        path, _ = QFileDialog.getOpenFileName(self, "Import Obsidian", "", "Markdown (*.md)")
+        if not path:
+            return
+        try:
+            papers = _obsidian_fmt.import_file(path)
         except Exception as e:
             from PyQt6.QtWidgets import QMessageBox
             QMessageBox.critical(self, "Import Failed", str(e))

--- a/gui/library/page.py
+++ b/gui/library/page.py
@@ -11,15 +11,20 @@ from PyQt6.QtWidgets import (
     QHBoxLayout,
     QLabel,
     QLineEdit,
+    QMenu,
     QPushButton,
     QScrollArea,
     QSizePolicy,
     QStackedWidget,
+    QTextEdit,
     QVBoxLayout,
     QWidget,
 )
 
-from storage.db import list_papers, set_has_pdf, set_pdf_path
+from formats.bibtex import BibTeXFormat
+from storage.db import list_papers, save_papers_metadata, set_has_pdf, set_pdf_path
+
+_bibtex_fmt = BibTeXFormat()
 from gui.theme import BG as _BG, PANEL as _PANEL, BORDER as _BORDER
 from gui.theme import ACCENT as _ACCENT, TEXT as _TEXT, MUTED as _MUTED
 from gui.theme import (
@@ -679,6 +684,14 @@ class LibraryPage(QWidget):
         refresh_btn.setStyleSheet(_BTN)
         refresh_btn.clicked.connect(self.refresh)
         hdr.addWidget(refresh_btn)
+
+        self._import_btn = QPushButton("Import")
+        self._import_btn.setFixedHeight(BTN_H_MD)
+        self._import_btn.setCursor(Qt.CursorShape.PointingHandCursor)
+        self._import_btn.setStyleSheet(_BTN)
+        self._import_btn.clicked.connect(self._show_import_menu)
+        hdr.addWidget(self._import_btn)
+
         inner.addLayout(hdr)
         inner.addSpacing(SPACE_LG)
 
@@ -879,6 +892,100 @@ class LibraryPage(QWidget):
         for card in self._cards:
             if card.paper_id() in self._selected:
                 card.start_download_if_needed()
+
+    # ── Import ────────────────────────────────────────────────────────────────
+
+    def _show_import_menu(self) -> None:
+        menu = QMenu(self)
+        menu.addAction("BibTeX file…",        self._import_bibtex_file)
+        menu.addAction("Paste BibTeX citation…", self._import_bibtex_paste)
+        menu.addSeparator()
+        menu.addAction("PDF…",    self._import_not_implemented)
+        menu.addAction("Folder…", self._import_not_implemented)
+        menu.exec(self._import_btn.mapToGlobal(self._import_btn.rect().bottomLeft()))
+
+    def _import_bibtex_file(self) -> None:
+        path, _ = QFileDialog.getOpenFileName(self, "Import BibTeX", "", "BibTeX (*.bib)")
+        if not path:
+            return
+        try:
+            papers = _bibtex_fmt.import_file(path)
+        except Exception as e:
+            from PyQt6.QtWidgets import QMessageBox
+            QMessageBox.critical(self, "Import Failed", str(e))
+            return
+        self._finish_import(papers)
+
+    def _import_bibtex_paste(self) -> None:
+        from PyQt6.QtWidgets import QDialog, QDialogButtonBox
+        dlg = QDialog(self)
+        dlg.setWindowTitle("Paste BibTeX")
+        dlg.setStyleSheet(f"background: {_BG}; color: {_TEXT};")
+        dlg.resize(560, 340)
+
+        lay = QVBoxLayout(dlg)
+        lay.setContentsMargins(DIALOG_PAD, DIALOG_PAD, DIALOG_PAD, DIALOG_PAD)
+        lay.setSpacing(SPACE_MD)
+
+        lbl = QLabel("Paste one or more BibTeX entries below:")
+        lbl.setStyleSheet(f"font-size: {FONT_BODY}px;")
+        lay.addWidget(lbl)
+
+        editor = QTextEdit()
+        editor.setPlaceholderText("@article{...}")
+        editor.setStyleSheet(f"""
+            QTextEdit {{
+                background: {_PANEL}; border: 1px solid {_BORDER};
+                border-radius: {RADIUS_MD}px; color: {_TEXT};
+                font-family: monospace; font-size: {FONT_SECONDARY}px; padding: 8px;
+            }}
+        """)
+        lay.addWidget(editor, stretch=1)
+
+        btns = QDialogButtonBox(
+            QDialogButtonBox.StandardButton.Ok | QDialogButtonBox.StandardButton.Cancel
+        )
+        btns.accepted.connect(dlg.accept)
+        btns.rejected.connect(dlg.reject)
+        lay.addWidget(btns)
+
+        if dlg.exec() != QDialog.DialogCode.Accepted:
+            return
+
+        text = editor.toPlainText().strip()
+        if not text:
+            return
+        try:
+            papers = _bibtex_fmt.import_string(text)
+        except Exception as e:
+            from PyQt6.QtWidgets import QMessageBox
+            QMessageBox.critical(self, "Import Failed", str(e))
+            return
+        self._finish_import(papers)
+
+    def _import_not_implemented(self) -> None:
+        from PyQt6.QtGui import QAction
+        from PyQt6.QtWidgets import QMessageBox
+        sender = self.sender()
+        label = sender.text() if isinstance(sender, QAction) else "This"
+        QMessageBox.warning(self, "Not Implemented", f"{label} is not yet implemented.")
+
+    def _finish_import(self, papers) -> None:
+        from PyQt6.QtWidgets import QMessageBox
+        from storage.db import get_paper
+        added = skipped = 0
+        for meta in papers:
+            existing = get_paper(meta.paper_id)
+            if existing is not None:
+                skipped += 1
+            else:
+                save_papers_metadata([meta])
+                added += 1
+        self.refresh()
+        QMessageBox.information(
+            self, "Import Complete",
+            f"Added {added} paper(s).  Skipped {skipped} already in library."
+        )
 
     def _on_add_to_project(self) -> None:
         if not self._selected:

--- a/linxiv_mcp.py
+++ b/linxiv_mcp.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import Any, Optional
 
-from mcp.server.fastmcp import FastMCP
+from mcp.server.fastmcp import FastMCP # pyright: ignore
 
 import storage.db as db
 from storage.notes import Note, ensure_notes_db, get_notes, get_project_notes

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ dependencies = [
     "markdown",
     "openai",
     "pydantic",
+    "pybtex",
     "python-dotenv",
     "uvicorn[standard]",
 ]
@@ -40,6 +41,7 @@ include = [
     "search.py",
     "AI_tools.py",
     "api",
+    "formats",
     "gui",
     "sources",
     "storage",

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,7 @@ google-genai
 httpx
 markdown
 openai
+pybtex
 pydantic
 python-dotenv
 uvicorn[standard]

--- a/storage/db.py
+++ b/storage/db.py
@@ -292,9 +292,12 @@ def get_graph_data() -> tuple[list[dict], list[dict]]:
                 "tags":      row["tags"] if row["tags"] is not None else [],
                 "has_pdf":   bool(row["has_pdf"]),
                 "published": row["published"].isoformat() if row["published"] else None,
+                "url":       row["url"],
+                "doi":       row["doi"],
+                "summary":   row["summary"],
             }
             for row in conn.execute(
-                "SELECT paper_id, title, category, tags, has_pdf, published FROM latest_papers"
+                "SELECT paper_id, title, category, tags, has_pdf, published, url, doi, summary FROM latest_papers"
             )
         ]
         author_rows = conn.execute("""

--- a/tests/test_bibtex.py
+++ b/tests/test_bibtex.py
@@ -1,0 +1,205 @@
+"""Tests for formats/bibtex.py — import/export round-trips and edge cases."""
+
+from __future__ import annotations
+
+import datetime
+import os
+import sys
+import tempfile
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from formats.bibtex import BibTeXFormat, _parse_year
+
+_fmt = BibTeXFormat()
+
+# ---------------------------------------------------------------------------
+# _parse_year
+# ---------------------------------------------------------------------------
+
+class TestParseYear:
+    def test_valid_year(self):
+        assert _parse_year({"year": "2023"}) == datetime.date(2023, 1, 1)
+
+    def test_missing_year_falls_back(self):
+        assert _parse_year({}) == datetime.date(1900, 1, 1)
+
+    def test_non_numeric_year_falls_back(self):
+        assert _parse_year({"year": "forthcoming"}) == datetime.date(1900, 1, 1)
+
+    def test_empty_string_falls_back(self):
+        assert _parse_year({"year": ""}) == datetime.date(1900, 1, 1)
+
+
+# ---------------------------------------------------------------------------
+# import_string
+# ---------------------------------------------------------------------------
+
+_ARTICLE_BIB = """\
+@article{smith2020,
+  author  = {Smith, John},
+  title   = {A Great Paper},
+  year    = {2020},
+  journal = {Nature},
+  doi     = {10.1234/test},
+  abstract = {This is the abstract.},
+  url     = {https://example.com/paper},
+}
+"""
+
+_NO_DOI_BIB = """\
+@inproceedings{doe2019,
+  author    = {Doe, Jane},
+  title     = {Proceedings Paper},
+  year      = {2019},
+  booktitle = {NeurIPS},
+}
+"""
+
+_MULTI_AUTHOR_BIB = """\
+@article{multi2021,
+  author = {Alice, A. and Bob, B. and Carol, C.},
+  title  = {Multi-author Work},
+  year   = {2021},
+}
+"""
+
+
+class TestImportString:
+    def test_basic_article_fields(self):
+        papers = _fmt.import_string(_ARTICLE_BIB)
+        assert len(papers) == 1
+        p = papers[0]
+        assert p.title == "A Great Paper"
+        assert p.published == datetime.date(2020, 1, 1)
+        assert p.doi == "10.1234/test"
+        assert p.paper_id == "10.1234/test"
+        assert p.journal_ref == "Nature"
+        assert p.summary == "This is the abstract."
+        assert p.url == "https://example.com/paper"
+        assert p.source == "bibtex"
+        assert p.version == 1
+
+    def test_authors_parsed(self):
+        papers = _fmt.import_string(_ARTICLE_BIB)
+        assert len(papers[0].authors) == 1
+        assert "Smith" in papers[0].authors[0]
+
+    def test_multi_author(self):
+        papers = _fmt.import_string(_MULTI_AUTHOR_BIB)
+        assert len(papers[0].authors) == 3
+
+    def test_no_doi_uses_key_as_paper_id(self):
+        papers = _fmt.import_string(_NO_DOI_BIB)
+        assert papers[0].paper_id == "doe2019"
+        assert papers[0].doi is None
+
+    def test_booktitle_used_as_journal_ref(self):
+        papers = _fmt.import_string(_NO_DOI_BIB)
+        assert papers[0].journal_ref == "NeurIPS"
+
+    def test_multiple_entries(self):
+        combined = _ARTICLE_BIB + _NO_DOI_BIB
+        papers = _fmt.import_string(combined)
+        assert len(papers) == 2
+
+    def test_missing_abstract_is_empty_string(self):
+        papers = _fmt.import_string(_NO_DOI_BIB)
+        assert papers[0].summary == ""
+
+    def test_missing_url_is_none(self):
+        papers = _fmt.import_string(_NO_DOI_BIB)
+        assert papers[0].url is None
+
+
+# ---------------------------------------------------------------------------
+# import_file
+# ---------------------------------------------------------------------------
+
+class TestImportFile:
+    def test_import_from_file(self):
+        with tempfile.NamedTemporaryFile(suffix=".bib", mode="w", delete=False) as f:
+            f.write(_ARTICLE_BIB)
+            path = f.name
+        try:
+            papers = _fmt.import_file(path)
+            assert len(papers) == 1
+            assert papers[0].title == "A Great Paper"
+        finally:
+            os.unlink(path)
+
+    def test_import_multi_entry_file(self):
+        with tempfile.NamedTemporaryFile(suffix=".bib", mode="w", delete=False) as f:
+            f.write(_ARTICLE_BIB + _NO_DOI_BIB)
+            path = f.name
+        try:
+            papers = _fmt.import_file(path)
+            assert len(papers) == 2
+        finally:
+            os.unlink(path)
+
+
+# ---------------------------------------------------------------------------
+# export_papers
+# ---------------------------------------------------------------------------
+
+class TestExportPapers:
+    def _make_paper(self, **overrides):
+        base = {
+            "paper_id": "2301.00001",
+            "title": "Test Export",
+            "summary": "An abstract.",
+            "published": datetime.date(2023, 1, 1),
+            "doi": None,
+            "journal_ref": None,
+            "url": None,
+        }
+        base.update(overrides)
+        return base
+
+    def test_export_contains_title(self):
+        out = _fmt.export_papers([self._make_paper()])
+        assert "Test Export" in out
+
+    def test_export_contains_year(self):
+        out = _fmt.export_papers([self._make_paper()])
+        assert "2023" in out
+
+    def test_export_contains_doi(self):
+        out = _fmt.export_papers([self._make_paper(doi="10.9999/x")])
+        assert "10.9999/x" in out
+
+    def test_export_contains_journal(self):
+        out = _fmt.export_papers([self._make_paper(journal_ref="Science")])
+        assert "Science" in out
+
+    def test_export_contains_url(self):
+        out = _fmt.export_papers([self._make_paper(url="https://example.com")])
+        assert "https://example.com" in out
+
+    def test_export_multiple_papers(self):
+        papers = [self._make_paper(paper_id="a"), self._make_paper(paper_id="b")]
+        out = _fmt.export_papers(papers)
+        assert out.count("@article") == 2
+
+    def test_export_empty_list(self):
+        out = _fmt.export_papers([])
+        assert isinstance(out, str)
+
+
+# ---------------------------------------------------------------------------
+# round-trip: import then export
+# ---------------------------------------------------------------------------
+
+class TestRoundTrip:
+    def test_import_export_preserves_title(self):
+        papers = _fmt.import_string(_ARTICLE_BIB)
+        exported = _fmt.export_papers([p.model_dump() for p in papers])
+        reimported = _fmt.import_string(exported)
+        assert reimported[0].title == papers[0].title
+
+    def test_import_export_preserves_year(self):
+        papers = _fmt.import_string(_ARTICLE_BIB)
+        exported = _fmt.export_papers([p.model_dump() for p in papers])
+        reimported = _fmt.import_string(exported)
+        assert reimported[0].published.year == 2020

--- a/tests/test_csv_fmt.py
+++ b/tests/test_csv_fmt.py
@@ -1,0 +1,223 @@
+"""Tests for formats/csv_fmt.py — import/export round-trips and edge cases."""
+
+from __future__ import annotations
+
+import csv
+import datetime
+import io
+import os
+import sys
+import tempfile
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from formats.csv_fmt import CSVFormat, TSVFormat
+
+_fmt = CSVFormat()
+_tsv = TSVFormat()
+
+
+# ---------------------------------------------------------------------------
+# helpers
+# ---------------------------------------------------------------------------
+
+def _make_paper(**overrides) -> dict:
+    base = {
+        "paper_id":  "2301.00001",
+        "title":     "Test Paper",
+        "authors":   ["Alice Author", "Bob Builder"],
+        "category":  "cs.LG",
+        "tags":      ["ml", "nlp"],
+        "published": datetime.date(2023, 1, 1),
+        "has_pdf":   False,
+    }
+    base.update(overrides)
+    return base
+
+
+def _write_temp_csv(content: str, suffix: str = ".csv") -> str:
+    f = tempfile.NamedTemporaryFile(suffix=suffix, mode="w", delete=False,
+                                   encoding="utf-8", newline="")
+    f.write(content)
+    f.close()
+    return f.name
+
+
+# ---------------------------------------------------------------------------
+# export_papers
+# ---------------------------------------------------------------------------
+
+class TestExportPapers:
+    def test_output_has_header(self):
+        out = _fmt.export_papers([_make_paper()])
+        reader = csv.DictReader(io.StringIO(out))
+        assert set(reader.fieldnames or []) >= {"paper_id", "title", "authors", "category", "tags", "published", "has_pdf"}
+
+    def test_single_paper_fields(self):
+        out = _fmt.export_papers([_make_paper()])
+        row = next(csv.DictReader(io.StringIO(out)))
+        assert row["paper_id"] == "2301.00001"
+        assert row["title"] == "Test Paper"
+        assert row["published"] == "2023-01-01"
+        assert row["has_pdf"] == "N"
+
+    def test_authors_semicolon_separated(self):
+        out = _fmt.export_papers([_make_paper()])
+        row = next(csv.DictReader(io.StringIO(out)))
+        assert row["authors"] == "Alice Author; Bob Builder"
+
+    def test_tags_comma_separated(self):
+        out = _fmt.export_papers([_make_paper()])
+        row = next(csv.DictReader(io.StringIO(out)))
+        assert row["tags"] == "ml, nlp"
+
+    def test_has_pdf_true(self):
+        out = _fmt.export_papers([_make_paper(has_pdf=True)])
+        row = next(csv.DictReader(io.StringIO(out)))
+        assert row["has_pdf"] == "Y"
+
+    def test_date_as_datetime_object(self):
+        out = _fmt.export_papers([_make_paper(published=datetime.datetime(2022, 3, 5))])
+        row = next(csv.DictReader(io.StringIO(out)))
+        assert row["published"].startswith("2022-03-05")
+
+    def test_multiple_papers_row_count(self):
+        papers = [_make_paper(paper_id="a"), _make_paper(paper_id="b")]
+        out = _fmt.export_papers(papers)
+        rows = list(csv.DictReader(io.StringIO(out)))
+        assert len(rows) == 2
+
+    def test_empty_list_only_header(self):
+        out = _fmt.export_papers([])
+        rows = list(csv.DictReader(io.StringIO(out)))
+        assert rows == []
+
+
+# ---------------------------------------------------------------------------
+# import_file
+# ---------------------------------------------------------------------------
+
+class TestImportFile:
+    def test_basic_fields(self):
+        content = "paper_id,title,authors,category,tags,published,has_pdf\n2301.00001,My Paper,A. Author,cs.LG,ml,2023-01-01,N\n"
+        path = _write_temp_csv(content)
+        try:
+            papers = _fmt.import_file(path)
+            assert len(papers) == 1
+            p = papers[0]
+            assert p.paper_id == "2301.00001"
+            assert p.title == "My Paper"
+            assert p.category == "cs.LG"
+            assert p.published == datetime.date(2023, 1, 1)
+        finally:
+            os.unlink(path)
+
+    def test_authors_parsed_from_semicolons(self):
+        content = "paper_id,title,authors,category,tags,published,has_pdf\n1,T,Alice; Bob,,,2020-01-01,N\n"
+        path = _write_temp_csv(content)
+        try:
+            papers = _fmt.import_file(path)
+            assert papers[0].authors == ["Alice", "Bob"]
+        finally:
+            os.unlink(path)
+
+    def test_tags_parsed_from_commas(self):
+        content = "paper_id,title,authors,category,tags,published,has_pdf\n1,T,,,,2020-01-01,N\n"
+        content = "paper_id,title,authors,category,tags,published,has_pdf\n1,T,,cs.AI,\"ml, nlp\",2020-01-01,N\n"
+        path = _write_temp_csv(content)
+        try:
+            papers = _fmt.import_file(path)
+            assert papers[0].tags == ["ml", "nlp"]
+        finally:
+            os.unlink(path)
+
+    def test_skips_rows_without_paper_id(self):
+        content = "paper_id,title,authors,category,tags,published,has_pdf\n,No ID paper,,,,2020-01-01,N\n1,Has ID,,,,2021-01-01,N\n"
+        path = _write_temp_csv(content)
+        try:
+            papers = _fmt.import_file(path)
+            assert len(papers) == 1
+            assert papers[0].paper_id == "1"
+        finally:
+            os.unlink(path)
+
+    def test_missing_date_uses_fallback(self):
+        content = "paper_id,title,authors,category,tags,published,has_pdf\n1,T,,,,,N\n"
+        path = _write_temp_csv(content)
+        try:
+            papers = _fmt.import_file(path)
+            assert papers[0].published == datetime.date(1900, 1, 1)
+        finally:
+            os.unlink(path)
+
+    def test_multiple_rows(self):
+        content = "paper_id,title,authors,category,tags,published,has_pdf\n1,A,,,, 2021-01-01,N\n2,B,,,,2022-01-01,N\n"
+        path = _write_temp_csv(content)
+        try:
+            papers = _fmt.import_file(path)
+            assert len(papers) == 2
+        finally:
+            os.unlink(path)
+
+
+# ---------------------------------------------------------------------------
+# TSV
+# ---------------------------------------------------------------------------
+
+class TestTSVFormat:
+    def test_export_uses_tab_delimiter(self):
+        out = _tsv.export_papers([_make_paper()])
+        assert "\t" in out
+
+    def test_tsv_round_trip(self):
+        exported = _tsv.export_papers([_make_paper()])
+        path = _write_temp_csv(exported, suffix=".tsv")
+        try:
+            papers = _tsv.import_file(path)
+            assert len(papers) == 1
+            assert papers[0].paper_id == "2301.00001"
+        finally:
+            os.unlink(path)
+
+
+# ---------------------------------------------------------------------------
+# round-trip
+# ---------------------------------------------------------------------------
+
+class TestRoundTrip:
+    def _round_trip(self, paper: dict):
+        exported = _fmt.export_papers([paper])
+        path = _write_temp_csv(exported)
+        try:
+            return _fmt.import_file(path)
+        finally:
+            os.unlink(path)
+
+    def test_preserves_paper_id(self):
+        assert self._round_trip(_make_paper())[0].paper_id == "2301.00001"
+
+    def test_preserves_title(self):
+        assert self._round_trip(_make_paper())[0].title == "Test Paper"
+
+    def test_preserves_authors(self):
+        rt = self._round_trip(_make_paper())
+        assert rt[0].authors == ["Alice Author", "Bob Builder"]
+
+    def test_preserves_published(self):
+        assert self._round_trip(_make_paper())[0].published == datetime.date(2023, 1, 1)
+
+    def test_preserves_category(self):
+        assert self._round_trip(_make_paper())[0].category == "cs.LG"
+
+    def test_preserves_tags(self):
+        assert self._round_trip(_make_paper())[0].tags == ["ml", "nlp"]
+
+    def test_two_papers_round_trip(self):
+        papers = [_make_paper(paper_id="a", title="A"), _make_paper(paper_id="b", title="B")]
+        exported = _fmt.export_papers(papers)
+        path = _write_temp_csv(exported)
+        try:
+            rt = _fmt.import_file(path)
+        finally:
+            os.unlink(path)
+        assert {p.paper_id for p in rt} == {"a", "b"}

--- a/tests/test_json_fmt.py
+++ b/tests/test_json_fmt.py
@@ -1,0 +1,235 @@
+"""Tests for formats/json_fmt.py — import/export round-trips and edge cases."""
+
+from __future__ import annotations
+
+import datetime
+import json
+import os
+import sys
+import tempfile
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from formats.json_fmt import JSONFormat, _parse_date, _parse_list
+
+_fmt = JSONFormat()
+
+
+# ---------------------------------------------------------------------------
+# helpers
+# ---------------------------------------------------------------------------
+
+class TestParseDate:
+    def test_iso_string(self):
+        assert _parse_date("2023-06-15") == datetime.date(2023, 6, 15)
+
+    def test_iso_string_with_time(self):
+        assert _parse_date("2023-06-15T10:00:00") == datetime.date(2023, 6, 15)
+
+    def test_date_object_passthrough(self):
+        d = datetime.date(2021, 3, 1)
+        assert _parse_date(d) == d
+
+    def test_invalid_string_falls_back(self):
+        assert _parse_date("not-a-date") == datetime.date(1900, 1, 1)
+
+    def test_empty_string_falls_back(self):
+        assert _parse_date("") == datetime.date(1900, 1, 1)
+
+    def test_none_falls_back(self):
+        assert _parse_date(None) == datetime.date(1900, 1, 1)
+
+
+class TestParseList:
+    def test_list_passthrough(self):
+        assert _parse_list(["a", "b"]) == ["a", "b"]
+
+    def test_semicolon_separated_string(self):
+        assert _parse_list("a; b; c") == ["a", "b", "c"]
+
+    def test_comma_separated_string(self):
+        assert _parse_list("a,b,c", sep=",") == ["a", "b", "c"]
+
+    def test_empty_string_returns_empty(self):
+        assert _parse_list("") == []
+
+    def test_none_returns_empty(self):
+        assert _parse_list(None) == []
+
+
+# ---------------------------------------------------------------------------
+# export_papers
+# ---------------------------------------------------------------------------
+
+def _make_paper(**overrides) -> dict:
+    base = {
+        "paper_id":   "2301.00001",
+        "version":    1,
+        "title":      "Test Paper",
+        "authors":    ["Alice Author", "Bob Builder"],
+        "published":  datetime.date(2023, 1, 1),
+        "summary":    "A test abstract.",
+        "category":   "cs.LG",
+        "tags":       ["ml", "nlp"],
+        "doi":        None,
+        "journal_ref": None,
+        "url":        None,
+        "source":     "test",
+    }
+    base.update(overrides)
+    return base
+
+
+class TestExportPapers:
+    def test_output_is_valid_json(self):
+        out = _fmt.export_papers([_make_paper()])
+        parsed = json.loads(out)
+        assert "papers" in parsed
+
+    def test_single_paper_fields(self):
+        out = _fmt.export_papers([_make_paper()])
+        p = json.loads(out)["papers"][0]
+        assert p["paper_id"] == "2301.00001"
+        assert p["title"] == "Test Paper"
+        assert p["authors"] == ["Alice Author", "Bob Builder"]
+        assert p["published"] == "2023-01-01"
+
+    def test_date_serialized_as_iso_string(self):
+        out = _fmt.export_papers([_make_paper(published=datetime.date(2022, 5, 10))])
+        p = json.loads(out)["papers"][0]
+        assert p["published"] == "2022-05-10"
+
+    def test_multiple_papers(self):
+        papers = [_make_paper(paper_id="a"), _make_paper(paper_id="b")]
+        out = _fmt.export_papers(papers)
+        assert len(json.loads(out)["papers"]) == 2
+
+    def test_empty_list(self):
+        out = _fmt.export_papers([])
+        assert json.loads(out) == {"papers": []}
+
+
+# ---------------------------------------------------------------------------
+# import_file
+# ---------------------------------------------------------------------------
+
+def _write_temp_json(data: dict) -> str:
+    f = tempfile.NamedTemporaryFile(suffix=".json", mode="w", delete=False, encoding="utf-8")
+    json.dump(data, f)
+    f.close()
+    return f.name
+
+
+class TestImportFile:
+    def test_basic_fields(self):
+        path = _write_temp_json({"papers": [{
+            "paper_id": "2301.00001",
+            "title": "Hello World",
+            "authors": ["A. Author"],
+            "published": "2023-01-01",
+            "summary": "Abstract here.",
+            "category": "cs.AI",
+            "source": "test",
+        }]})
+        try:
+            papers = _fmt.import_file(path)
+            assert len(papers) == 1
+            p = papers[0]
+            assert p.paper_id == "2301.00001"
+            assert p.title == "Hello World"
+            assert p.authors == ["A. Author"]
+            assert p.published == datetime.date(2023, 1, 1)
+            assert p.summary == "Abstract here."
+            assert p.category == "cs.AI"
+        finally:
+            os.unlink(path)
+
+    def test_flat_list_without_papers_key(self):
+        path = _write_temp_json([{"paper_id": "x", "title": "T", "authors": []}])
+        try:
+            papers = _fmt.import_file(path)
+            assert len(papers) == 1
+            assert papers[0].paper_id == "x"
+        finally:
+            os.unlink(path)
+
+    def test_tags_parsed(self):
+        path = _write_temp_json({"papers": [{
+            "paper_id": "1", "title": "T", "authors": [], "tags": ["a", "b"],
+        }]})
+        try:
+            papers = _fmt.import_file(path)
+            assert papers[0].tags == ["a", "b"]
+        finally:
+            os.unlink(path)
+
+    def test_missing_optional_fields_are_none(self):
+        path = _write_temp_json({"papers": [{"paper_id": "1", "title": "T", "authors": []}]})
+        try:
+            papers = _fmt.import_file(path)
+            p = papers[0]
+            assert p.doi is None
+            assert p.url is None
+            assert p.tags is None
+        finally:
+            os.unlink(path)
+
+    def test_multiple_entries(self):
+        path = _write_temp_json({"papers": [
+            {"paper_id": "1", "title": "A", "authors": []},
+            {"paper_id": "2", "title": "B", "authors": []},
+        ]})
+        try:
+            papers = _fmt.import_file(path)
+            assert len(papers) == 2
+        finally:
+            os.unlink(path)
+
+
+# ---------------------------------------------------------------------------
+# round-trip
+# ---------------------------------------------------------------------------
+
+class TestRoundTrip:
+    def _round_trip(self, paper: dict):
+        exported = _fmt.export_papers([paper])
+        path = tempfile.NamedTemporaryFile(suffix=".json", mode="w", delete=False, encoding="utf-8")
+        path.write(exported)
+        path.close()
+        try:
+            return _fmt.import_file(path.name)
+        finally:
+            os.unlink(path.name)
+
+    def test_preserves_paper_id(self):
+        assert self._round_trip(_make_paper())[0].paper_id == "2301.00001"
+
+    def test_preserves_title(self):
+        assert self._round_trip(_make_paper())[0].title == "Test Paper"
+
+    def test_preserves_authors(self):
+        rt = self._round_trip(_make_paper())
+        assert rt[0].authors == ["Alice Author", "Bob Builder"]
+
+    def test_preserves_published_date(self):
+        rt = self._round_trip(_make_paper())
+        assert rt[0].published == datetime.date(2023, 1, 1)
+
+    def test_preserves_tags(self):
+        rt = self._round_trip(_make_paper())
+        assert rt[0].tags == ["ml", "nlp"]
+
+    def test_preserves_category(self):
+        assert self._round_trip(_make_paper())[0].category == "cs.LG"
+
+    def test_two_papers_round_trip(self):
+        papers = [_make_paper(paper_id="a", title="A"), _make_paper(paper_id="b", title="B")]
+        exported = _fmt.export_papers(papers)
+        path = tempfile.NamedTemporaryFile(suffix=".json", mode="w", delete=False, encoding="utf-8")
+        path.write(exported)
+        path.close()
+        try:
+            rt = _fmt.import_file(path.name)
+        finally:
+            os.unlink(path.name)
+        assert {p.paper_id for p in rt} == {"a", "b"}

--- a/tests/test_json_fmt.py
+++ b/tests/test_json_fmt.py
@@ -113,7 +113,7 @@ class TestExportPapers:
 # import_file
 # ---------------------------------------------------------------------------
 
-def _write_temp_json(data: dict) -> str:
+def _write_temp_json(data: dict | list) -> str:
     f = tempfile.NamedTemporaryFile(suffix=".json", mode="w", delete=False, encoding="utf-8")
     json.dump(data, f)
     f.close()

--- a/tests/test_markdown_fmt.py
+++ b/tests/test_markdown_fmt.py
@@ -1,0 +1,352 @@
+"""Tests for formats/markdown.py — import/export round-trips and edge cases."""
+
+from __future__ import annotations
+
+import datetime
+import os
+import sys
+import tempfile
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from formats.markdown import MarkdownFormat, ObsidianFormat, _paper_id_from_url
+
+_md  = MarkdownFormat()
+_obs = ObsidianFormat()
+
+
+# ---------------------------------------------------------------------------
+# helpers
+# ---------------------------------------------------------------------------
+
+def _make_paper(**overrides) -> dict:
+    base = {
+        "paper_id": "2301.00001",
+        "title":    "Test Paper",
+        "authors":  ["Alice Author", "Bob Builder"],
+        "category": "cs.LG",
+        "tags":     ["ml", "nlp"],
+        "published": datetime.date(2023, 1, 1),
+    }
+    base.update(overrides)
+    return base
+
+
+# ---------------------------------------------------------------------------
+# _paper_id_from_url
+# ---------------------------------------------------------------------------
+
+class TestPaperIdFromUrl:
+    def test_arxiv_url(self):
+        assert _paper_id_from_url("https://arxiv.org/abs/2301.00001") == "2301.00001"
+
+    def test_http_arxiv_url(self):
+        assert _paper_id_from_url("http://arxiv.org/abs/1234.56789") == "1234.56789"
+
+    def test_non_arxiv_url_returns_full(self):
+        assert _paper_id_from_url("https://example.com/paper") == "https://example.com/paper"
+
+    def test_bare_id_returned_as_is(self):
+        assert _paper_id_from_url("2301.00001") == "2301.00001"
+
+
+# ---------------------------------------------------------------------------
+# MarkdownFormat — export
+# ---------------------------------------------------------------------------
+
+class TestMarkdownExport:
+    def test_contains_title(self):
+        out = _md.export_papers([_make_paper()])
+        assert "Test Paper" in out
+
+    def test_contains_arxiv_url(self):
+        out = _md.export_papers([_make_paper()])
+        assert "arxiv.org/abs/2301.00001" in out
+
+    def test_contains_authors(self):
+        out = _md.export_papers([_make_paper()])
+        assert "Alice Author" in out
+        assert "Bob Builder" in out
+
+    def test_contains_category(self):
+        out = _md.export_papers([_make_paper()])
+        assert "cs.LG" in out
+
+    def test_contains_tags(self):
+        out = _md.export_papers([_make_paper()])
+        assert "ml" in out
+        assert "nlp" in out
+
+    def test_no_authors_skips_authors_line(self):
+        out = _md.export_papers([_make_paper(authors=[])])
+        assert "Authors:" not in out
+
+    def test_no_category_skips_category_line(self):
+        out = _md.export_papers([_make_paper(category="")])
+        assert "Category:" not in out
+
+    def test_no_tags_skips_tags_line(self):
+        out = _md.export_papers([_make_paper(tags=[])])
+        assert "Tags:" not in out
+
+    def test_multiple_papers(self):
+        papers = [_make_paper(paper_id="a", title="A"), _make_paper(paper_id="b", title="B")]
+        out = _md.export_papers(papers)
+        assert "A" in out and "B" in out
+
+    def test_empty_list_has_header(self):
+        out = _md.export_papers([])
+        assert "# Selected Papers" in out
+
+
+# ---------------------------------------------------------------------------
+# MarkdownFormat — import_string
+# ---------------------------------------------------------------------------
+
+class TestMarkdownImport:
+    def test_basic_import(self):
+        out = _md.export_papers([_make_paper()])
+        papers = _md.import_string(out)
+        assert len(papers) == 1
+
+    def test_paper_id_extracted_from_url(self):
+        out = _md.export_papers([_make_paper()])
+        p = _md.import_string(out)[0]
+        assert p.paper_id == "2301.00001"
+
+    def test_title_preserved(self):
+        out = _md.export_papers([_make_paper()])
+        assert _md.import_string(out)[0].title == "Test Paper"
+
+    def test_authors_preserved(self):
+        out = _md.export_papers([_make_paper()])
+        p = _md.import_string(out)[0]
+        assert "Alice Author" in p.authors
+        assert "Bob Builder" in p.authors
+
+    def test_category_preserved(self):
+        out = _md.export_papers([_make_paper()])
+        assert _md.import_string(out)[0].category == "cs.LG"
+
+    def test_tags_preserved(self):
+        out = _md.export_papers([_make_paper()])
+        assert _md.import_string(out)[0].tags == ["ml", "nlp"]
+
+    def test_multiple_papers(self):
+        papers = [_make_paper(paper_id="2301.00001", title="A"),
+                  _make_paper(paper_id="2301.00002", title="B")]
+        out = _md.export_papers(papers)
+        rt = _md.import_string(out)
+        assert len(rt) == 2
+        assert {p.paper_id for p in rt} == {"2301.00001", "2301.00002"}
+
+    def test_empty_export_returns_empty(self):
+        out = _md.export_papers([])
+        assert _md.import_string(out) == []
+
+    def test_source_is_import(self):
+        out = _md.export_papers([_make_paper()])
+        assert _md.import_string(out)[0].source == "import"
+
+
+# ---------------------------------------------------------------------------
+# MarkdownFormat — import_file
+# ---------------------------------------------------------------------------
+
+class TestMarkdownImportFile:
+    def test_import_from_file(self):
+        out = _md.export_papers([_make_paper()])
+        with tempfile.NamedTemporaryFile(suffix=".md", mode="w", delete=False, encoding="utf-8") as f:
+            f.write(out)
+            path = f.name
+        try:
+            papers = _md.import_file(path)
+            assert len(papers) == 1
+            assert papers[0].paper_id == "2301.00001"
+        finally:
+            os.unlink(path)
+
+
+# ---------------------------------------------------------------------------
+# MarkdownFormat — round-trip
+# ---------------------------------------------------------------------------
+
+class TestMarkdownRoundTrip:
+    def _rt(self, paper: dict):
+        return _md.import_string(_md.export_papers([paper]))
+
+    def test_paper_id(self):
+        assert self._rt(_make_paper())[0].paper_id == "2301.00001"
+
+    def test_title(self):
+        assert self._rt(_make_paper())[0].title == "Test Paper"
+
+    def test_authors(self):
+        rt = self._rt(_make_paper())
+        assert rt[0].authors == ["Alice Author", "Bob Builder"]
+
+    def test_category(self):
+        assert self._rt(_make_paper())[0].category == "cs.LG"
+
+    def test_tags(self):
+        assert self._rt(_make_paper())[0].tags == ["ml", "nlp"]
+
+    def test_no_tags_round_trip(self):
+        rt = self._rt(_make_paper(tags=[]))
+        assert not rt[0].tags
+
+    def test_special_chars_in_title(self):
+        rt = self._rt(_make_paper(title="Transformers: A Survey (2023)"))
+        assert rt[0].title == "Transformers: A Survey (2023)"
+
+
+# ---------------------------------------------------------------------------
+# ObsidianFormat — export
+# ---------------------------------------------------------------------------
+
+class TestObsidianExport:
+    def test_has_yaml_frontmatter(self):
+        out = _obs.export_papers([_make_paper()])
+        assert out.startswith("---")
+        assert "papers: 1" in out
+
+    def test_frontmatter_contains_tags(self):
+        out = _obs.export_papers([_make_paper()])
+        assert "  - ml" in out
+        assert "  - nlp" in out
+
+    def test_frontmatter_tags_are_deduplicated(self):
+        papers = [_make_paper(tags=["ml"]), _make_paper(paper_id="x", tags=["ml"])]
+        out = _obs.export_papers(papers)
+        assert out.count("  - ml") == 1
+
+    def test_frontmatter_tags_sorted(self):
+        out = _obs.export_papers([_make_paper(tags=["zzz", "aaa"])])
+        aaa_pos = out.index("  - aaa")
+        zzz_pos = out.index("  - zzz")
+        assert aaa_pos < zzz_pos
+
+    def test_no_tags_omits_tags_key(self):
+        out = _obs.export_papers([_make_paper(tags=[])])
+        assert "tags:" not in out
+
+    def test_contains_h2_section_per_paper(self):
+        papers = [_make_paper(paper_id="a", title="A"), _make_paper(paper_id="b", title="B")]
+        out = _obs.export_papers(papers)
+        assert out.count("## [") == 2
+
+    def test_section_contains_bold_authors(self):
+        out = _obs.export_papers([_make_paper()])
+        assert "**Authors:**" in out
+        assert "Alice Author" in out
+
+    def test_section_contains_bold_category(self):
+        out = _obs.export_papers([_make_paper()])
+        assert "**Category:** cs.LG" in out
+
+    def test_section_contains_bold_tags(self):
+        out = _obs.export_papers([_make_paper()])
+        assert "**Tags:**" in out
+
+
+# ---------------------------------------------------------------------------
+# ObsidianFormat — import_string
+# ---------------------------------------------------------------------------
+
+class TestObsidianImport:
+    def test_basic_import(self):
+        out = _obs.export_papers([_make_paper()])
+        papers = _obs.import_string(out)
+        assert len(papers) == 1
+
+    def test_paper_id_from_url(self):
+        out = _obs.export_papers([_make_paper()])
+        assert _obs.import_string(out)[0].paper_id == "2301.00001"
+
+    def test_title_preserved(self):
+        out = _obs.export_papers([_make_paper()])
+        assert _obs.import_string(out)[0].title == "Test Paper"
+
+    def test_authors_preserved(self):
+        out = _obs.export_papers([_make_paper()])
+        p = _obs.import_string(out)[0]
+        assert "Alice Author" in p.authors
+        assert "Bob Builder" in p.authors
+
+    def test_category_preserved(self):
+        out = _obs.export_papers([_make_paper()])
+        assert _obs.import_string(out)[0].category == "cs.LG"
+
+    def test_tags_preserved(self):
+        out = _obs.export_papers([_make_paper()])
+        assert _obs.import_string(out)[0].tags == ["ml", "nlp"]
+
+    def test_multiple_papers(self):
+        papers = [_make_paper(paper_id="2301.00001", title="A"),
+                  _make_paper(paper_id="2301.00002", title="B")]
+        rt = _obs.import_string(_obs.export_papers(papers))
+        assert len(rt) == 2
+        assert {p.paper_id for p in rt} == {"2301.00001", "2301.00002"}
+
+    def test_empty_export_returns_empty(self):
+        assert _obs.import_string(_obs.export_papers([])) == []
+
+    def test_source_is_import(self):
+        out = _obs.export_papers([_make_paper()])
+        assert _obs.import_string(out)[0].source == "import"
+
+
+# ---------------------------------------------------------------------------
+# ObsidianFormat — import_file
+# ---------------------------------------------------------------------------
+
+class TestObsidianImportFile:
+    def test_import_from_file(self):
+        out = _obs.export_papers([_make_paper()])
+        with tempfile.NamedTemporaryFile(suffix=".md", mode="w", delete=False, encoding="utf-8") as f:
+            f.write(out)
+            path = f.name
+        try:
+            papers = _obs.import_file(path)
+            assert len(papers) == 1
+            assert papers[0].paper_id == "2301.00001"
+        finally:
+            os.unlink(path)
+
+
+# ---------------------------------------------------------------------------
+# ObsidianFormat — round-trip
+# ---------------------------------------------------------------------------
+
+class TestObsidianRoundTrip:
+    def _rt(self, paper: dict):
+        return _obs.import_string(_obs.export_papers([paper]))
+
+    def test_paper_id(self):
+        assert self._rt(_make_paper())[0].paper_id == "2301.00001"
+
+    def test_title(self):
+        assert self._rt(_make_paper())[0].title == "Test Paper"
+
+    def test_authors(self):
+        rt = self._rt(_make_paper())
+        assert rt[0].authors == ["Alice Author", "Bob Builder"]
+
+    def test_category(self):
+        assert self._rt(_make_paper())[0].category == "cs.LG"
+
+    def test_tags(self):
+        assert self._rt(_make_paper())[0].tags == ["ml", "nlp"]
+
+    def test_no_tags_round_trip(self):
+        rt = self._rt(_make_paper(tags=[]))
+        assert not rt[0].tags
+
+    def test_special_chars_in_title(self):
+        rt = self._rt(_make_paper(title="Attention Is All You Need"))
+        assert rt[0].title == "Attention Is All You Need"
+
+    def test_two_papers_ids(self):
+        papers = [_make_paper(paper_id="2301.00001"), _make_paper(paper_id="2301.00002")]
+        rt = _obs.import_string(_obs.export_papers(papers))
+        assert {p.paper_id for p in rt} == {"2301.00001", "2301.00002"}

--- a/tests/test_non_arxiv.py
+++ b/tests/test_non_arxiv.py
@@ -1,0 +1,511 @@
+"""Round-trip and correctness tests for papers from non-arXiv/non-OpenAlex sources.
+
+Covers BibTeX, JSON, CSV, Markdown, and Obsidian for papers whose paper_id is a
+DOI, a BibTeX cite-key, or any other non-arXiv identifier.
+"""
+
+from __future__ import annotations
+
+import datetime
+import io
+import csv
+import os
+import sys
+import tempfile
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from formats.bibtex import BibTeXFormat
+from formats.csv_fmt import CSVFormat
+from formats.json_fmt import JSONFormat
+from formats.markdown import (
+    MarkdownFormat, ObsidianFormat,
+    _is_arxiv_id, _paper_url,
+)
+
+_bib = BibTeXFormat()
+_csv = CSVFormat()
+_jsn = JSONFormat()
+_md  = MarkdownFormat()
+_obs = ObsidianFormat()
+
+
+# ---------------------------------------------------------------------------
+# Shared fixtures
+# ---------------------------------------------------------------------------
+
+def _doi_paper(**overrides) -> dict:
+    """A paper whose paper_id is a DOI (e.g. from an ACM/IEEE/Springer import)."""
+    base = {
+        "paper_id":    "10.1145/3290605.3300741",
+        "version":     1,
+        "title":       "Deep Learning for HCI",
+        "authors":     ["Jane Doe", "Bob Smith"],
+        "published":   datetime.date(2019, 5, 4),
+        "summary":     "An ACM CHI paper.",
+        "category":    None,
+        "tags":        ["hci", "deep-learning"],
+        "doi":         "10.1145/3290605.3300741",
+        "journal_ref": "CHI 2019",
+        "url":         "https://dl.acm.org/doi/10.1145/3290605.3300741",
+        "source":      "bibtex",
+    }
+    base.update(overrides)
+    return base
+
+
+def _key_paper(**overrides) -> dict:
+    """A paper whose paper_id is a bare BibTeX cite-key (no DOI)."""
+    base = {
+        "paper_id":    "vaswani2017attention",
+        "version":     1,
+        "title":       "Attention Is All You Need",
+        "authors":     ["Vaswani, Ashish", "Shazeer, Noam"],
+        "published":   datetime.date(2017, 6, 12),
+        "summary":     "The transformer paper.",
+        "category":    None,
+        "tags":        ["transformers", "nlp"],
+        "doi":         None,
+        "journal_ref": "NeurIPS 2017",
+        "url":         None,
+        "source":      "bibtex",
+    }
+    base.update(overrides)
+    return base
+
+
+def _arxiv_paper(**overrides) -> dict:
+    """A normal arXiv paper for mixed-source tests."""
+    base = {
+        "paper_id":  "2301.00001",
+        "version":   1,
+        "title":     "An arXiv Paper",
+        "authors":   ["Alice Arxiv"],
+        "published": datetime.date(2023, 1, 1),
+        "summary":   "",
+        "category":  "cs.LG",
+        "tags":      ["ml"],
+        "doi":       None,
+        "url":       None,
+        "source":    "arxiv",
+    }
+    base.update(overrides)
+    return base
+
+
+# ---------------------------------------------------------------------------
+# _is_arxiv_id
+# ---------------------------------------------------------------------------
+
+class TestIsArxivId:
+    def test_new_format(self):
+        assert _is_arxiv_id("2301.00001")
+
+    def test_new_format_with_version(self):
+        assert _is_arxiv_id("2301.00001v2")
+
+    def test_new_format_five_digits(self):
+        assert _is_arxiv_id("2301.12345")
+
+    def test_old_format(self):
+        assert _is_arxiv_id("cs/0612047")
+
+    def test_doi_is_not_arxiv(self):
+        assert not _is_arxiv_id("10.1145/3290605.3300741")
+
+    def test_bibtex_key_is_not_arxiv(self):
+        assert not _is_arxiv_id("vaswani2017attention")
+
+    def test_url_is_not_arxiv(self):
+        assert not _is_arxiv_id("https://arxiv.org/abs/2301.00001")
+
+    def test_empty_is_not_arxiv(self):
+        assert not _is_arxiv_id("")
+
+
+# ---------------------------------------------------------------------------
+# _paper_url
+# ---------------------------------------------------------------------------
+
+class TestPaperUrl:
+    def test_stored_url_takes_priority(self):
+        assert _paper_url("2301.00001", "https://example.com") == "https://example.com"
+
+    def test_arxiv_id_without_stored_url(self):
+        assert _paper_url("2301.00001", None) == "https://arxiv.org/abs/2301.00001"
+
+    def test_doi_without_stored_url_returns_empty(self):
+        assert _paper_url("10.1145/xyz", None) == ""
+
+    def test_bibtex_key_without_stored_url_returns_empty(self):
+        assert _paper_url("smith2020", None) == ""
+
+    def test_doi_with_stored_url(self):
+        assert _paper_url("10.1145/xyz", "https://dl.acm.org/doi/10.1145/xyz") == \
+               "https://dl.acm.org/doi/10.1145/xyz"
+
+
+# ---------------------------------------------------------------------------
+# BibTeX — non-arXiv import
+# ---------------------------------------------------------------------------
+
+_ACM_BIB = """\
+@inproceedings{doe2019deep,
+  author    = {Doe, Jane and Smith, Bob},
+  title     = {Deep Learning for HCI},
+  year      = {2019},
+  booktitle = {CHI 2019},
+  doi       = {10.1145/3290605.3300741},
+  url       = {https://dl.acm.org/doi/10.1145/3290605.3300741},
+  abstract  = {An ACM CHI paper.},
+}
+"""
+
+_NO_DOI_BIB = """\
+@article{vaswani2017attention,
+  author  = {Vaswani, Ashish and Shazeer, Noam},
+  title   = {Attention Is All You Need},
+  year    = {2017},
+  journal = {NeurIPS 2017},
+}
+"""
+
+_MIXED_BIB = """\
+@article{arxiv2023,
+  author = {Alice, A.},
+  title  = {An arXiv Paper},
+  year   = {2023},
+  doi    = {10.48550/arXiv.2301.00001},
+}
+@inproceedings{doe2019deep,
+  author    = {Doe, Jane},
+  title     = {Deep Learning for HCI},
+  year      = {2019},
+  booktitle = {CHI 2019},
+  doi       = {10.1145/3290605.3300741},
+}
+"""
+
+
+class TestBibTeXNonArxiv:
+    def test_doi_used_as_paper_id(self):
+        papers = _bib.import_string(_ACM_BIB)
+        assert papers[0].paper_id == "10.1145/3290605.3300741"
+
+    def test_doi_field_preserved(self):
+        papers = _bib.import_string(_ACM_BIB)
+        assert papers[0].doi == "10.1145/3290605.3300741"
+
+    def test_url_preserved(self):
+        papers = _bib.import_string(_ACM_BIB)
+        assert papers[0].url == "https://dl.acm.org/doi/10.1145/3290605.3300741"
+
+    def test_booktitle_as_journal_ref(self):
+        papers = _bib.import_string(_ACM_BIB)
+        assert papers[0].journal_ref == "CHI 2019"
+
+    def test_title_preserved(self):
+        papers = _bib.import_string(_ACM_BIB)
+        assert papers[0].title == "Deep Learning for HCI"
+
+    def test_year_parsed(self):
+        papers = _bib.import_string(_ACM_BIB)
+        assert papers[0].published.year == 2019
+
+    def test_source_is_bibtex(self):
+        papers = _bib.import_string(_ACM_BIB)
+        assert papers[0].source == "bibtex"
+
+    def test_no_doi_uses_cite_key(self):
+        papers = _bib.import_string(_NO_DOI_BIB)
+        assert papers[0].paper_id == "vaswani2017attention"
+        assert papers[0].doi is None
+
+    def test_mixed_doi_and_no_doi(self):
+        papers = _bib.import_string(_MIXED_BIB)
+        ids = {p.paper_id for p in papers}
+        assert "10.1145/3290605.3300741" in ids
+        assert "10.48550/arXiv.2301.00001" in ids
+
+    def test_export_doi_paper_contains_doi(self):
+        out = _bib.export_papers([_doi_paper()])
+        assert "10.1145/3290605.3300741" in out
+
+    def test_export_doi_paper_contains_title(self):
+        out = _bib.export_papers([_doi_paper()])
+        assert "Deep Learning for HCI" in out
+
+    def test_export_key_paper_contains_title(self):
+        out = _bib.export_papers([_key_paper()])
+        assert "Attention Is All You Need" in out
+
+    def test_bibtex_round_trip_doi_paper(self):
+        out = _bib.export_papers([_doi_paper()])
+        reimported = _bib.import_string(out)
+        assert reimported[0].title == "Deep Learning for HCI"
+        assert reimported[0].doi == "10.1145/3290605.3300741"
+
+
+# ---------------------------------------------------------------------------
+# JSON — non-arXiv round-trip
+# ---------------------------------------------------------------------------
+
+def _json_round_trip(paper: dict) -> list:
+    exported = _jsn.export_papers([paper])
+    path = tempfile.NamedTemporaryFile(suffix=".json", mode="w", delete=False, encoding="utf-8")
+    path.write(exported)
+    path.close()
+    try:
+        return _jsn.import_file(path.name)
+    finally:
+        os.unlink(path.name)
+
+
+class TestJSONNonArxiv:
+    def test_doi_paper_id_preserved(self):
+        assert _json_round_trip(_doi_paper())[0].paper_id == "10.1145/3290605.3300741"
+
+    def test_key_paper_id_preserved(self):
+        assert _json_round_trip(_key_paper())[0].paper_id == "vaswani2017attention"
+
+    def test_doi_field_preserved(self):
+        rt = _json_round_trip(_doi_paper())
+        assert rt[0].doi == "10.1145/3290605.3300741"
+
+    def test_url_preserved(self):
+        rt = _json_round_trip(_doi_paper())
+        assert rt[0].url == "https://dl.acm.org/doi/10.1145/3290605.3300741"
+
+    def test_title_preserved(self):
+        assert _json_round_trip(_doi_paper())[0].title == "Deep Learning for HCI"
+
+    def test_authors_preserved(self):
+        rt = _json_round_trip(_doi_paper())
+        assert rt[0].authors == ["Jane Doe", "Bob Smith"]
+
+    def test_tags_preserved(self):
+        rt = _json_round_trip(_doi_paper())
+        assert rt[0].tags == ["hci", "deep-learning"]
+
+    def test_mixed_sources_in_one_file(self):
+        papers = [_doi_paper(), _arxiv_paper()]
+        exported = _jsn.export_papers(papers)
+        path = tempfile.NamedTemporaryFile(suffix=".json", mode="w", delete=False, encoding="utf-8")
+        path.write(exported)
+        path.close()
+        try:
+            rt = _jsn.import_file(path.name)
+        finally:
+            os.unlink(path.name)
+        ids = {p.paper_id for p in rt}
+        assert "10.1145/3290605.3300741" in ids
+        assert "2301.00001" in ids
+
+
+# ---------------------------------------------------------------------------
+# CSV — non-arXiv round-trip
+# ---------------------------------------------------------------------------
+
+def _csv_round_trip(paper: dict) -> list:
+    exported = _csv.export_papers([paper])
+    f = tempfile.NamedTemporaryFile(suffix=".csv", mode="w", delete=False,
+                                    encoding="utf-8", newline="")
+    f.write(exported)
+    f.close()
+    try:
+        return _csv.import_file(f.name)
+    finally:
+        os.unlink(f.name)
+
+
+class TestCSVNonArxiv:
+    def test_doi_paper_id_preserved(self):
+        assert _csv_round_trip(_doi_paper())[0].paper_id == "10.1145/3290605.3300741"
+
+    def test_key_paper_id_preserved(self):
+        assert _csv_round_trip(_key_paper())[0].paper_id == "vaswani2017attention"
+
+    def test_title_preserved(self):
+        assert _csv_round_trip(_doi_paper())[0].title == "Deep Learning for HCI"
+
+    def test_authors_preserved(self):
+        rt = _csv_round_trip(_doi_paper())
+        assert rt[0].authors == ["Jane Doe", "Bob Smith"]
+
+    def test_tags_preserved(self):
+        rt = _csv_round_trip(_doi_paper())
+        assert rt[0].tags == ["hci", "deep-learning"]
+
+    def test_doi_with_slash_in_paper_id(self):
+        # DOIs contain slashes — must survive CSV quoting
+        rt = _csv_round_trip(_doi_paper())
+        assert "/" in rt[0].paper_id
+
+    def test_mixed_sources_row_count(self):
+        exported = _csv.export_papers([_doi_paper(), _arxiv_paper()])
+        rows = list(csv.DictReader(io.StringIO(exported)))
+        assert len(rows) == 2
+        ids = {r["paper_id"] for r in rows}
+        assert "10.1145/3290605.3300741" in ids
+        assert "2301.00001" in ids
+
+
+# ---------------------------------------------------------------------------
+# Markdown — non-arXiv export correctness
+# ---------------------------------------------------------------------------
+
+class TestMarkdownNonArxivExport:
+    def test_does_not_use_fake_arxiv_url_for_doi_paper(self):
+        out = _md.export_papers([_doi_paper()])
+        assert "arxiv.org/abs/10.1145" not in out
+
+    def test_uses_stored_url_for_doi_paper(self):
+        out = _md.export_papers([_doi_paper()])
+        assert "dl.acm.org" in out
+
+    def test_paper_id_line_written_for_doi_paper(self):
+        out = _md.export_papers([_doi_paper()])
+        assert "Paper-ID: 10.1145/3290605.3300741" in out
+
+    def test_paper_id_line_written_for_key_paper(self):
+        out = _md.export_papers([_key_paper()])
+        assert "Paper-ID: vaswani2017attention" in out
+
+    def test_no_paper_id_line_for_arxiv_paper(self):
+        out = _md.export_papers([_arxiv_paper()])
+        assert "Paper-ID:" not in out
+
+    def test_arxiv_paper_uses_arxiv_url(self):
+        out = _md.export_papers([_arxiv_paper()])
+        assert "arxiv.org/abs/2301.00001" in out
+
+    def test_key_paper_no_url_has_empty_link(self):
+        out = _md.export_papers([_key_paper()])
+        assert "]()" in out
+
+    def test_title_present_for_doi_paper(self):
+        out = _md.export_papers([_doi_paper()])
+        assert "Deep Learning for HCI" in out
+
+
+# ---------------------------------------------------------------------------
+# Markdown — non-arXiv round-trip
+# ---------------------------------------------------------------------------
+
+class TestMarkdownNonArxivRoundTrip:
+    def _rt(self, paper: dict):
+        return _md.import_string(_md.export_papers([paper]))
+
+    def test_doi_paper_id_preserved(self):
+        assert self._rt(_doi_paper())[0].paper_id == "10.1145/3290605.3300741"
+
+    def test_key_paper_id_preserved(self):
+        assert self._rt(_key_paper())[0].paper_id == "vaswani2017attention"
+
+    def test_arxiv_paper_id_preserved(self):
+        assert self._rt(_arxiv_paper())[0].paper_id == "2301.00001"
+
+    def test_doi_title_preserved(self):
+        assert self._rt(_doi_paper())[0].title == "Deep Learning for HCI"
+
+    def test_key_title_preserved(self):
+        assert self._rt(_key_paper())[0].title == "Attention Is All You Need"
+
+    def test_doi_authors_preserved(self):
+        rt = self._rt(_doi_paper())
+        assert rt[0].authors == ["Jane Doe", "Bob Smith"]
+
+    def test_doi_tags_preserved(self):
+        assert self._rt(_doi_paper())[0].tags == ["hci", "deep-learning"]
+
+    def test_doi_url_preserved(self):
+        rt = self._rt(_doi_paper())
+        assert rt[0].url == "https://dl.acm.org/doi/10.1145/3290605.3300741"
+
+    def test_mixed_sources_both_ids_correct(self):
+        papers = [_doi_paper(), _arxiv_paper()]
+        rt = _md.import_string(_md.export_papers(papers))
+        ids = {p.paper_id for p in rt}
+        assert "10.1145/3290605.3300741" in ids
+        assert "2301.00001" in ids
+
+    def test_three_sources_mixed(self):
+        papers = [_doi_paper(), _key_paper(), _arxiv_paper()]
+        rt = _md.import_string(_md.export_papers(papers))
+        ids = {p.paper_id for p in rt}
+        assert ids == {"10.1145/3290605.3300741", "vaswani2017attention", "2301.00001"}
+
+
+# ---------------------------------------------------------------------------
+# Obsidian — non-arXiv export correctness
+# ---------------------------------------------------------------------------
+
+class TestObsidianNonArxivExport:
+    def test_does_not_use_fake_arxiv_url_for_doi_paper(self):
+        out = _obs.export_papers([_doi_paper()])
+        assert "arxiv.org/abs/10.1145" not in out
+
+    def test_uses_stored_url_for_doi_paper(self):
+        out = _obs.export_papers([_doi_paper()])
+        assert "dl.acm.org" in out
+
+    def test_paper_id_line_written_for_doi_paper(self):
+        out = _obs.export_papers([_doi_paper()])
+        assert "**Paper-ID:** 10.1145/3290605.3300741" in out
+
+    def test_paper_id_line_written_for_key_paper(self):
+        out = _obs.export_papers([_key_paper()])
+        assert "**Paper-ID:** vaswani2017attention" in out
+
+    def test_no_paper_id_line_for_arxiv_paper(self):
+        out = _obs.export_papers([_arxiv_paper()])
+        assert "**Paper-ID:**" not in out
+
+    def test_arxiv_paper_uses_arxiv_url(self):
+        out = _obs.export_papers([_arxiv_paper()])
+        assert "arxiv.org/abs/2301.00001" in out
+
+
+# ---------------------------------------------------------------------------
+# Obsidian — non-arXiv round-trip
+# ---------------------------------------------------------------------------
+
+class TestObsidianNonArxivRoundTrip:
+    def _rt(self, paper: dict):
+        return _obs.import_string(_obs.export_papers([paper]))
+
+    def test_doi_paper_id_preserved(self):
+        assert self._rt(_doi_paper())[0].paper_id == "10.1145/3290605.3300741"
+
+    def test_key_paper_id_preserved(self):
+        assert self._rt(_key_paper())[0].paper_id == "vaswani2017attention"
+
+    def test_arxiv_paper_id_preserved(self):
+        assert self._rt(_arxiv_paper())[0].paper_id == "2301.00001"
+
+    def test_doi_title_preserved(self):
+        assert self._rt(_doi_paper())[0].title == "Deep Learning for HCI"
+
+    def test_doi_authors_preserved(self):
+        rt = self._rt(_doi_paper())
+        assert rt[0].authors == ["Jane Doe", "Bob Smith"]
+
+    def test_doi_tags_preserved(self):
+        assert self._rt(_doi_paper())[0].tags == ["hci", "deep-learning"]
+
+    def test_doi_url_preserved(self):
+        rt = self._rt(_doi_paper())
+        assert rt[0].url == "https://dl.acm.org/doi/10.1145/3290605.3300741"
+
+    def test_mixed_sources_both_ids_correct(self):
+        papers = [_doi_paper(), _arxiv_paper()]
+        rt = _obs.import_string(_obs.export_papers(papers))
+        ids = {p.paper_id for p in rt}
+        assert "10.1145/3290605.3300741" in ids
+        assert "2301.00001" in ids
+
+    def test_three_sources_mixed(self):
+        papers = [_doi_paper(), _key_paper(), _arxiv_paper()]
+        rt = _obs.import_string(_obs.export_papers(papers))
+        ids = {p.paper_id for p in rt}
+        assert ids == {"10.1145/3290605.3300741", "vaswani2017attention", "2301.00001"}

--- a/tests/test_non_arxiv.py
+++ b/tests/test_non_arxiv.py
@@ -509,3 +509,113 @@ class TestObsidianNonArxivRoundTrip:
         rt = _obs.import_string(_obs.export_papers(papers))
         ids = {p.paper_id for p in rt}
         assert ids == {"10.1145/3290605.3300741", "vaswani2017attention", "2301.00001"}
+
+
+# ---------------------------------------------------------------------------
+# Graph export contract — getSelectedPaperData() shape
+#
+# graph.js builds paper dicts with a fixed set of fields. These tests use that
+# exact shape to ensure the format layer handles missing/null url correctly and
+# that Paper-ID round-trips survive even when url is absent from the payload.
+# ---------------------------------------------------------------------------
+
+def _graph_paper(paper_id: str, title: str, url=None, doi=None, **kwargs) -> dict:
+    """Mirrors the shape emitted by getSelectedPaperData() in graph.js."""
+    return {
+        "paper_id":  paper_id,
+        "title":     title,
+        "category":  kwargs.get("category", ""),
+        "tags":      kwargs.get("tags", []),
+        "has_pdf":   kwargs.get("has_pdf", False),
+        "published": kwargs.get("published", "2023-01-01"),
+        "authors":   kwargs.get("authors", []),
+        "url":       url,
+        "doi":       doi,
+        "summary":   kwargs.get("summary", ""),
+    }
+
+
+class TestGraphExportContract:
+    """Ensure format exporters handle the exact dict shape graph.js produces."""
+
+    # arXiv paper — url is None but paper_id is an arXiv ID
+    def test_arxiv_paper_no_url_markdown(self):
+        p = _graph_paper("2301.00001", "A Paper")
+        out = _md.export_papers([p])
+        assert "arxiv.org/abs/2301.00001" in out
+        assert "Paper-ID:" not in out
+
+    def test_arxiv_paper_no_url_obsidian(self):
+        p = _graph_paper("2301.00001", "A Paper")
+        out = _obs.export_papers([p])
+        assert "arxiv.org/abs/2301.00001" in out
+        assert "**Paper-ID:**" not in out
+
+    def test_arxiv_paper_round_trip_markdown(self):
+        p = _graph_paper("2301.00001", "A Paper")
+        rt = _md.import_string(_md.export_papers([p]))
+        assert rt[0].paper_id == "2301.00001"
+
+    def test_arxiv_paper_round_trip_obsidian(self):
+        p = _graph_paper("2301.00001", "A Paper")
+        rt = _obs.import_string(_obs.export_papers([p]))
+        assert rt[0].paper_id == "2301.00001"
+
+    # DOI paper — url is populated by graph.js
+    def test_doi_paper_with_url_markdown(self):
+        p = _graph_paper("10.1145/3290605.3300741", "CHI Paper",
+                         url="https://dl.acm.org/doi/10.1145/3290605.3300741")
+        out = _md.export_papers([p])
+        assert "dl.acm.org" in out
+        assert "arxiv.org/abs/10.1145" not in out
+
+    def test_doi_paper_with_url_round_trip_markdown(self):
+        p = _graph_paper("10.1145/3290605.3300741", "CHI Paper",
+                         url="https://dl.acm.org/doi/10.1145/3290605.3300741")
+        rt = _md.import_string(_md.export_papers([p]))
+        assert rt[0].paper_id == "10.1145/3290605.3300741"
+        assert rt[0].url == "https://dl.acm.org/doi/10.1145/3290605.3300741"
+
+    def test_doi_paper_with_url_round_trip_obsidian(self):
+        p = _graph_paper("10.1145/3290605.3300741", "CHI Paper",
+                         url="https://dl.acm.org/doi/10.1145/3290605.3300741")
+        rt = _obs.import_string(_obs.export_papers([p]))
+        assert rt[0].paper_id == "10.1145/3290605.3300741"
+
+    # DOI paper — url is None (shouldn't happen after our db fix, but defensive)
+    def test_doi_paper_null_url_markdown_no_fake_arxiv_link(self):
+        p = _graph_paper("10.1145/3290605.3300741", "CHI Paper", url=None)
+        out = _md.export_papers([p])
+        assert "arxiv.org/abs/10.1145" not in out
+        assert "Paper-ID: 10.1145/3290605.3300741" in out
+
+    def test_doi_paper_null_url_round_trip_markdown(self):
+        p = _graph_paper("10.1145/3290605.3300741", "CHI Paper", url=None)
+        rt = _md.import_string(_md.export_papers([p]))
+        assert rt[0].paper_id == "10.1145/3290605.3300741"
+
+    def test_doi_paper_null_url_round_trip_obsidian(self):
+        p = _graph_paper("10.1145/3290605.3300741", "CHI Paper", url=None)
+        rt = _obs.import_string(_obs.export_papers([p]))
+        assert rt[0].paper_id == "10.1145/3290605.3300741"
+
+    # Mixed arXiv + non-arXiv from graph export
+    def test_mixed_graph_export_markdown(self):
+        papers = [
+            _graph_paper("2301.00001", "arXiv Paper"),
+            _graph_paper("10.1145/xyz", "ACM Paper",
+                         url="https://dl.acm.org/doi/10.1145/xyz"),
+        ]
+        rt = _md.import_string(_md.export_papers(papers))
+        ids = {p.paper_id for p in rt}
+        assert ids == {"2301.00001", "10.1145/xyz"}
+
+    def test_mixed_graph_export_obsidian(self):
+        papers = [
+            _graph_paper("2301.00001", "arXiv Paper"),
+            _graph_paper("10.1145/xyz", "ACM Paper",
+                         url="https://dl.acm.org/doi/10.1145/xyz"),
+        ]
+        rt = _obs.import_string(_obs.export_papers(papers))
+        ids = {p.paper_id for p in rt}
+        assert ids == {"2301.00001", "10.1145/xyz"}


### PR DESCRIPTION
## Summary

- **Format layer** (\`formats/\`): Added a \`PaperFileFormat\` protocol and six concrete implementations — BibTeX, JSON, CSV, TSV, Markdown, and Obsidian — each with \`import_file\` and \`export_papers\`. A central \`registry\` in \`formats/__init__.py\` maps format names and file extensions to instances.
- **Export refactor** (\`gui/graph/page.py\`): Removed inline export logic from all five \`_save_*\` methods; they now delegate to the corresponding format class. Cleaned up the now-unused \`csv\` and \`io\` imports.
- **Import UI** (\`gui/library/page.py\`): Extended the Import dropdown with JSON, CSV, Markdown, and Obsidian file importers alongside the existing BibTeX ones. All handlers share the same \`_finish_import\` flow (dupe check → save → refresh).
- **Tests** (\`tests/\`): 132 passing unit tests across four files covering helpers, export output, file import, and full round-trips for every format.

## Closes / relates to

- Closes #45 — BibTeX import and export via pybtex
- Closes #48 — Additional export formats: TSV/CSV output
- Partially addresses #49 — Add more formats in formats/ and sources/ (file formats done; source formats still open)

## Test plan

- [ ] \`uv run pytest tests/test_bibtex.py tests/test_json_fmt.py tests/test_csv_fmt.py tests/test_markdown_fmt.py\` — all 132 tests pass
- [ ] Export a selection from the graph page in each format and verify the file opens correctly
- [ ] Import each exported file back via the Library Import menu and verify papers appear without duplicates
- [ ] Confirm PDF and Folder stubs in the Import menu still show the "not yet implemented" warning

🤖 Generated with [Claude Code](https://claude.com/claude-code)