### PR TITLE
tests: add coverage for 10 untested db.py functions

### DIFF
--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -1,9 +1,10 @@
 """Tests for db.py — pure functions and DB round-trips."""
 import datetime
+import sqlite3
 import sys
 import os
 
-# import pytest
+import pytest
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
@@ -314,3 +315,459 @@ Hello world of transformers.
 
         result = extract_source(bad_path)
         assert result == ""
+
+
+# ---------------------------------------------------------------------------
+# set_has_pdf
+# ---------------------------------------------------------------------------
+
+class TestSetHasPdf:
+    def test_set_has_pdf_true(self, tmp_db):
+        db.save_paper(_make_result("2204.12985v1"))
+        db.set_has_pdf("2204.12985", 1, True)
+        row = db.get_paper("2204.12985", version=1)
+        assert row is not None
+        assert bool(row["has_pdf"]) is True
+
+    def test_set_has_pdf_false(self, tmp_db):
+        db.save_paper(_make_result("2204.12985v1"))
+        db.set_has_pdf("2204.12985", 1, True)
+        db.set_has_pdf("2204.12985", 1, False)
+        row = db.get_paper("2204.12985", version=1)
+        assert row is not None
+        assert bool(row["has_pdf"]) is False
+
+    def test_set_has_pdf_only_affects_target_version(self, tmp_db):
+        db.save_paper(_make_result("2204.12985v1"))
+        db.save_paper(_make_result("2204.12985v2"))
+        db.set_has_pdf("2204.12985", 1, True)
+        row_v2 = db.get_paper("2204.12985", version=2)
+        assert row_v2 is not None
+        assert not bool(row_v2["has_pdf"])
+
+    def test_set_has_pdf_default_is_false(self, tmp_db):
+        db.save_paper(_make_result("2204.12985v1"))
+        row = db.get_paper("2204.12985", version=1)
+        assert row is not None
+        assert not bool(row["has_pdf"])
+
+
+# ---------------------------------------------------------------------------
+# set_pdf_path
+# ---------------------------------------------------------------------------
+
+class TestSetPdfPath:
+    def test_set_pdf_path_single_version(self, tmp_db):
+        db.save_paper(_make_result("2204.12985v1"))
+        db.set_pdf_path("2204.12985", "/tmp/paper.pdf")
+        row = db.get_paper("2204.12985", version=1)
+        assert row is not None
+        assert row["pdf_path"] == "/tmp/paper.pdf"
+
+    def test_set_pdf_path_all_versions(self, tmp_db):
+        db.save_paper(_make_result("2204.12985v1"))
+        db.save_paper(_make_result("2204.12985v2"))
+        db.set_pdf_path("2204.12985", "/tmp/paper.pdf")
+        row_v1 = db.get_paper("2204.12985", version=1)
+        row_v2 = db.get_paper("2204.12985", version=2)
+        assert row_v1 is not None and row_v1["pdf_path"] == "/tmp/paper.pdf"
+        assert row_v2 is not None and row_v2["pdf_path"] == "/tmp/paper.pdf"
+
+    def test_set_pdf_path_overwrites_previous(self, tmp_db):
+        db.save_paper(_make_result("2204.12985v1"))
+        db.set_pdf_path("2204.12985", "/tmp/old.pdf")
+        db.set_pdf_path("2204.12985", "/tmp/new.pdf")
+        row = db.get_paper("2204.12985", version=1)
+        assert row is not None
+        assert row["pdf_path"] == "/tmp/new.pdf"
+
+    def test_set_pdf_path_does_not_affect_other_papers(self, tmp_db):
+        db.save_paper(_make_result("2204.12985v1"))
+        db.save_paper(_make_result("2301.00001v1"))
+        db.set_pdf_path("2204.12985", "/tmp/paper.pdf")
+        other = db.get_paper("2301.00001", version=1)
+        assert other is not None
+        assert other["pdf_path"] is None
+
+
+# ---------------------------------------------------------------------------
+# delete_paper
+# ---------------------------------------------------------------------------
+
+class TestDeletePaper:
+    def test_delete_removes_paper(self, tmp_db):
+        db.save_paper(_make_result("2204.12985v1"))
+        db.delete_paper("2204.12985")
+        assert db.get_paper("2204.12985") is None
+
+    def test_delete_removes_all_versions(self, tmp_db):
+        db.save_paper(_make_result("2204.12985v1"))
+        db.save_paper(_make_result("2204.12985v2"))
+        db.save_paper(_make_result("2204.12985v3"))
+        db.delete_paper("2204.12985")
+        assert db.get_all_versions("2204.12985") == []
+
+    def test_delete_only_affects_target_paper(self, tmp_db):
+        db.save_paper(_make_result("2204.12985v1"))
+        db.save_paper(_make_result("2301.00001v1"))
+        db.delete_paper("2204.12985")
+        assert db.get_paper("2301.00001") is not None
+
+    def test_delete_nonexistent_is_noop(self, tmp_db):
+        # Should not raise
+        db.delete_paper("0000.00000")
+
+    def test_delete_removes_from_list(self, tmp_db):
+        db.save_paper(_make_result("2204.12985v1"))
+        db.delete_paper("2204.12985")
+        rows = db.list_papers()
+        ids = [r["paper_id"] for r in rows]
+        assert "2204.12985" not in ids
+
+
+# ---------------------------------------------------------------------------
+# get_all_versions
+# ---------------------------------------------------------------------------
+
+class TestGetAllVersions:
+    def test_returns_empty_for_unknown_paper(self, tmp_db):
+        assert db.get_all_versions("0000.00000") == []
+
+    def test_returns_single_version(self, tmp_db):
+        db.save_paper(_make_result("2204.12985v1"))
+        rows = db.get_all_versions("2204.12985")
+        assert len(rows) == 1
+        assert rows[0]["version"] == 1
+
+    def test_returns_multiple_versions_oldest_first(self, tmp_db):
+        db.save_paper(_make_result("2204.12985v1"))
+        db.save_paper(_make_result("2204.12985v3"))
+        db.save_paper(_make_result("2204.12985v2"))
+        rows = db.get_all_versions("2204.12985")
+        versions = [r["version"] for r in rows]
+        assert versions == sorted(versions)
+
+    def test_does_not_return_other_papers(self, tmp_db):
+        db.save_paper(_make_result("2204.12985v1"))
+        db.save_paper(_make_result("2301.00001v1"))
+        rows = db.get_all_versions("2204.12985")
+        assert all(r["paper_id"] == "2204.12985" for r in rows)
+
+
+# ---------------------------------------------------------------------------
+# get_graph_data
+# ---------------------------------------------------------------------------
+
+class TestGetGraphData:
+    def test_empty_db_returns_empty_nodes_and_edges(self, tmp_db):
+        nodes, edges = db.get_graph_data()
+        assert nodes == []
+        assert edges == []
+
+    def test_paper_node_present(self, tmp_db):
+        db.save_paper(_make_result("2204.12985v1", title="My Paper"))
+        nodes, edges = db.get_graph_data()
+        paper_nodes = [n for n in nodes if n.get("type") == "paper"]
+        assert len(paper_nodes) == 1
+        assert paper_nodes[0]["id"] == "2204.12985"
+        assert paper_nodes[0]["label"] == "My Paper"
+
+    def test_author_node_present(self, tmp_db):
+        db.save_paper(_make_result("2204.12985v1", authors=["Alice Smith"]))
+        nodes, edges = db.get_graph_data()
+        author_nodes = [n for n in nodes if n.get("type") == "author"]
+        assert any(n["label"] == "Alice Smith" for n in author_nodes)
+
+    def test_edge_connects_paper_to_author(self, tmp_db):
+        db.save_paper(_make_result("2204.12985v1", authors=["Alice Smith"]))
+        nodes, edges = db.get_graph_data()
+        assert any(e["source"] == "2204.12985" and "Alice Smith" in e["target"] for e in edges)
+
+    def test_shared_author_has_single_node(self, tmp_db):
+        db.save_paper(_make_result("2204.12985v1", authors=["Shared Author"]))
+        db.save_paper(_make_result("2301.00001v1", authors=["Shared Author"]))
+        nodes, edges = db.get_graph_data()
+        author_nodes = [n for n in nodes if n.get("type") == "author" and n["label"] == "Shared Author"]
+        assert len(author_nodes) == 1
+
+    def test_paper_node_has_expected_fields(self, tmp_db):
+        db.save_paper(_make_result("2204.12985v1", primary_category="cs.LG"))
+        nodes, _ = db.get_graph_data()
+        paper_node = next(n for n in nodes if n.get("type") == "paper")
+        for key in ("id", "label", "type", "category", "tags", "has_pdf", "published"):
+            assert key in paper_node
+
+    def test_tags_defaults_to_empty_list_when_none(self, tmp_db):
+        db.save_paper(_make_result("2204.12985v1"))  # no tags
+        nodes, _ = db.get_graph_data()
+        paper_node = next(n for n in nodes if n.get("type") == "paper")
+        assert paper_node["tags"] == []
+
+
+# ---------------------------------------------------------------------------
+# get_categories
+# ---------------------------------------------------------------------------
+
+class TestGetCategories:
+    def test_empty_db_returns_empty_list(self, tmp_db):
+        assert db.get_categories() == []
+
+    def test_returns_distinct_categories(self, tmp_db):
+        db.save_paper(_make_result("2204.12985v1", primary_category="cs.LG"))
+        db.save_paper(_make_result("2301.00001v1", primary_category="math.CO"))
+        db.save_paper(_make_result("2301.00002v1", primary_category="cs.LG"))  # duplicate
+        cats = db.get_categories()
+        assert cats.count("cs.LG") == 1
+        assert "math.CO" in cats
+
+    def test_returns_sorted_list(self, tmp_db):
+        db.save_paper(_make_result("2204.12985v1", primary_category="stat.ML"))
+        db.save_paper(_make_result("2301.00001v1", primary_category="cs.LG"))
+        db.save_paper(_make_result("2301.00002v1", primary_category="math.CO"))
+        cats = db.get_categories()
+        assert cats == sorted(cats)
+
+    def test_only_latest_version_category_counted(self, tmp_db):
+        db.save_paper(_make_result("2204.12985v1", primary_category="cs.AI"))
+        db.save_paper(_make_result("2204.12985v2", primary_category="cs.LG"))
+        cats = db.get_categories()
+        # latest version is v2 with cs.LG; cs.AI should not appear
+        assert "cs.LG" in cats
+        assert "cs.AI" not in cats
+
+
+# ---------------------------------------------------------------------------
+# get_tags
+# ---------------------------------------------------------------------------
+
+class TestGetTags:
+    def test_empty_db_returns_empty_list(self, tmp_db):
+        assert db.get_tags() == []
+
+    def test_returns_distinct_tags(self, tmp_db):
+        db.save_paper(_make_result("2204.12985v1"), tags=["ml", "transformers"])
+        db.save_paper(_make_result("2301.00001v1"), tags=["ml", "diffusion"])
+        tags = db.get_tags()
+        assert tags.count("ml") == 1
+        assert "transformers" in tags
+        assert "diffusion" in tags
+
+    def test_returns_sorted_list(self, tmp_db):
+        db.save_paper(_make_result("2204.12985v1"), tags=["zoo", "alpha", "beta"])
+        tags = db.get_tags()
+        assert tags == sorted(tags)
+
+    def test_paper_without_tags_not_included(self, tmp_db):
+        db.save_paper(_make_result("2204.12985v1"), tags=["ml"])
+        db.save_paper(_make_result("2301.00001v1"))  # no tags
+        tags = db.get_tags()
+        assert tags == ["ml"]
+
+
+# ---------------------------------------------------------------------------
+# add_paper_tags
+# ---------------------------------------------------------------------------
+
+class TestAddPaperTags:
+    def test_add_tags_to_paper_without_tags(self, tmp_db):
+        db.save_paper(_make_result("2204.12985v1"))
+        result = db.add_paper_tags("2204.12985", ["ml", "transformers"])
+        assert "ml" in result
+        assert "transformers" in result
+
+    def test_add_tags_persisted_to_db(self, tmp_db):
+        db.save_paper(_make_result("2204.12985v1"))
+        db.add_paper_tags("2204.12985", ["ml"])
+        row = db.get_paper("2204.12985")
+        assert row is not None
+        assert "ml" in row["tags"]
+
+    def test_add_tags_deduplicates(self, tmp_db):
+        db.save_paper(_make_result("2204.12985v1"), tags=["ml"])
+        result = db.add_paper_tags("2204.12985", ["ml", "new_tag"])
+        assert result.count("ml") == 1
+        assert "new_tag" in result
+
+    def test_add_tags_preserves_existing(self, tmp_db):
+        db.save_paper(_make_result("2204.12985v1"), tags=["existing"])
+        result = db.add_paper_tags("2204.12985", ["new"])
+        assert "existing" in result
+        assert "new" in result
+
+    def test_add_tags_returns_updated_list(self, tmp_db):
+        db.save_paper(_make_result("2204.12985v1"), tags=["a"])
+        result = db.add_paper_tags("2204.12985", ["b", "c"])
+        assert set(result) == {"a", "b", "c"}
+
+    def test_add_tags_raises_for_unknown_paper(self, tmp_db):
+        with pytest.raises(KeyError):
+            db.add_paper_tags("0000.00000", ["ml"])
+
+
+# ---------------------------------------------------------------------------
+# remove_paper_tags
+# ---------------------------------------------------------------------------
+
+class TestRemovePaperTags:
+    def test_remove_tag_from_paper(self, tmp_db):
+        db.save_paper(_make_result("2204.12985v1"), tags=["ml", "transformers"])
+        result = db.remove_paper_tags("2204.12985", ["ml"])
+        assert "ml" not in result
+        assert "transformers" in result
+
+    def test_remove_tag_persisted_to_db(self, tmp_db):
+        db.save_paper(_make_result("2204.12985v1"), tags=["ml", "transformers"])
+        db.remove_paper_tags("2204.12985", ["ml"])
+        row = db.get_paper("2204.12985")
+        assert row is not None
+        assert "ml" not in row["tags"]
+
+    def test_remove_nonexistent_tag_is_noop(self, tmp_db):
+        db.save_paper(_make_result("2204.12985v1"), tags=["ml"])
+        result = db.remove_paper_tags("2204.12985", ["nonexistent"])
+        assert result == ["ml"]
+
+    def test_remove_multiple_tags(self, tmp_db):
+        db.save_paper(_make_result("2204.12985v1"), tags=["a", "b", "c"])
+        result = db.remove_paper_tags("2204.12985", ["a", "c"])
+        assert result == ["b"]
+
+    def test_remove_all_tags_leaves_empty_list(self, tmp_db):
+        db.save_paper(_make_result("2204.12985v1"), tags=["x"])
+        result = db.remove_paper_tags("2204.12985", ["x"])
+        assert result == []
+
+    def test_remove_tags_raises_for_unknown_paper(self, tmp_db):
+        with pytest.raises(KeyError):
+            db.remove_paper_tags("0000.00000", ["ml"])
+
+
+# ---------------------------------------------------------------------------
+# search_full_text
+# ---------------------------------------------------------------------------
+#
+# NOTE: search_full_text() has a known bug: the SQL query uses alias `fts` in
+# `WHERE fts MATCH ?` but SQLite FTS5 requires the full table name
+# (papers_fts MATCH ?).  The tests are marked xfail(strict=False) so they
+# document intended behaviour and will automatically start passing once the
+# production code is fixed.  The fix is in storage/db.py (not in scope here).
+
+@pytest.mark.xfail(
+    strict=False,
+    raises=Exception,
+    reason=(
+        "search_full_text() uses 'WHERE fts MATCH ?' with a table alias; "
+        "SQLite FTS5 requires the bare table name ('WHERE papers_fts MATCH ?'). "
+        "Fix storage/db.py search_full_text() to resolve."
+    ),
+)
+class TestSearchFullText:
+    def test_returns_empty_for_no_indexed_content(self, tmp_db):
+        db.save_paper(_make_result("2204.12985v1"))
+        # No full text set, FTS index empty
+        results = db.search_full_text("transformers")
+        assert results == []
+
+    def test_finds_paper_with_matching_content(self, tmp_db):
+        db.save_paper(_make_result("2204.12985v1"))
+        db.set_full_text("2204.12985", 1, "This paper studies transformers in NLP.")
+        results = db.search_full_text("transformers")
+        assert len(results) >= 1
+        assert any(r["paper_id"] == "2204.12985" for r in results)
+
+    def test_does_not_return_non_matching_paper(self, tmp_db):
+        db.save_paper(_make_result("2204.12985v1"))
+        db.save_paper(_make_result("2301.00001v1"))
+        db.set_full_text("2204.12985", 1, "This paper studies transformers.")
+        db.set_full_text("2301.00001", 1, "This paper is about diffusion models.")
+        results = db.search_full_text("transformers")
+        ids = [r["paper_id"] for r in results]
+        assert "2204.12985" in ids
+        assert "2301.00001" not in ids
+
+    def test_limit_parameter_respected(self, tmp_db):
+        for i in range(5):
+            pid = f"2204.1298{i}v1"
+            db.save_paper(_make_result(pid, title=f"Paper {i}"))
+            db.set_full_text(f"2204.1298{i}", 1, "quantum computing research paper")
+        results = db.search_full_text("quantum", limit=3)
+        assert len(results) <= 3
+
+    def test_multi_word_query(self, tmp_db):
+        db.save_paper(_make_result("2204.12985v1"))
+        db.set_full_text("2204.12985", 1, "attention mechanisms in neural networks.")
+        results = db.search_full_text("attention neural")
+        assert any(r["paper_id"] == "2204.12985" for r in results)
+
+
+# ---------------------------------------------------------------------------
+# Migration-path test
+# ---------------------------------------------------------------------------
+
+class TestMigrationPath:
+    def test_init_db_adds_missing_columns(self, tmp_path, monkeypatch):
+        """
+        Simulate a DB that only has the original minimal papers schema (no
+        extra columns). Calling init_db() should add all expected columns via
+        the ALTER TABLE migration logic.
+        """
+        import storage.db as db_module
+
+        db_file = str(tmp_path / "migrate_test.db")
+
+        # Patch _connect to point to our isolated test DB
+        real_connect = db_module._connect
+
+        def patched_connect(db_path=None):
+            del db_path
+            return real_connect(db_file)
+
+        monkeypatch.setattr(db_module, "_connect", patched_connect)
+
+        # Create a minimal papers table that is missing the newer columns
+        conn = sqlite3.connect(db_file, detect_types=sqlite3.PARSE_DECLTYPES)
+        conn.row_factory = sqlite3.Row
+        conn.execute("""
+            CREATE TABLE papers (
+                paper_id    TEXT    NOT NULL,
+                version     INTEGER NOT NULL,
+                title       TEXT    NOT NULL,
+                url         TEXT,
+                published   DATE,
+                category    TEXT,
+                summary     TEXT,
+                authors     LIST,
+                tags        LIST,
+                has_pdf     BOOL NOT NULL DEFAULT 0,
+                PRIMARY KEY (paper_id, version)
+            )
+        """)
+        conn.commit()
+        conn.close()
+
+        # Now call init_db() — it should run migration and add missing columns
+        db_module.init_db()
+
+        # Verify all expected columns are present.
+        # We only check columns that the migration loop adds; columns like
+        # `doi` that were never in the migration list won't be back-filled.
+        check_conn = sqlite3.connect(db_file)
+        col_names = {row[1] for row in check_conn.execute("PRAGMA table_info(papers)")}
+        check_conn.close()
+
+        # These are the columns the migration loop is responsible for adding
+        migrated_columns = {
+            "updated",
+            "categories",
+            "journal_ref",
+            "comment",
+            "tags",
+            "has_pdf",
+            "source",
+            "pdf_path",
+            "full_text",
+            "downloaded_source",
+        }
+        assert migrated_columns.issubset(col_names), (
+            f"Missing columns after migration: {migrated_columns - col_names}"
+        )

--- a/tests/test_notes.py
+++ b/tests/test_notes.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import sqlite3
+
 import pytest
 
 from storage.notes import (
@@ -321,3 +323,31 @@ class TestCountPaperNotes:
         assert count_paper_notes("Y") == 1
         n.delete()
         assert count_paper_notes("Y") == 0
+
+
+# ---------------------------------------------------------------------------
+# FK enforcement test (cross-cutting)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.xfail(
+    strict=True,
+    reason=(
+        "notes.project_id has no FOREIGN KEY constraint and _connect() does not "
+        "enable PRAGMA foreign_keys, so IntegrityError is not raised. "
+        "This test documents the expected (but not yet implemented) behavior."
+    ),
+)
+@pytest.mark.usefixtures("tmp_db")
+def test_note_with_nonexistent_project_id_raises_integrity_error():
+    """
+    Inserting a note that references a project_id not present in the projects
+    table should raise sqlite3.IntegrityError.
+
+    NOTE: Currently xfail — the schema has no FK declaration and SQLite FK
+    enforcement is off by default. Once the schema and/or _connect are updated
+    to enforce this constraint, remove the xfail marker.
+    """
+    # No projects exist in the DB (we use tmp_db, not note_projects)
+    n = Note(paper_id="2204.12985", project_id=9999)
+    with pytest.raises(sqlite3.IntegrityError):
+        n.save()

--- a/tests/test_projects.py
+++ b/tests/test_projects.py
@@ -1,4 +1,5 @@
 """Tests for projects.py — pure functions, Q predicates, and DB round-trips."""
+import sqlite3
 import sys
 import os
 
@@ -232,3 +233,41 @@ class TestProjectAddPaper:
         assert p.paper_count == 1
         p.add_paper("2301.00001")
         assert p.paper_count == 2
+
+
+# ---------------------------------------------------------------------------
+# Project membership source-of-truth test (cross-cutting)
+# ---------------------------------------------------------------------------
+
+class TestProjectMembershipSourceOfTruth:
+    def test_add_paper_in_memory_and_db(self, tmp_db):
+        """
+        After add_paper(), the paper_id must appear both in the in-memory
+        paper_ids list AND in the persisted paper_ids JSON column in the DB.
+
+        Note: Projects store membership as a JSON LIST column (paper_ids) on
+        the projects row — there is no separate bridge table. The DB-side check
+        queries that column directly via json_each().
+        """
+        p = Project(name="Source of Truth Test")
+        p.save()
+        p.add_paper("2204.12985")
+
+        # In-memory check
+        assert "2204.12985" in p.paper_ids
+
+        # DB-side check: query paper_ids JSON column via sqlite3 directly
+        conn = sqlite3.connect(tmp_db)
+        conn.row_factory = sqlite3.Row
+        row = conn.execute(
+            """
+            SELECT je.value AS paper_id
+            FROM projects, json_each(projects.paper_ids) je
+            WHERE projects.id = ?
+            """,
+            (p.id,),
+        ).fetchone()
+        conn.close()
+
+        assert row is not None
+        assert row["paper_id"] == "2204.12985"


### PR DESCRIPTION
## Summary

- Adds test classes for all 10 previously untested functions in `storage/db.py`: `set_has_pdf`, `set_pdf_path`, `delete_paper`, `get_all_versions`, `get_graph_data`, `get_categories`, `get_tags`, `add_paper_tags`, `remove_paper_tags`, `search_full_text`
- Adds a migration-path test verifying `init_db()` back-fills all expected columns on an older schema (no extra columns)
- Adds a notes FK enforcement test (`test_notes.py`) — marked `xfail(strict=True)` since the notes schema has no FK declaration and `_connect()` does not enable `PRAGMA foreign_keys`; documents the gap for a future fix
- Adds a project membership source-of-truth test (`test_projects.py`) verifying `add_paper()` updates both the in-memory `paper_ids` list and the persisted JSON column in the DB (adapted from the spec since there is no `project_papers` bridge table)

## Notable findings uncovered during test writing

1. **`search_full_text()` SQL bug** (`storage/db.py:402`): the query uses `WHERE fts MATCH ?` with an alias but SQLite FTS5 requires the bare table name (`WHERE papers_fts MATCH ?`). The 5 `search_full_text` tests are marked `xfail(strict=False)` and will automatically start passing once the production code is fixed.
2. **No FK on `notes.project_id`** and `_connect()` does not enable `PRAGMA foreign_keys`, so inserting a note with a non-existent `project_id` silently succeeds rather than raising `IntegrityError`.

## Test plan

- [x] `uv run pytest tests/ -x` — 628 passed, 6 xfailed, 0 failed
- [x] All new test classes use the `tmp_db` fixture
- [x] No `conftest.py` or `storage/` files were modified

🤖 Generated with [Claude Code](https://claude.com/claude-code)