### PR TITLE
fix(db): schema versioning + named INSERT params

### DIFF
--- a/storage/db.py
+++ b/storage/db.py
@@ -85,6 +85,38 @@ def _connect(db_path: str = DB_PATH) -> sqlite3.Connection:
     return conn
 
 
+def _migration_v1(conn: sqlite3.Connection) -> None:
+    """Add columns that were missing from the original CREATE TABLE definition.
+
+    This migration is idempotent: it checks which columns already exist before
+    issuing any ALTER TABLE, so it is safe to run against both fresh databases
+    (that already have these columns from the CREATE TABLE) and legacy databases
+    that are missing some of them.
+    """
+    existing = {row[1] for row in conn.execute("PRAGMA table_info(papers)")}
+    for col, typedef in [
+        ("updated",          "DATE"),
+        ("categories",       "LIST"),
+        ("journal_ref",      "TEXT"),
+        ("comment",          "TEXT"),
+        ("tags",             "LIST"),
+        ("has_pdf",          "BOOL NOT NULL DEFAULT 0"),
+        ("source",           "TEXT DEFAULT 'arxiv'"),
+        ("pdf_path",         "TEXT DEFAULT NULL"),
+        ("full_text",        "TEXT"),
+        ("downloaded_source","BOOL DEFAULT 0"),
+    ]:
+        if col not in existing:
+            conn.execute(f"ALTER TABLE papers ADD COLUMN {col} {typedef}")
+
+
+# Registry of all schema migrations, in order.
+# Each entry is (version: int, fn: Callable[[Connection], None]).
+_MIGRATIONS: list[tuple[int, object]] = [
+    (1, _migration_v1),
+]
+
+
 def init_db() -> None:
     with _connect() as conn:
         conn.executescript("""
@@ -112,23 +144,24 @@ def init_db() -> None:
             WHERE version = (
                 SELECT MAX(version) FROM papers WHERE paper_id = p.paper_id
             );
+
+            CREATE TABLE IF NOT EXISTS schema_migrations (
+                version     INTEGER PRIMARY KEY,
+                applied_at  TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+            );
         """)
-        # Migrate existing DBs that are missing columns
-        existing = {row[1] for row in conn.execute("PRAGMA table_info(papers)")}
-        for col, typedef in [
-            ("updated",     "DATE"),
-            ("categories",  "LIST"),
-            ("journal_ref", "TEXT"),
-            ("comment",     "TEXT"),
-            ("tags",        "LIST"),
-            ("has_pdf",     "BOOL NOT NULL DEFAULT 0"),
-            ("source",      "TEXT DEFAULT 'arxiv'"),
-            ("pdf_path",    "TEXT DEFAULT NULL"),
-            ("full_text",   "TEXT"),
-            ("downloaded_source", "BOOL DEFAULT 0"),
-        ]:
-            if col not in existing:
-                conn.execute(f"ALTER TABLE papers ADD COLUMN {col} {typedef}")
+
+        # Apply any pending migrations based on user_version.
+        current_version: int = conn.execute("PRAGMA user_version").fetchone()[0]
+        for version, fn in _MIGRATIONS:
+            if version > current_version:
+                fn(conn)  # type: ignore[call-arg]
+                conn.execute(
+                    "INSERT OR IGNORE INTO schema_migrations (version) VALUES (?)",
+                    (version,),
+                )
+                conn.execute(f"PRAGMA user_version = {version}")
+                current_version = version
 
         # FTS5 virtual table for full-text search of TeX source
         conn.execute("""
@@ -160,24 +193,26 @@ def _insert(conn: sqlite3.Connection, paper: arxiv.Result, tags: list[str] | Non
         INSERT OR REPLACE INTO papers
             (paper_id, version, title, url, published, updated,
              category, categories, doi, journal_ref, comment, summary, authors, tags, source)
-        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-    """, (
-        paper_id,
-        version,
-        paper.title,
-        paper.pdf_url,
-        paper.published.date(),
-        paper.updated.date(),
-        paper.primary_category,
-        paper.categories,
-        paper.doi,
-        paper.journal_ref,
-        paper.comment,
-        paper.summary,
-        [a.name for a in paper.authors],
-        tags,
-        "arxiv",
-    ))
+        VALUES
+            (:paper_id, :version, :title, :url, :published, :updated,
+             :category, :categories, :doi, :journal_ref, :comment, :summary, :authors, :tags, :source)
+    """, {
+        "paper_id":    paper_id,
+        "version":     version,
+        "title":       paper.title,
+        "url":         paper.pdf_url,
+        "published":   paper.published.date(),
+        "updated":     paper.updated.date(),
+        "category":    paper.primary_category,
+        "categories":  paper.categories,
+        "doi":         paper.doi,
+        "journal_ref": paper.journal_ref,
+        "comment":     paper.comment,
+        "summary":     paper.summary,
+        "authors":     [a.name for a in paper.authors],
+        "tags":        tags,
+        "source":      "arxiv",
+    })
     return paper_id, version
 
 
@@ -186,29 +221,30 @@ def _insert_metadata(conn: sqlite3.Connection, meta: PaperMetadata, tags: list[s
     merged_tags = meta.tags
     if tags:
         merged_tags = list(set((merged_tags or []) + tags))
-    conn.execute(
-    """
+    conn.execute("""
         INSERT OR REPLACE INTO papers
             (paper_id, version, title, url, published, updated,
              category, categories, doi, journal_ref, comment, summary, authors, tags, source)
-        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-    """, (
-        meta.paper_id,
-        meta.version,
-        meta.title,
-        meta.url,
-        meta.published,
-        meta.updated,
-        meta.category,
-        meta.categories,
-        meta.doi,
-        meta.journal_ref,
-        meta.comment,
-        meta.summary,
-        meta.authors,
-        merged_tags,
-        meta.source,
-    ))
+        VALUES
+            (:paper_id, :version, :title, :url, :published, :updated,
+             :category, :categories, :doi, :journal_ref, :comment, :summary, :authors, :tags, :source)
+    """, {
+        "paper_id":    meta.paper_id,
+        "version":     meta.version,
+        "title":       meta.title,
+        "url":         meta.url,
+        "published":   meta.published,
+        "updated":     meta.updated,
+        "category":    meta.category,
+        "categories":  meta.categories,
+        "doi":         meta.doi,
+        "journal_ref": meta.journal_ref,
+        "comment":     meta.comment,
+        "summary":     meta.summary,
+        "authors":     meta.authors,
+        "tags":        merged_tags,
+        "source":      meta.source,
+    })
     return meta.paper_id, meta.version
 
 


### PR DESCRIPTION
## Summary

- **Task 1 (Schema versioning):** Replaced the ad-hoc ALTER TABLE loop in `init_db()` with a proper migration system. A `_MIGRATIONS` registry maps version numbers to migration functions. `init_db()` reads `PRAGMA user_version`, applies any pending migrations in order, records each in the new `schema_migrations` table via `INSERT OR IGNORE`, and writes the new `user_version` back — making repeated `init_db()` calls fully idempotent. The existing ALTER TABLE content becomes migration v1 (`_migration_v1`), which preserves the column-existence guard for both fresh and pre-versioning databases.

- **Task 2 (\_rebuild\_papers\_with\_root\_fk):** Skipped. The function does not exist anywhere on this branch (confirmed by grep). The coordinator was unreachable to clarify intent. No code was invented. This should be addressed if the function arrives from another branch.

- **Task 3 (Named-column INSERTs):** Both `_insert()` and `_insert_metadata()` now use named `:param` bindings with a `dict` argument instead of positional `?` placeholders, making the column→value mapping explicit and robust against future column additions or reordering.

## Test plan

- [x] `uv run pytest tests/test_db.py -x` — all 29 tests pass
- [x] Migration idempotency: fresh-DB path (CREATE TABLE already has all columns; v1 loop finds them all present and skips all ALTERs) and re-entrant path (`user_version` already at 1; migration loop body never entered)
- [ ] Manual verification against a legacy pre-versioning DB recommended before merging

🤖 Generated with [Claude Code](https://claude.com/claude-code)