### PR TITLE
Crossref source (#62)

### DIFF
--- a/gui/settings/page.py
+++ b/gui/settings/page.py
@@ -1,10 +1,13 @@
 from __future__ import annotations
 
+import os
+
 from PyQt6.QtCore import Qt
 from PyQt6.QtWidgets import (
     QFrame,
     QHBoxLayout,
     QLabel,
+    QLineEdit,
     QScrollArea,
     QVBoxLayout,
     QWidget,
@@ -98,17 +101,36 @@ class SettingsPage(QWidget):
         inner.addWidget(title)
         inner.addSpacing(SPACE_XL)
 
-        # ── Placeholder section ───────────────────────────────────────────────
-        inner.addWidget(_section_label("General"))
+        # ── Metadata Sources section ──────────────────────────────────────────
+        inner.addWidget(_section_label("Metadata Sources"))
         inner.addSpacing(SPACE_SM)
 
-        placeholder = QLabel("No settings configured yet.")
-        placeholder.setStyleSheet(
-            f"color: {_MUTED}; font-size: {FONT_BODY}px; "
+        mailto_field = QLineEdit()
+        mailto_field.setPlaceholderText("your@email.com")
+        mailto_field.setText(os.environ.get("CROSSREF_MAILTO", ""))
+        mailto_field.setFixedWidth(240)
+        mailto_field.setStyleSheet(
             f"background: {_PANEL}; border: 1px solid {_BORDER}; "
-            f"border-radius: {RADIUS_LG}px; padding: {CARD_PAD_V}px {CARD_PAD_H}px;"
+            f"border-radius: 6px; color: {_TEXT}; font-size: {FONT_BODY}px; "
+            f"padding: 4px 10px;"
         )
-        inner.addWidget(placeholder)
+
+        def _save_mailto() -> None:
+            from config import ENV_PATH
+            from dotenv import set_key
+            value = mailto_field.text().strip()
+            os.environ["CROSSREF_MAILTO"] = value
+            set_key(str(ENV_PATH), "CROSSREF_MAILTO", value)
+
+        mailto_field.editingFinished.connect(_save_mailto)
+
+        inner.addWidget(_Card([
+            _SettingRow(
+                "CrossRef Email (mailto)",
+                "Your email for CrossRef's polite pool — faster, more reliable metadata responses.",
+                mailto_field,
+            )
+        ]))
 
         inner.addStretch()
         scroll.setWidget(content)

--- a/linxiv_cli.py
+++ b/linxiv_cli.py
@@ -21,6 +21,7 @@ except PackageNotFoundError:
 
 from sources.arxiv_source import ArxivSource
 from sources.base import PaperMetadata, PaperSource
+from sources.crossref_source import CrossRefSource
 from sources.openalex_source import OpenAlexSource
 import storage.db as db
 from storage.notes import ensure_notes_db
@@ -53,6 +54,7 @@ def _render_paper(meta: PaperMetadata) -> str | None:
 _SOURCES: dict[str, type[PaperSource]] = {
     "arxiv":    ArxivSource,
     "openalex": OpenAlexSource,
+    "crossref": CrossRefSource,
 }
 
 def _source_for(name: str) -> PaperSource:

--- a/sources/__init__.py
+++ b/sources/__init__.py
@@ -6,11 +6,13 @@ Add new sources by implementing PaperSource and importing them here.
 from .base import PaperMetadata, PaperSource
 from .arxiv_source import ArxivSource
 from .openalex_source import OpenAlexSource
+from .crossref_source import CrossRefSource, fetch_by_doi, search_by_title
 from .fetch_paper_metadata import fetch_paper_metadata, search_papers, gen_md_file, gen_md_files
 from .doi_resolve import resolve_doi, _resolve_doi
 
 __all__ = [
     "PaperMetadata", "PaperSource", "ArxivSource", "OpenAlexSource",
+    "CrossRefSource", "fetch_by_doi", "search_by_title",
     "fetch_paper_metadata", "search_papers", "gen_md_file", "gen_md_files",
     "resolve_doi", "_resolve_doi",
 ]

--- a/sources/crossref_source.py
+++ b/sources/crossref_source.py
@@ -1,0 +1,122 @@
+"""CrossRef paper source — REST API, no authentication required.
+
+Include a mailto address in CROSSREF_MAILTO env var to use CrossRef's polite pool.
+"""
+
+from __future__ import annotations
+
+import datetime
+import os
+import re
+
+import httpx
+
+from sources.base import PaperMetadata, PaperSource
+
+CROSSREF_BASE = "https://api.crossref.org/works"
+
+
+def _mailto_header() -> str:
+    addr = os.environ.get("CROSSREF_MAILTO", "")
+    return f"linXiv/1.0 (mailto:{addr})" if addr else "linXiv/1.0"
+
+
+def _parse_crossref_work(msg: dict, doi: str = "") -> PaperMetadata:
+    """Convert a CrossRef work message dict to PaperMetadata."""
+    titles = msg.get("title", [])
+    title = titles[0] if titles else ""
+
+    authors: list[str] = []
+    for a in msg.get("author", []):
+        given = a.get("given", "")
+        family = a.get("family", "")
+        name = f"{given} {family}".strip()
+        if name:
+            authors.append(name)
+
+    pub_date = datetime.date.today()
+    dp = msg.get("published", {}).get("date-parts", [[]])
+    if dp and dp[0]:
+        parts = dp[0]
+        try:
+            pub_date = datetime.date(
+                parts[0],
+                parts[1] if len(parts) > 1 else 1,
+                parts[2] if len(parts) > 2 else 1,
+            )
+        except (ValueError, TypeError):
+            pass
+
+    abstract = msg.get("abstract") or ""
+    abstract = re.sub(r"<[^>]+>", "", abstract).strip()
+
+    journal = (msg.get("container-title") or [""])[0]
+    paper_doi = doi or msg.get("DOI", "")
+    url = msg.get("URL") or (f"https://doi.org/{paper_doi}" if paper_doi else None)
+
+    return PaperMetadata(
+        paper_id=paper_doi,
+        version=1,
+        title=title,
+        authors=authors,
+        published=pub_date,
+        summary=abstract,
+        category=journal or None,
+        doi=paper_doi or None,
+        url=url,
+        source="crossref",
+    )
+
+
+def fetch_by_doi(doi: str) -> PaperMetadata | None:
+    """Fetch CrossRef metadata for a DOI. Returns None on any error."""
+    try:
+        with httpx.Client(headers={"User-Agent": _mailto_header()}, timeout=10.0) as client:
+            resp = client.get(f"{CROSSREF_BASE}/{doi}")
+        if resp.status_code != 200:
+            return None
+        msg = resp.json().get("message", {})
+        if not msg.get("title"):
+            return None
+        return _parse_crossref_work(msg, doi=doi)
+    except Exception:
+        return None
+
+
+def search_by_title(title: str, limit: int = 5) -> list[PaperMetadata]:
+    """Search CrossRef by title. Returns empty list on any error."""
+    try:
+        with httpx.Client(headers={"User-Agent": _mailto_header()}, timeout=10.0) as client:
+            resp = client.get(
+                CROSSREF_BASE,
+                params={"query.title": title, "rows": limit},
+            )
+        if resp.status_code != 200:
+            return []
+        items = resp.json().get("message", {}).get("items", [])
+        results = []
+        for item in items:
+            doi = item.get("DOI", "")
+            if item.get("title") and doi:
+                results.append(_parse_crossref_work(item, doi=doi))
+        return results
+    except Exception:
+        return []
+
+
+class CrossRefSource(PaperSource):
+    """Paper source backed by the CrossRef REST API."""
+
+    source_name: str = "crossref"
+
+    def search(self, query: str, max_results: int = 10) -> list[PaperMetadata]:
+        results = search_by_title(query, limit=max_results)
+        if results is None:
+            raise ValueError("CrossRef search failed")
+        return results
+
+    def fetch_by_id(self, doi: str) -> PaperMetadata:
+        meta = fetch_by_doi(doi)
+        if meta is None:
+            raise ValueError(f"CrossRef: no record found for DOI '{doi}'")
+        return meta

--- a/tests/test_crossref_source.py
+++ b/tests/test_crossref_source.py
@@ -1,0 +1,305 @@
+"""Unit tests for sources/crossref_source.py — all network calls are mocked."""
+
+from __future__ import annotations
+
+import datetime
+import pytest
+from unittest.mock import MagicMock, patch
+import httpx
+
+from sources.base import PaperMetadata
+from sources.crossref_source import (
+    _parse_crossref_work,
+    fetch_by_doi,
+    search_by_title,
+    CrossRefSource,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_msg(**kwargs) -> dict:
+    """Build a minimal CrossRef work message dict."""
+    return {
+        "title": kwargs.get("title", ["Test Paper"]),
+        "author": kwargs.get("author", [{"given": "Jane", "family": "Doe"}]),
+        "published": kwargs.get("published", {"date-parts": [[2023, 6, 15]]}),
+        "abstract": kwargs.get("abstract", "<p>An abstract.</p>"),
+        "container-title": kwargs.get("container-title", ["Journal of Testing"]),
+        "URL": kwargs.get("URL", "https://doi.org/10.1000/xyz"),
+        "DOI": kwargs.get("DOI", "10.1000/xyz"),
+    }
+
+
+def _mock_response(status: int = 200, json_data: dict | None = None) -> MagicMock:
+    resp = MagicMock()
+    resp.status_code = status
+    resp.json.return_value = json_data or {}
+    return resp
+
+
+# ---------------------------------------------------------------------------
+# _parse_crossref_work
+# ---------------------------------------------------------------------------
+
+class TestParseCrossrefWork:
+    def test_returns_paper_metadata(self):
+        meta = _parse_crossref_work(_make_msg(), doi="10.1000/xyz")
+        assert isinstance(meta, PaperMetadata)
+
+    def test_source_is_crossref(self):
+        meta = _parse_crossref_work(_make_msg(), doi="10.1000/xyz")
+        assert meta.source == "crossref"
+
+    def test_paper_id_is_doi(self):
+        meta = _parse_crossref_work(_make_msg(), doi="10.1000/xyz")
+        assert meta.paper_id == "10.1000/xyz"
+
+    def test_doi_field_set(self):
+        meta = _parse_crossref_work(_make_msg(), doi="10.1000/xyz")
+        assert meta.doi == "10.1000/xyz"
+
+    def test_title_extracted(self):
+        meta = _parse_crossref_work(_make_msg(title=["My Title"]), doi="10.1000/xyz")
+        assert meta.title == "My Title"
+
+    def test_authors_joined(self):
+        msg = _make_msg(author=[
+            {"given": "Alice", "family": "Smith"},
+            {"given": "Bob", "family": "Jones"},
+        ])
+        meta = _parse_crossref_work(msg, doi="10.1000/xyz")
+        assert meta.authors == ["Alice Smith", "Bob Jones"]
+
+    def test_author_with_only_family_name(self):
+        msg = _make_msg(author=[{"family": "Einstein"}])
+        meta = _parse_crossref_work(msg, doi="10.1000/xyz")
+        assert meta.authors == ["Einstein"]
+
+    def test_authors_without_name_skipped(self):
+        msg = _make_msg(author=[{"given": "Alice", "family": "Smith"}, {}])
+        meta = _parse_crossref_work(msg, doi="10.1000/xyz")
+        assert meta.authors == ["Alice Smith"]
+
+    def test_full_date_parsed(self):
+        meta = _parse_crossref_work(_make_msg(published={"date-parts": [[2021, 3, 15]]}), doi="10.1000/xyz")
+        assert meta.published == datetime.date(2021, 3, 15)
+
+    def test_year_only_date_defaults_month_day_to_1(self):
+        meta = _parse_crossref_work(_make_msg(published={"date-parts": [[2020]]}), doi="10.1000/xyz")
+        assert meta.published == datetime.date(2020, 1, 1)
+
+    def test_year_month_date_defaults_day_to_1(self):
+        meta = _parse_crossref_work(_make_msg(published={"date-parts": [[2020, 7]]}), doi="10.1000/xyz")
+        assert meta.published == datetime.date(2020, 7, 1)
+
+    def test_malformed_date_falls_back_to_today(self):
+        meta = _parse_crossref_work(_make_msg(published={"date-parts": [["bad"]]}), doi="10.1000/xyz")
+        assert isinstance(meta.published, datetime.date)
+
+    def test_missing_published_falls_back_to_today(self):
+        msg = _make_msg()
+        del msg["published"]
+        meta = _parse_crossref_work(msg, doi="10.1000/xyz")
+        assert isinstance(meta.published, datetime.date)
+
+    def test_html_stripped_from_abstract(self):
+        msg = _make_msg(abstract="<jats:p>Clean <b>text</b> here</jats:p>")
+        meta = _parse_crossref_work(msg, doi="10.1000/xyz")
+        assert "<" not in meta.summary
+        assert "Clean" in meta.summary
+        assert "text" in meta.summary
+
+    def test_none_abstract_becomes_empty_string(self):
+        meta = _parse_crossref_work(_make_msg(abstract=None), doi="10.1000/xyz")
+        assert meta.summary == ""
+
+    def test_container_title_becomes_category(self):
+        meta = _parse_crossref_work(_make_msg(**{"container-title": ["Nature"]}), doi="10.1000/xyz")
+        assert meta.category == "Nature"
+
+    def test_empty_container_title_gives_none_category(self):
+        meta = _parse_crossref_work(_make_msg(**{"container-title": []}), doi="10.1000/xyz")
+        assert meta.category is None
+
+    def test_url_from_message(self):
+        meta = _parse_crossref_work(_make_msg(URL="https://doi.org/10.1000/xyz"), doi="10.1000/xyz")
+        assert meta.url == "https://doi.org/10.1000/xyz"
+
+    def test_url_falls_back_to_doi_url(self):
+        msg = _make_msg(URL=None)
+        msg["URL"] = None
+        meta = _parse_crossref_work(msg, doi="10.5678/abc")
+        assert meta.url == "https://doi.org/10.5678/abc"
+
+    def test_version_is_always_1(self):
+        meta = _parse_crossref_work(_make_msg(), doi="10.1000/xyz")
+        assert meta.version == 1
+
+
+# ---------------------------------------------------------------------------
+# fetch_by_doi
+# ---------------------------------------------------------------------------
+
+class TestFetchByDoi:
+    def _make_full_response(self, doi: str = "10.1000/xyz") -> dict:
+        return {"message": _make_msg(DOI=doi)}
+
+    def test_happy_path_returns_paper_metadata(self):
+        mock_resp = _mock_response(200, self._make_full_response())
+        with patch("httpx.Client") as mock_client_cls:
+            mock_client_cls.return_value.__enter__.return_value.get.return_value = mock_resp
+            result = fetch_by_doi("10.1000/xyz")
+        assert isinstance(result, PaperMetadata)
+        assert result.source == "crossref"
+        assert result.paper_id == "10.1000/xyz"
+
+    def test_404_returns_none(self):
+        mock_resp = _mock_response(404, {})
+        with patch("httpx.Client") as mock_client_cls:
+            mock_client_cls.return_value.__enter__.return_value.get.return_value = mock_resp
+            result = fetch_by_doi("10.1000/notfound")
+        assert result is None
+
+    def test_connection_error_returns_none(self):
+        with patch("httpx.Client") as mock_client_cls:
+            mock_client_cls.return_value.__enter__.return_value.get.side_effect = httpx.ConnectError("timeout")
+            result = fetch_by_doi("10.1000/xyz")
+        assert result is None
+
+    def test_missing_title_returns_none(self):
+        msg = _make_msg(title=[])
+        mock_resp = _mock_response(200, {"message": msg})
+        with patch("httpx.Client") as mock_client_cls:
+            mock_client_cls.return_value.__enter__.return_value.get.return_value = mock_resp
+            result = fetch_by_doi("10.1000/xyz")
+        assert result is None
+
+    def test_empty_message_returns_none(self):
+        mock_resp = _mock_response(200, {"message": {}})
+        with patch("httpx.Client") as mock_client_cls:
+            mock_client_cls.return_value.__enter__.return_value.get.return_value = mock_resp
+            result = fetch_by_doi("10.1000/xyz")
+        assert result is None
+
+    def test_doi_passed_as_paper_id(self):
+        mock_resp = _mock_response(200, self._make_full_response(doi="10.9999/test"))
+        with patch("httpx.Client") as mock_client_cls:
+            mock_client_cls.return_value.__enter__.return_value.get.return_value = mock_resp
+            result = fetch_by_doi("10.9999/test")
+        assert result is not None
+        assert result.paper_id == "10.9999/test"
+
+
+# ---------------------------------------------------------------------------
+# search_by_title
+# ---------------------------------------------------------------------------
+
+class TestSearchByTitle:
+    def _make_search_response(self, titles: list[str]) -> dict:
+        items = [
+            _make_msg(title=[t], DOI=f"10.1000/{i}")
+            for i, t in enumerate(titles)
+        ]
+        return {"message": {"items": items}}
+
+    def test_happy_path_returns_list(self):
+        mock_resp = _mock_response(200, self._make_search_response(["Paper A", "Paper B"]))
+        with patch("httpx.Client") as mock_client_cls:
+            mock_client_cls.return_value.__enter__.return_value.get.return_value = mock_resp
+            results = search_by_title("neural networks")
+        assert len(results) == 2
+        assert all(isinstance(r, PaperMetadata) for r in results)
+
+    def test_empty_items_returns_empty_list(self):
+        mock_resp = _mock_response(200, {"message": {"items": []}})
+        with patch("httpx.Client") as mock_client_cls:
+            mock_client_cls.return_value.__enter__.return_value.get.return_value = mock_resp
+            results = search_by_title("xyzzy nonexistent")
+        assert results == []
+
+    def test_network_error_returns_empty_list(self):
+        with patch("httpx.Client") as mock_client_cls:
+            mock_client_cls.return_value.__enter__.return_value.get.side_effect = httpx.ConnectError("timeout")
+            results = search_by_title("attention is all you need")
+        assert results == []
+
+    def test_non_200_returns_empty_list(self):
+        mock_resp = _mock_response(503, {})
+        with patch("httpx.Client") as mock_client_cls:
+            mock_client_cls.return_value.__enter__.return_value.get.return_value = mock_resp
+            results = search_by_title("test query")
+        assert results == []
+
+    def test_rows_param_sent_correctly(self):
+        mock_resp = _mock_response(200, {"message": {"items": []}})
+        with patch("httpx.Client") as mock_client_cls:
+            mock_get = mock_client_cls.return_value.__enter__.return_value.get
+            mock_get.return_value = mock_resp
+            search_by_title("test", limit=3)
+        params = mock_get.call_args[1]["params"]
+        assert params["rows"] == 3
+        assert params["query.title"] == "test"
+
+    def test_items_without_doi_are_skipped(self):
+        items = [
+            {"title": ["Paper With DOI"], "DOI": "10.1000/valid", "author": [], "published": {"date-parts": [[2023]]}, "abstract": None, "container-title": [], "URL": None},
+            {"title": ["Paper Without DOI"]},  # no DOI
+        ]
+        mock_resp = _mock_response(200, {"message": {"items": items}})
+        with patch("httpx.Client") as mock_client_cls:
+            mock_client_cls.return_value.__enter__.return_value.get.return_value = mock_resp
+            results = search_by_title("test")
+        assert len(results) == 1
+        assert results[0].title == "Paper With DOI"
+
+
+# ---------------------------------------------------------------------------
+# CrossRefSource class
+# ---------------------------------------------------------------------------
+
+class TestCrossRefSourceClass:
+    def test_source_name(self):
+        assert CrossRefSource.source_name == "crossref"
+
+    def test_fetch_by_id_returns_metadata_on_success(self):
+        mock_meta = PaperMetadata(
+            paper_id="10.1000/xyz", version=1, title="Paper", authors=[],
+            published=datetime.date(2023, 1, 1), summary="", source="crossref",
+        )
+        source = CrossRefSource()
+        with patch("sources.crossref_source.fetch_by_doi", return_value=mock_meta):
+            result = source.fetch_by_id("10.1000/xyz")
+        assert result is mock_meta
+
+    def test_fetch_by_id_raises_when_not_found(self):
+        source = CrossRefSource()
+        with patch("sources.crossref_source.fetch_by_doi", return_value=None):
+            with pytest.raises(ValueError, match="no record found"):
+                source.fetch_by_id("10.1000/notfound")
+
+    def test_search_returns_list_on_success(self):
+        mock_results = [
+            PaperMetadata(
+                paper_id="10.1000/a", version=1, title="Result A", authors=[],
+                published=datetime.date(2023, 1, 1), summary="", source="crossref",
+            )
+        ]
+        source = CrossRefSource()
+        with patch("sources.crossref_source.search_by_title", return_value=mock_results):
+            results = source.search("attention mechanism", max_results=5)
+        assert results is mock_results
+
+    def test_search_passes_max_results(self):
+        source = CrossRefSource()
+        with patch("sources.crossref_source.search_by_title", return_value=[]) as mock_fn:
+            source.search("test", max_results=7)
+        mock_fn.assert_called_once_with("test", limit=7)
+
+    def test_search_returns_empty_list_when_no_results(self):
+        source = CrossRefSource()
+        with patch("sources.crossref_source.search_by_title", return_value=[]):
+            results = source.search("xyzzy nonexistent")
+        assert results == []


### PR DESCRIPTION
* add CrossRefSource — fetch_by_doi, search_by_title, CLI registration, settings UI

Closes #37. New source module implements the PaperSource protocol backed by CrossRef's REST API (no auth required). Standalone fetch_by_doi/search_by_title return None/[] on error; class methods raise ValueError for CLI use. User-Agent picks up CROSSREF_MAILTO from env at call-time. Settings page exposes a QLineEdit that persists the address to .env via dotenv.set_key. 38 new unit tests, all mocked.

* fix type error: CrossRefSource must explicitly subclass PaperSource

Pyright rejects structural-only Protocol conformance when the class is stored in dict[str, type[PaperSource]]; explicit subclassing resolves it.

Assisted-by: Claude Sonnet 4.6 <noreply@anthropic.com>