### PR TITLE
db: database hardening — schema versioning, FK constraints, dedup, indexes, test coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,5 @@ selected_papers.json
 user_settings.json
 .venv
 # env state
+gui/qt_assets/paper_widgets.md
+gui/qt_assets/selection_bar.md

--- a/gui/projects/page.py
+++ b/gui/projects/page.py
@@ -1325,7 +1325,9 @@ class ProjectsPage(QWidget):
 
         try:
             from storage.projects import filter_projects, ensure_projects_db, Q, Status
+            from storage.notes import ensure_notes_db
             ensure_projects_db()
+            ensure_notes_db()
             projects = filter_projects(Q("status = ?", Status.ACTIVE))
         except Exception:
             projects = []

--- a/storage/db.py
+++ b/storage/db.py
@@ -4,6 +4,7 @@ import json
 from pathlib import Path
 import re
 import sqlite3
+from collections.abc import Callable
 from typing import Optional, TYPE_CHECKING
 from .paths import old_pdf_dir, pdf_dir
 import arxiv
@@ -104,7 +105,7 @@ def _migration_v1(conn: sqlite3.Connection) -> None:
             conn.execute(f"ALTER TABLE papers ADD COLUMN {col} {typedef}")
 
 
-_MIGRATIONS: list[tuple[int, object]] = [
+_MIGRATIONS: list[tuple[int, Callable[[sqlite3.Connection], None]]] = [
     (1, _migration_v1),
 ]
 
@@ -202,7 +203,7 @@ def init_db() -> None:
         current_version: int = conn.execute("PRAGMA user_version").fetchone()[0]
         for version, fn in _MIGRATIONS:
             if version > current_version:
-                fn(conn)  # type: ignore[call-arg]
+                fn(conn)
                 conn.execute(
                     "INSERT OR IGNORE INTO schema_migrations (version) VALUES (?)",
                     (version,),
@@ -263,7 +264,7 @@ def parse_entry_id(entry_id: str) -> tuple[str, int]:
     return paper_id, version
 
 
-def _insert(conn: sqlite3.Connection, paper: arxiv.Result, tags: list[str] | None = None) -> tuple[str, int]:
+def _insert_arxiv(conn: sqlite3.Connection, paper: arxiv.Result, tags: list[str] | None = None) -> tuple[str, int]:
     paper_id, version = parse_entry_id(paper.entry_id)
     conn.execute("INSERT OR IGNORE INTO paper_roots(paper_id) VALUES (?)", (paper_id,))
     conn.execute("""
@@ -329,13 +330,13 @@ def _insert_metadata(conn: sqlite3.Connection, meta: PaperMetadata, tags: list[s
 def save_paper(paper: arxiv.Result, tags: list[str] | None = None) -> tuple[str, int]:
     """Insert or replace a single arxiv paper. Returns (paper_id, version)."""
     with _connect() as conn:
-        return _insert(conn, paper, tags)
+        return _insert_arxiv(conn, paper, tags)
 
 
 def save_papers(papers: list[arxiv.Result], tags: list[str] | None = None) -> list[tuple[str, int]]:
     """Batch insert/replace arxiv papers in a single transaction. Returns list of (paper_id, version)."""
     with _connect() as conn:
-        return [_insert(conn, paper, tags) for paper in papers]
+        return [_insert_arxiv(conn, paper, tags) for paper in papers]
 
 
 def save_paper_metadata(meta: PaperMetadata, tags: list[str] | None = None) -> tuple[str, int]:

--- a/storage/db.py
+++ b/storage/db.py
@@ -114,14 +114,14 @@ def _rebuild_papers_with_root_fk(conn: sqlite3.Connection) -> None:
     conn.execute((_MIGRATIONS_DIR / "papers_add_root_fk.sql").read_text())
     old_cols = {row[1] for row in conn.execute("PRAGMA table_info(papers)")}
     col_list = ", ".join(
-        row[1] for row in conn.execute("PRAGMA table_info(papers_new)")
+        row[1] for row in conn.execute("PRAGMA table_info(papers_intermediate)")
         if row[1] in old_cols
     )
-    conn.execute(f"INSERT INTO papers_new ({col_list}) SELECT {col_list} FROM papers")
+    conn.execute(f"INSERT INTO papers_intermediate ({col_list}) SELECT {col_list} FROM papers")
     conn.executescript("""
         DROP VIEW IF EXISTS latest_papers;
         DROP TABLE papers;
-        ALTER TABLE papers_new RENAME TO papers;
+        ALTER TABLE papers_intermediate RENAME TO papers;
 
         CREATE VIEW latest_papers AS
         SELECT * FROM papers p

--- a/storage/db.py
+++ b/storage/db.py
@@ -13,6 +13,7 @@ if TYPE_CHECKING:
     from sources.base import PaperMetadata
 
 DB_PATH = str(Path(__file__).parent.parent / "papers.db")
+_MIGRATIONS_DIR = Path(__file__).parent / "migrations"
 
 # --- adapters: Python → SQLite storage ---
 sqlite3.register_adapter(list,              lambda v: json.dumps(v))
@@ -89,20 +90,14 @@ def _connect(db_path: str = DB_PATH) -> sqlite3.Connection:
 
 def _migration_v1(conn: sqlite3.Connection) -> None:
     existing = {row[1] for row in conn.execute("PRAGMA table_info(papers)")}
-    for col, typedef in [
-        ("updated",           "DATE"),
-        ("categories",        "LIST"),
-        ("journal_ref",       "TEXT"),
-        ("comment",           "TEXT"),
-        ("tags",              "LIST"),
-        ("has_pdf",           "BOOL NOT NULL DEFAULT 0"),
-        ("source",            "TEXT DEFAULT 'arxiv'"),
-        ("pdf_path",          "TEXT DEFAULT NULL"),
-        ("full_text",         "TEXT"),
-        ("downloaded_source", "BOOL DEFAULT 0"),
-    ]:
-        if col not in existing:
-            conn.execute(f"ALTER TABLE papers ADD COLUMN {col} {typedef}")
+    sql = (_MIGRATIONS_DIR / "papers_v1.sql").read_text()
+    for statement in sql.splitlines():
+        statement = statement.strip()
+        if not statement or statement.startswith("--"):
+            continue
+        col_name = statement.split()[5]
+        if col_name not in existing:
+            conn.execute(statement)
 
 
 _MIGRATIONS: list[tuple[int, Callable[[sqlite3.Connection], None]]] = [
@@ -116,36 +111,14 @@ def _papers_has_root_fk(conn: sqlite3.Connection) -> bool:
 
 
 def _rebuild_papers_with_root_fk(conn: sqlite3.Connection) -> None:
-    cols = [row[1] for row in conn.execute("PRAGMA table_info(papers)")]
-    col_list = ", ".join(cols)
-    conn.executescript(f"""
-        CREATE TABLE papers_new (
-            paper_id    TEXT    NOT NULL,
-            version     INTEGER NOT NULL,
-            title       TEXT    NOT NULL,
-            url         TEXT,
-            published   DATE,
-            updated     DATE,
-            category    TEXT,
-            categories  LIST,
-            doi         TEXT,
-            journal_ref TEXT,
-            comment     TEXT,
-            summary     TEXT,
-            authors     LIST,
-            tags        LIST,
-            has_pdf     BOOL NOT NULL DEFAULT 0,
-            source      TEXT DEFAULT 'arxiv',
-            pdf_path    TEXT DEFAULT NULL,
-            full_text   TEXT,
-            downloaded_source BOOL DEFAULT 0,
-            PRIMARY KEY (paper_id, version),
-            FOREIGN KEY (paper_id) REFERENCES paper_roots(paper_id) ON DELETE CASCADE
-        );
-
-        INSERT INTO papers_new ({col_list})
-        SELECT {col_list} FROM papers;
-
+    conn.execute((_MIGRATIONS_DIR / "papers_add_root_fk.sql").read_text())
+    old_cols = {row[1] for row in conn.execute("PRAGMA table_info(papers)")}
+    col_list = ", ".join(
+        row[1] for row in conn.execute("PRAGMA table_info(papers_new)")
+        if row[1] in old_cols
+    )
+    conn.execute(f"INSERT INTO papers_new ({col_list}) SELECT {col_list} FROM papers")
+    conn.executescript("""
         DROP VIEW IF EXISTS latest_papers;
         DROP TABLE papers;
         ALTER TABLE papers_new RENAME TO papers;

--- a/storage/db.py
+++ b/storage/db.py
@@ -516,7 +516,7 @@ def search_full_text(query: str, limit: int = 20) -> list[sqlite3.Row]:
         return conn.execute("""
             SELECT p.* FROM papers p
             JOIN papers_fts fts ON p.paper_id = fts.paper_id
-            WHERE fts MATCH ?
+            WHERE papers_fts MATCH ?
             ORDER BY rank
             LIMIT ?
         """, (query, limit)).fetchall()

--- a/storage/db.py
+++ b/storage/db.py
@@ -86,13 +86,38 @@ def _connect(db_path: str = DB_PATH) -> sqlite3.Connection:
     return conn
 
 
+def _migration_v1(conn: sqlite3.Connection) -> None:
+    existing = {row[1] for row in conn.execute("PRAGMA table_info(papers)")}
+    for col, typedef in [
+        ("updated",           "DATE"),
+        ("categories",        "LIST"),
+        ("journal_ref",       "TEXT"),
+        ("comment",           "TEXT"),
+        ("tags",              "LIST"),
+        ("has_pdf",           "BOOL NOT NULL DEFAULT 0"),
+        ("source",            "TEXT DEFAULT 'arxiv'"),
+        ("pdf_path",          "TEXT DEFAULT NULL"),
+        ("full_text",         "TEXT"),
+        ("downloaded_source", "BOOL DEFAULT 0"),
+    ]:
+        if col not in existing:
+            conn.execute(f"ALTER TABLE papers ADD COLUMN {col} {typedef}")
+
+
+_MIGRATIONS: list[tuple[int, object]] = [
+    (1, _migration_v1),
+]
+
+
 def _papers_has_root_fk(conn: sqlite3.Connection) -> bool:
     rows = conn.execute("PRAGMA foreign_key_list(papers)").fetchall()
     return any(row["table"] == "paper_roots" and row["from"] == "paper_id" for row in rows)
 
 
 def _rebuild_papers_with_root_fk(conn: sqlite3.Connection) -> None:
-    conn.executescript("""
+    cols = [row[1] for row in conn.execute("PRAGMA table_info(papers)")]
+    col_list = ", ".join(cols)
+    conn.executescript(f"""
         CREATE TABLE papers_new (
             paper_id    TEXT    NOT NULL,
             version     INTEGER NOT NULL,
@@ -117,16 +142,8 @@ def _rebuild_papers_with_root_fk(conn: sqlite3.Connection) -> None:
             FOREIGN KEY (paper_id) REFERENCES paper_roots(paper_id) ON DELETE CASCADE
         );
 
-        INSERT INTO papers_new (
-            paper_id, version, title, url, published, updated,
-            category, categories, doi, journal_ref, comment, summary,
-            authors, tags, has_pdf, source, pdf_path, full_text, downloaded_source
-        )
-        SELECT
-            paper_id, version, title, url, published, updated,
-            category, categories, doi, journal_ref, comment, summary,
-            authors, tags, has_pdf, source, pdf_path, full_text, downloaded_source
-        FROM papers;
+        INSERT INTO papers_new ({col_list})
+        SELECT {col_list} FROM papers;
 
         DROP VIEW IF EXISTS latest_papers;
         DROP TABLE papers;
@@ -172,27 +189,26 @@ def init_db() -> None:
             WHERE version = (
                 SELECT MAX(version) FROM papers WHERE paper_id = p.paper_id
             );
+
+            CREATE TABLE IF NOT EXISTS schema_migrations (
+                version     INTEGER PRIMARY KEY,
+                applied_at  TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+            );
         """)
         conn.execute("""
             INSERT OR IGNORE INTO paper_roots(paper_id)
             SELECT DISTINCT paper_id FROM papers
         """)
-        # Migrate existing DBs that are missing columns
-        existing = {row[1] for row in conn.execute("PRAGMA table_info(papers)")}
-        for col, typedef in [
-            ("updated",     "DATE"),
-            ("categories",  "LIST"),
-            ("journal_ref", "TEXT"),
-            ("comment",     "TEXT"),
-            ("tags",        "LIST"),
-            ("has_pdf",     "BOOL NOT NULL DEFAULT 0"),
-            ("source",      "TEXT DEFAULT 'arxiv'"),
-            ("pdf_path",    "TEXT DEFAULT NULL"),
-            ("full_text",   "TEXT"),
-            ("downloaded_source", "BOOL DEFAULT 0"),
-        ]:
-            if col not in existing:
-                conn.execute(f"ALTER TABLE papers ADD COLUMN {col} {typedef}")
+        current_version: int = conn.execute("PRAGMA user_version").fetchone()[0]
+        for version, fn in _MIGRATIONS:
+            if version > current_version:
+                fn(conn)  # type: ignore[call-arg]
+                conn.execute(
+                    "INSERT OR IGNORE INTO schema_migrations (version) VALUES (?)",
+                    (version,),
+                )
+                conn.execute(f"PRAGMA user_version = {version}")
+                current_version = version
         if not _papers_has_root_fk(conn):
             _rebuild_papers_with_root_fk(conn)
 
@@ -254,24 +270,26 @@ def _insert(conn: sqlite3.Connection, paper: arxiv.Result, tags: list[str] | Non
         INSERT OR REPLACE INTO papers
             (paper_id, version, title, url, published, updated,
              category, categories, doi, journal_ref, comment, summary, authors, tags, source)
-        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-    """, (
-        paper_id,
-        version,
-        paper.title,
-        paper.pdf_url,
-        paper.published.date(),
-        paper.updated.date(),
-        paper.primary_category,
-        paper.categories,
-        paper.doi,
-        paper.journal_ref,
-        paper.comment,
-        paper.summary,
-        [a.name for a in paper.authors],
-        tags,
-        "arxiv",
-    ))
+        VALUES
+            (:paper_id, :version, :title, :url, :published, :updated,
+             :category, :categories, :doi, :journal_ref, :comment, :summary, :authors, :tags, :source)
+    """, {
+        "paper_id":    paper_id,
+        "version":     version,
+        "title":       paper.title,
+        "url":         paper.pdf_url,
+        "published":   paper.published.date(),
+        "updated":     paper.updated.date(),
+        "category":    paper.primary_category,
+        "categories":  paper.categories,
+        "doi":         paper.doi,
+        "journal_ref": paper.journal_ref,
+        "comment":     paper.comment,
+        "summary":     paper.summary,
+        "authors":     [a.name for a in paper.authors],
+        "tags":        tags,
+        "source":      "arxiv",
+    })
     return paper_id, version
 
 
@@ -281,29 +299,30 @@ def _insert_metadata(conn: sqlite3.Connection, meta: PaperMetadata, tags: list[s
     if tags:
         merged_tags = list(set((merged_tags or []) + tags))
     conn.execute("INSERT OR IGNORE INTO paper_roots(paper_id) VALUES (?)", (meta.paper_id,))
-    conn.execute(
-    """
+    conn.execute("""
         INSERT OR REPLACE INTO papers
             (paper_id, version, title, url, published, updated,
              category, categories, doi, journal_ref, comment, summary, authors, tags, source)
-        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-    """, (
-        meta.paper_id,
-        meta.version,
-        meta.title,
-        meta.url,
-        meta.published,
-        meta.updated,
-        meta.category,
-        meta.categories,
-        meta.doi,
-        meta.journal_ref,
-        meta.comment,
-        meta.summary,
-        meta.authors,
-        merged_tags,
-        meta.source,
-    ))
+        VALUES
+            (:paper_id, :version, :title, :url, :published, :updated,
+             :category, :categories, :doi, :journal_ref, :comment, :summary, :authors, :tags, :source)
+    """, {
+        "paper_id":    meta.paper_id,
+        "version":     meta.version,
+        "title":       meta.title,
+        "url":         meta.url,
+        "published":   meta.published,
+        "updated":     meta.updated,
+        "category":    meta.category,
+        "categories":  meta.categories,
+        "doi":         meta.doi,
+        "journal_ref": meta.journal_ref,
+        "comment":     meta.comment,
+        "summary":     meta.summary,
+        "authors":     meta.authors,
+        "tags":        merged_tags,
+        "source":      meta.source,
+    })
     return meta.paper_id, meta.version
 
 

--- a/storage/migrations/notes_add_project_fk.sql
+++ b/storage/migrations/notes_add_project_fk.sql
@@ -1,0 +1,27 @@
+-- Migration: add project_id FK constraint to notes table
+-- Rebuilds the table atomically. Safe to run on any existing notes DB.
+
+PRAGMA foreign_keys = OFF;
+
+CREATE TABLE notes_new (
+    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+    paper_id   TEXT    NOT NULL,
+    project_id INTEGER REFERENCES projects(id) ON DELETE SET NULL,
+    title      TEXT,
+    content    TEXT,
+    created_at TIMESTAMP,
+    updated_at TIMESTAMP
+);
+
+INSERT INTO notes_new (id, paper_id, project_id, title, content, created_at, updated_at)
+    SELECT id, paper_id, project_id, title, content, created_at, updated_at FROM notes;
+
+DROP TABLE notes;
+
+ALTER TABLE notes_new RENAME TO notes;
+
+CREATE INDEX IF NOT EXISTS idx_notes_paper_id   ON notes(paper_id);
+CREATE INDEX IF NOT EXISTS idx_notes_project_id ON notes(project_id);
+CREATE INDEX IF NOT EXISTS idx_notes_created_at ON notes(created_at);
+
+PRAGMA foreign_keys = ON;

--- a/storage/migrations/notes_add_project_fk.sql
+++ b/storage/migrations/notes_add_project_fk.sql
@@ -1,11 +1,11 @@
--- Migration: add project_id FK constraint to notes table
+-- Migration: add paper_roots and project_id FK constraints to notes table
 -- Rebuilds the table atomically. Safe to run on any existing notes DB.
 
 PRAGMA foreign_keys = OFF;
 
 CREATE TABLE notes_new (
     id         INTEGER PRIMARY KEY AUTOINCREMENT,
-    paper_id   TEXT    NOT NULL,
+    paper_id   TEXT    NOT NULL REFERENCES paper_roots(paper_id) ON DELETE CASCADE,
     project_id INTEGER REFERENCES projects(id) ON DELETE SET NULL,
     title      TEXT,
     content    TEXT,

--- a/storage/migrations/notes_add_project_fk.sql
+++ b/storage/migrations/notes_add_project_fk.sql
@@ -3,7 +3,7 @@
 
 PRAGMA foreign_keys = OFF;
 
-CREATE TABLE notes_new (
+CREATE TABLE notes_intermediate (
     id         INTEGER PRIMARY KEY AUTOINCREMENT,
     paper_id   TEXT    NOT NULL REFERENCES paper_roots(paper_id) ON DELETE CASCADE,
     project_id INTEGER REFERENCES projects(id) ON DELETE SET NULL,
@@ -13,12 +13,12 @@ CREATE TABLE notes_new (
     updated_at TIMESTAMP
 );
 
-INSERT INTO notes_new (id, paper_id, project_id, title, content, created_at, updated_at)
+INSERT INTO notes_intermediate (id, paper_id, project_id, title, content, created_at, updated_at)
     SELECT id, paper_id, project_id, title, content, created_at, updated_at FROM notes;
 
 DROP TABLE notes;
 
-ALTER TABLE notes_new RENAME TO notes;
+ALTER TABLE notes_intermediate RENAME TO notes;
 
 CREATE INDEX IF NOT EXISTS idx_notes_paper_id   ON notes(paper_id);
 CREATE INDEX IF NOT EXISTS idx_notes_project_id ON notes(project_id);

--- a/storage/migrations/papers_add_root_fk.sql
+++ b/storage/migrations/papers_add_root_fk.sql
@@ -1,0 +1,24 @@
+-- Migration: rebuild papers table to add paper_roots FK constraint
+CREATE TABLE papers_new (
+    paper_id    TEXT    NOT NULL,
+    version     INTEGER NOT NULL,
+    title       TEXT    NOT NULL,
+    url         TEXT,
+    published   DATE,
+    updated     DATE,
+    category    TEXT,
+    categories  LIST,
+    doi         TEXT,
+    journal_ref TEXT,
+    comment     TEXT,
+    summary     TEXT,
+    authors     LIST,
+    tags        LIST,
+    has_pdf     BOOL NOT NULL DEFAULT 0,
+    source      TEXT DEFAULT 'arxiv',
+    pdf_path    TEXT DEFAULT NULL,
+    full_text   TEXT,
+    downloaded_source BOOL DEFAULT 0,
+    PRIMARY KEY (paper_id, version),
+    FOREIGN KEY (paper_id) REFERENCES paper_roots(paper_id) ON DELETE CASCADE
+);

--- a/storage/migrations/papers_add_root_fk.sql
+++ b/storage/migrations/papers_add_root_fk.sql
@@ -1,5 +1,5 @@
 -- Migration: rebuild papers table to add paper_roots FK constraint
-CREATE TABLE papers_new (
+CREATE TABLE papers_intermediate (
     paper_id    TEXT    NOT NULL,
     version     INTEGER NOT NULL,
     title       TEXT    NOT NULL,

--- a/storage/migrations/papers_v1.sql
+++ b/storage/migrations/papers_v1.sql
@@ -1,0 +1,11 @@
+-- Migration v1: add columns absent from the original papers schema
+ALTER TABLE papers ADD COLUMN updated           DATE;
+ALTER TABLE papers ADD COLUMN categories        LIST;
+ALTER TABLE papers ADD COLUMN journal_ref       TEXT;
+ALTER TABLE papers ADD COLUMN comment           TEXT;
+ALTER TABLE papers ADD COLUMN tags              LIST;
+ALTER TABLE papers ADD COLUMN has_pdf           BOOL NOT NULL DEFAULT 0;
+ALTER TABLE papers ADD COLUMN source            TEXT DEFAULT 'arxiv';
+ALTER TABLE papers ADD COLUMN pdf_path          TEXT DEFAULT NULL;
+ALTER TABLE papers ADD COLUMN full_text         TEXT;
+ALTER TABLE papers ADD COLUMN downloaded_source BOOL DEFAULT 0;

--- a/storage/migrations/project_papers_add_fk.sql
+++ b/storage/migrations/project_papers_add_fk.sql
@@ -1,0 +1,10 @@
+-- Migration: add paper_id → paper_roots FK to project_papers table.
+-- Preserves added_at and note columns from the live schema.
+CREATE TABLE project_papers_intermediate (
+    project_id INTEGER   NOT NULL REFERENCES projects(id)              ON DELETE CASCADE,
+    paper_id   TEXT      NOT NULL REFERENCES paper_roots(paper_id)     ON DELETE CASCADE,
+    position   INTEGER,
+    added_at   TIMESTAMP,
+    note       TEXT,
+    PRIMARY KEY (project_id, paper_id)
+);

--- a/storage/migrations/projects_drop_paper_ids.sql
+++ b/storage/migrations/projects_drop_paper_ids.sql
@@ -5,7 +5,7 @@
 -- generated from PRAGMA table_info(projects) so that any columns added
 -- by future migrations are preserved.
 
-CREATE TABLE projects_new (
+CREATE TABLE projects_intermediate (
     id           INTEGER   PRIMARY KEY AUTOINCREMENT,
     name         TEXT      NOT NULL,
     description  TEXT,

--- a/storage/migrations/projects_drop_paper_ids.sql
+++ b/storage/migrations/projects_drop_paper_ids.sql
@@ -1,0 +1,18 @@
+-- Migration: drop paper_ids JSON column from projects table
+-- project_papers bridge table becomes the single source of truth.
+--
+-- The INSERT SELECT is executed by Python with a dynamic column list
+-- generated from PRAGMA table_info(projects) so that any columns added
+-- by future migrations are preserved.
+
+CREATE TABLE projects_new (
+    id           INTEGER   PRIMARY KEY AUTOINCREMENT,
+    name         TEXT      NOT NULL,
+    description  TEXT,
+    color        INTEGER,
+    created_at   TIMESTAMP,
+    updated_at   TIMESTAMP,
+    archived_at  TIMESTAMP,
+    project_tags LIST,
+    status       TEXT      NOT NULL DEFAULT 'active'
+);

--- a/storage/migrations/projects_migrate_paper_ids.sql
+++ b/storage/migrations/projects_migrate_paper_ids.sql
@@ -1,0 +1,6 @@
+-- Migrate paper_ids JSON array column into project_papers bridge table.
+-- json_each key is the 0-based array index, used as position.
+INSERT OR IGNORE INTO project_papers (project_id, paper_id, position)
+SELECT p.id, je.value, CAST(je.key AS INTEGER)
+FROM projects p, json_each(p.paper_ids) AS je
+WHERE p.paper_ids IS NOT NULL;

--- a/storage/migrations/projects_rebuild_swap.sql
+++ b/storage/migrations/projects_rebuild_swap.sql
@@ -1,0 +1,4 @@
+-- Swap projects_new into place after the dynamic INSERT SELECT has run.
+DROP TABLE projects;
+ALTER TABLE projects_new RENAME TO projects;
+CREATE INDEX IF NOT EXISTS idx_projects_status ON projects(status);

--- a/storage/migrations/projects_rebuild_swap.sql
+++ b/storage/migrations/projects_rebuild_swap.sql
@@ -1,4 +1,4 @@
--- Swap projects_new into place after the dynamic INSERT SELECT has run.
+-- Swap projects_intermediate into place after the dynamic INSERT SELECT has run.
 DROP TABLE projects;
-ALTER TABLE projects_new RENAME TO projects;
+ALTER TABLE projects_intermediate RENAME TO projects;
 CREATE INDEX IF NOT EXISTS idx_projects_status ON projects(status);

--- a/storage/notes.py
+++ b/storage/notes.py
@@ -17,24 +17,77 @@ def _notes_table_exists() -> bool:
     return row is not None
 
 
-def ensure_notes_db() -> None:
-    if not _notes_table_exists():
-        init_notes_db()
-
-
 def init_notes_db() -> None:
     init_table(
         "notes",
         [
             ("id",         int, "PRIMARY KEY AUTOINCREMENT"),
             ("paper_id",   str, "NOT NULL"),
-            ("project_id", int),
+            ("project_id", int, "REFERENCES projects(id) ON DELETE SET NULL"),
             ("title",      str),
             ("content",    str),
             ("created_at", datetime.datetime),
             ("updated_at", datetime.datetime),
         ],
     )
+    with _connect() as conn:
+        conn.executescript("""
+            CREATE INDEX IF NOT EXISTS idx_notes_paper_id   ON notes(paper_id);
+            CREATE INDEX IF NOT EXISTS idx_notes_project_id ON notes(project_id);
+            CREATE INDEX IF NOT EXISTS idx_notes_created_at ON notes(created_at);
+        """)
+
+
+def _migrate_notes_db() -> None:
+    """Add FK constraint and indexes to an existing notes table if absent."""
+    with _connect() as conn:
+        fk_rows = conn.execute("PRAGMA foreign_key_list(notes)").fetchall()
+        has_fk = any(
+            row["table"] == "projects" and row["to"] == "id"
+            for row in fk_rows
+        )
+        if has_fk:
+            # Ensure indexes exist even if a prior rebuild was skipped.
+            conn.execute("CREATE INDEX IF NOT EXISTS idx_notes_paper_id   ON notes(paper_id)")
+            conn.execute("CREATE INDEX IF NOT EXISTS idx_notes_project_id ON notes(project_id)")
+            conn.execute("CREATE INDEX IF NOT EXISTS idx_notes_created_at ON notes(created_at)")
+            return
+
+        # Rebuild the table to add the FK constraint.
+        # executescript issues an implicit COMMIT before running, so use it
+        # here to ensure the multi-step rebuild is atomic.
+        conn.executescript("""
+            PRAGMA foreign_keys = OFF;
+
+            CREATE TABLE notes_new (
+                id         INTEGER PRIMARY KEY AUTOINCREMENT,
+                paper_id   TEXT    NOT NULL,
+                project_id INTEGER REFERENCES projects(id) ON DELETE SET NULL,
+                title      TEXT,
+                content    TEXT,
+                created_at TIMESTAMP,
+                updated_at TIMESTAMP
+            );
+
+            INSERT INTO notes_new (id, paper_id, project_id, title, content, created_at, updated_at)
+                SELECT id, paper_id, project_id, title, content, created_at, updated_at FROM notes;
+
+            DROP TABLE notes;
+
+            ALTER TABLE notes_new RENAME TO notes;
+
+            CREATE INDEX IF NOT EXISTS idx_notes_paper_id   ON notes(paper_id);
+            CREATE INDEX IF NOT EXISTS idx_notes_project_id ON notes(project_id);
+            CREATE INDEX IF NOT EXISTS idx_notes_created_at ON notes(created_at);
+
+            PRAGMA foreign_keys = ON;
+        """)
+
+
+def ensure_notes_db() -> None:
+    if not _notes_table_exists():
+        init_notes_db()
+    _migrate_notes_db()
 
 
 # ── Data model ────────────────────────────────────────────────────────────────

--- a/storage/notes.py
+++ b/storage/notes.py
@@ -26,7 +26,7 @@ def init_notes_db() -> None:
         "notes",
         [
             ("id",         int, "PRIMARY KEY AUTOINCREMENT"),
-            ("paper_id",   str, "NOT NULL"),
+            ("paper_id",   str, "NOT NULL REFERENCES paper_roots(paper_id) ON DELETE CASCADE"),
             ("project_id", int, "REFERENCES projects(id) ON DELETE SET NULL"),
             ("title",      str),
             ("content",    str),
@@ -43,20 +43,23 @@ def init_notes_db() -> None:
 
 
 def _migrate_notes_db() -> None:
-    """Add FK constraint and indexes to an existing notes table if absent."""
+    """Add FK constraints and indexes to an existing notes table if absent."""
     with _connect() as conn:
         fk_rows = conn.execute("PRAGMA foreign_key_list(notes)").fetchall()
-        has_fk = any(
-            row["table"] == "projects" and row["to"] == "id"
-            for row in fk_rows
-        )
-        if has_fk:
-            # Ensure indexes exist even if a prior rebuild was skipped.
+        has_project_fk = any(row["table"] == "projects"    and row["to"] == "id"       for row in fk_rows)
+        has_paper_fk   = any(row["table"] == "paper_roots" and row["to"] == "paper_id" for row in fk_rows)
+        if has_project_fk and has_paper_fk:
             conn.execute("CREATE INDEX IF NOT EXISTS idx_notes_paper_id   ON notes(paper_id)")
             conn.execute("CREATE INDEX IF NOT EXISTS idx_notes_project_id ON notes(project_id)")
             conn.execute("CREATE INDEX IF NOT EXISTS idx_notes_created_at ON notes(created_at)")
             return
 
+        # Seed paper_roots for any notes whose paper_id isn't there yet
+        # so the rebuild doesn't fail on orphaned rows.
+        conn.execute("""
+            INSERT OR IGNORE INTO paper_roots(paper_id)
+            SELECT DISTINCT paper_id FROM notes WHERE paper_id IS NOT NULL
+        """)
         conn.executescript(
             (_MIGRATIONS_DIR / "notes_add_project_fk.sql").read_text()
         )
@@ -98,6 +101,10 @@ class Note:
         if self.id is None:
             self.created_at = now
             with _connect() as conn:
+                conn.execute(
+                    "INSERT OR IGNORE INTO paper_roots(paper_id) VALUES (?)",
+                    (self.paper_id,),
+                )
                 cur = conn.execute(
                     """
                     INSERT INTO notes (paper_id, project_id, title, content, created_at, updated_at)

--- a/storage/notes.py
+++ b/storage/notes.py
@@ -4,7 +4,11 @@ import datetime
 from dataclasses import dataclass
 from typing import Optional
 
+from pathlib import Path
+
 from .db import _connect, init_table
+
+_MIGRATIONS_DIR = Path(__file__).parent / "migrations"
 
 
 # ── DB schema ─────────────────────────────────────────────────────────────────
@@ -53,35 +57,9 @@ def _migrate_notes_db() -> None:
             conn.execute("CREATE INDEX IF NOT EXISTS idx_notes_created_at ON notes(created_at)")
             return
 
-        # Rebuild the table to add the FK constraint.
-        # executescript issues an implicit COMMIT before running, so use it
-        # here to ensure the multi-step rebuild is atomic.
-        conn.executescript("""
-            PRAGMA foreign_keys = OFF;
-
-            CREATE TABLE notes_new (
-                id         INTEGER PRIMARY KEY AUTOINCREMENT,
-                paper_id   TEXT    NOT NULL,
-                project_id INTEGER REFERENCES projects(id) ON DELETE SET NULL,
-                title      TEXT,
-                content    TEXT,
-                created_at TIMESTAMP,
-                updated_at TIMESTAMP
-            );
-
-            INSERT INTO notes_new (id, paper_id, project_id, title, content, created_at, updated_at)
-                SELECT id, paper_id, project_id, title, content, created_at, updated_at FROM notes;
-
-            DROP TABLE notes;
-
-            ALTER TABLE notes_new RENAME TO notes;
-
-            CREATE INDEX IF NOT EXISTS idx_notes_paper_id   ON notes(paper_id);
-            CREATE INDEX IF NOT EXISTS idx_notes_project_id ON notes(project_id);
-            CREATE INDEX IF NOT EXISTS idx_notes_created_at ON notes(created_at);
-
-            PRAGMA foreign_keys = ON;
-        """)
+        conn.executescript(
+            (_MIGRATIONS_DIR / "notes_add_project_fk.sql").read_text()
+        )
 
 
 def ensure_notes_db() -> None:

--- a/storage/projects.py
+++ b/storage/projects.py
@@ -64,18 +64,16 @@ def ensure_projects_db() -> None:
 
 
 def _migrate_projects_db() -> None:
-    """Add missing columns and convert data from older schemas."""
+    """Add missing columns, convert data from older schemas, and drop obsolete columns."""
+    _ensure_project_membership_table()
     with _connect() as conn:
         existing = {row[1] for row in conn.execute("PRAGMA table_info(projects)")}
-        for col, typedef in [
-            ("paper_ids",    "LIST"),
-            ("project_tags", "LIST"),
-        ]:
-            if col not in existing:
-                conn.execute(f"ALTER TABLE projects ADD COLUMN {col} {typedef}")
+
+        # Add project_tags if missing (old schema without it)
+        if "project_tags" not in existing:
+            conn.execute("ALTER TABLE projects ADD COLUMN project_tags LIST")
 
         # Migrate color: TEXT hex strings like "#5b8dee" → INTEGER
-        # Only rows where color is stored as a text hex string need converting.
         rows = conn.execute(
             "SELECT id, color FROM projects WHERE typeof(color) = 'text'"
         ).fetchall()
@@ -86,12 +84,49 @@ def _migrate_projects_db() -> None:
                     "UPDATE projects SET color = ? WHERE id = ?",
                     (int(raw.lstrip("#"), 16), row["id"]),
                 )
-    _ensure_project_membership_table()
-    _backfill_project_memberships()
+
+        # If paper_ids JSON column still exists: migrate its data into project_papers,
+        # then rebuild the projects table without that column.
+        if "paper_ids" in existing:
+            old_rows = conn.execute("SELECT id, paper_ids FROM projects").fetchall()
+            for proj_row in old_rows:
+                proj_id = proj_row["id"]
+                paper_ids = proj_row["paper_ids"] or []
+                for pos, pid in enumerate(paper_ids):
+                    conn.execute(
+                        "INSERT OR IGNORE INTO project_papers (project_id, paper_id, position) VALUES (?, ?, ?)",
+                        (proj_id, pid, pos),
+                    )
+            conn.execute("""
+                CREATE TABLE projects_new (
+                    id           INTEGER   PRIMARY KEY AUTOINCREMENT,
+                    name         TEXT      NOT NULL,
+                    description  TEXT,
+                    color        INTEGER,
+                    created_at   TIMESTAMP,
+                    updated_at   TIMESTAMP,
+                    archived_at  TIMESTAMP,
+                    project_tags LIST,
+                    status       TEXT      NOT NULL DEFAULT 'active'
+                )
+            """)
+            conn.execute("""
+                INSERT INTO projects_new
+                    (id, name, description, color, created_at, updated_at,
+                     archived_at, project_tags, status)
+                SELECT id, name, description, color, created_at, updated_at,
+                       archived_at, project_tags, status
+                FROM projects
+            """)
+            conn.execute("DROP TABLE projects")
+            conn.execute("ALTER TABLE projects_new RENAME TO projects")
+            conn.execute(
+                "CREATE INDEX IF NOT EXISTS idx_projects_status ON projects(status)"
+            )
 
 
 def init_projects_db() -> None:
-    """Create the projects table if it doesn't exist."""
+    """Create the projects and project_papers tables if they don't exist."""
     init_table(
         "projects",
         [
@@ -103,7 +138,6 @@ def init_projects_db() -> None:
             ("updated_at",   datetime.datetime),
             ("archived_at",  datetime.datetime),
             ("project_tags", list),
-            ("paper_ids",    list),            # ordered; source of truth for membership & order
             ("status",       str,              "NOT NULL DEFAULT 'active'"),
         ],
     )
@@ -125,6 +159,12 @@ def _ensure_project_membership_table() -> None:
         conn.execute(
             "CREATE INDEX IF NOT EXISTS idx_project_papers_project_pos ON project_papers(project_id, position)"
         )
+        conn.execute(
+            "CREATE INDEX IF NOT EXISTS idx_projects_status ON projects(status)"
+        )
+        conn.execute(
+            "CREATE INDEX IF NOT EXISTS idx_project_papers_paper_id ON project_papers(paper_id)"
+        )
 
 
 def _backfill_project_memberships() -> None:
@@ -141,23 +181,28 @@ def _backfill_project_memberships() -> None:
             _sync_project_papers(conn, project_id, paper_ids)
 
 
-def _load_project_papers(conn, project_id: int) -> list[str]:
-    rows = conn.execute(
-        "SELECT paper_id FROM project_papers WHERE project_id = ? ORDER BY position ASC",
-        (project_id,),
-    ).fetchall()
+def _load_paper_ids(project_id: int) -> list[str]:
+    with _connect() as conn:
+        rows = conn.execute(
+            "SELECT paper_id FROM project_papers WHERE project_id = ? ORDER BY position ASC",
+            (project_id,),
+        ).fetchall()
     return [row["paper_id"] for row in rows]
+
+
+def _save_paper_ids(conn, project_id: int, paper_ids: list[str]) -> None:
+    conn.execute("DELETE FROM project_papers WHERE project_id = ?", (project_id,))
+    conn.executemany(
+        "INSERT INTO project_papers(project_id, paper_id, position) VALUES (?, ?, ?)",
+        [(project_id, pid, idx) for idx, pid in enumerate(paper_ids)],
+    )
 
 
 def _sync_project_papers(conn, project_id: int, paper_ids: list[str]) -> None:
     deduped = list(dict.fromkeys(paper_ids))
     for pid in deduped:
         conn.execute("INSERT OR IGNORE INTO paper_roots(paper_id) VALUES (?)", (pid,))
-    conn.execute("DELETE FROM project_papers WHERE project_id = ?", (project_id,))
-    conn.executemany(
-        "INSERT INTO project_papers(project_id, paper_id, position) VALUES (?, ?, ?)",
-        [(project_id, pid, idx) for idx, pid in enumerate(deduped)],
-    )
+    _save_paper_ids(conn, project_id, deduped)
 
 
 # ── Colour helpers ────────────────────────────────────────────────────────────
@@ -172,7 +217,29 @@ def color_from_hex(hex_str: str) -> int:
     return int(hex_str.lstrip("#"), 16)
 
 
-# ── Data model 
+# ── Internal helpers ──────────────────────────────────────────────────────────
+
+def _load_paper_ids(project_id: int) -> list[str]:
+    """Return the ordered list of paper_ids for a project from the bridge table."""
+    with _connect() as conn:
+        rows = conn.execute(
+            "SELECT paper_id FROM project_papers WHERE project_id = ? ORDER BY position",
+            (project_id,),
+        ).fetchall()
+    return [row["paper_id"] for row in rows]
+
+
+def _save_paper_ids(conn, project_id: int, paper_ids: list[str]) -> None:
+    conn.execute("DELETE FROM project_papers WHERE project_id = ?", (project_id,))
+    for pos, pid in enumerate(paper_ids):
+        conn.execute("INSERT OR IGNORE INTO paper_roots(paper_id) VALUES (?)", (pid,))
+        conn.execute(
+            "INSERT INTO project_papers (project_id, paper_id, position) VALUES (?, ?, ?)",
+            (project_id, pid, pos),
+        )
+
+
+# ── Data model
 
 @dataclass
 class Project:
@@ -180,25 +247,22 @@ class Project:
     description:  str                         = ""
     color:        Optional[int]               = None   # packed RGB, e.g. 0x5b8dee
     project_tags: list[str]                   = field(default_factory=list)
-    paper_ids:    list[str]                   = field(default_factory=list)  # ordered; persisted in DB
+    paper_ids:    list[str]                   = field(default_factory=list)  # in-memory; sourced from project_papers
     status:       Status                      = Status.ACTIVE
     id:           Optional[int]               = None
     created_at:   Optional[datetime.datetime] = None
     updated_at:   Optional[datetime.datetime] = None
     archived_at:  Optional[datetime.datetime] = None
 
-    # ── Construction 
+    # ── Construction
 
     @classmethod
     def from_row(cls, row) -> Project:
         """Construct a Project from a sqlite3.Row returned by a projects query."""
-        paper_ids = row["paper_ids"] or []
-        if row["id"] is not None and _project_papers_table_exists():
-            with _connect() as conn:
-                joined_ids = _load_project_papers(conn, row["id"])
-            paper_ids = joined_ids
+        proj_id = row["id"]
+        paper_ids = _load_paper_ids(proj_id) if proj_id is not None else []
         return cls(
-            id           = row["id"],
+            id           = proj_id,
             name         = row["name"],
             description  = row["description"] or "",
             color        = int(row["color"]) if row["color"] is not None else None,
@@ -210,7 +274,7 @@ class Project:
             archived_at  = row["archived_at"],
         )
 
-    # ── Persistence 
+    # ── Persistence
 
     def save(self) -> None:
         """Insert (if new) or update (if existing) the project row."""
@@ -223,31 +287,31 @@ class Project:
                     """
                     INSERT INTO projects
                         (name, description, color, created_at, updated_at, archived_at,
-                         project_tags, paper_ids, status)
-                    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+                         project_tags, status)
+                    VALUES (?, ?, ?, ?, ?, ?, ?, ?)
                     """,
                     (self.name, self.description, self.color,
                      self.created_at, self.updated_at, self.archived_at,
-                     self.project_tags, self.paper_ids, self.status),
+                     self.project_tags, self.status),
                 )
                 self.id = cur.lastrowid
                 assert self.id is not None
-                _sync_project_papers(conn, self.id, self.paper_ids)
+                _save_paper_ids(conn, self.id, self.paper_ids)
         else:
             with _connect() as conn:
                 conn.execute(
                     """
                     UPDATE projects
                     SET name = ?, description = ?, color = ?, updated_at = ?,
-                        archived_at = ?, project_tags = ?, paper_ids = ?, status = ?
+                        archived_at = ?, project_tags = ?, status = ?
                     WHERE id = ?
                     """,
                     (self.name, self.description, self.color,
                      self.updated_at, self.archived_at,
-                     self.project_tags, self.paper_ids, self.status, self.id),
+                     self.project_tags, self.status, self.id),
                 )
                 assert self.id is not None
-                _sync_project_papers(conn, self.id, self.paper_ids)
+                _save_paper_ids(conn, self.id, self.paper_ids)
 
     def delete(self) -> None:
         """
@@ -283,7 +347,8 @@ class Project:
             self.paper_ids.append(paper_id)
         else:
             self.paper_ids.insert(position, paper_id)
-        self.save()
+        with _connect() as conn:
+            _save_paper_ids(conn, self.id, self.paper_ids)
 
     def add_papers(self, paper_ids: list[str]) -> None:
         """Bulk-add papers, appended in order. Skips duplicates."""
@@ -293,7 +358,8 @@ class Project:
         if not new_ids:
             return
         self.paper_ids.extend(new_ids)
-        self.save()
+        with _connect() as conn:
+            _save_paper_ids(conn, self.id, self.paper_ids)
 
     def remove_paper(self, paper_id: str) -> None:
         """Remove a paper from this project."""
@@ -302,7 +368,8 @@ class Project:
         if paper_id not in self.paper_ids:
             return
         self.paper_ids.remove(paper_id)
-        self.save()
+        with _connect() as conn:
+            _save_paper_ids(conn, self.id, self.paper_ids)
 
     def reorder_paper(self, paper_id: str, new_position: int) -> None:
         """Move a paper to a new index within the ordered list."""
@@ -310,7 +377,8 @@ class Project:
             return
         self.paper_ids.remove(paper_id)
         self.paper_ids.insert(new_position, paper_id)
-        self.save()
+        with _connect() as conn:
+            _save_paper_ids(conn, self.id, self.paper_ids)
 
     def load_papers(self) -> list[str]:
         """Return paper_ids (already loaded from the DB row on construction)."""

--- a/storage/projects.py
+++ b/storage/projects.py
@@ -5,7 +5,11 @@ import enum
 from dataclasses import dataclass, field
 from typing import Optional
 
+from pathlib import Path
+
 from storage.db import _connect, init_table
+
+_MIGRATIONS_DIR = Path(__file__).parent / "migrations"
 
 
 # ── Query builder
@@ -97,27 +101,16 @@ def _migrate_projects_db() -> None:
                         "INSERT OR IGNORE INTO project_papers (project_id, paper_id, position) VALUES (?, ?, ?)",
                         (proj_id, pid, pos),
                     )
-            conn.execute("""
-                CREATE TABLE projects_new (
-                    id           INTEGER   PRIMARY KEY AUTOINCREMENT,
-                    name         TEXT      NOT NULL,
-                    description  TEXT,
-                    color        INTEGER,
-                    created_at   TIMESTAMP,
-                    updated_at   TIMESTAMP,
-                    archived_at  TIMESTAMP,
-                    project_tags LIST,
-                    status       TEXT      NOT NULL DEFAULT 'active'
-                )
-            """)
-            conn.execute("""
-                INSERT INTO projects_new
-                    (id, name, description, color, created_at, updated_at,
-                     archived_at, project_tags, status)
-                SELECT id, name, description, color, created_at, updated_at,
-                       archived_at, project_tags, status
-                FROM projects
-            """)
+            conn.execute(
+                (_MIGRATIONS_DIR / "projects_drop_paper_ids.sql").read_text()
+            )
+            keep_cols = ", ".join(
+                row[1] for row in conn.execute("PRAGMA table_info(projects)")
+                if row[1] != "paper_ids"
+            )
+            conn.execute(
+                f"INSERT INTO projects_new ({keep_cols}) SELECT {keep_cols} FROM projects"
+            )
             conn.execute("DROP TABLE projects")
             conn.execute("ALTER TABLE projects_new RENAME TO projects")
             conn.execute(

--- a/storage/projects.py
+++ b/storage/projects.py
@@ -92,15 +92,9 @@ def _migrate_projects_db() -> None:
         # If paper_ids JSON column still exists: migrate its data into project_papers,
         # then rebuild the projects table without that column.
         if "paper_ids" in existing:
-            old_rows = conn.execute("SELECT id, paper_ids FROM projects").fetchall()
-            for proj_row in old_rows:
-                proj_id = proj_row["id"]
-                paper_ids = proj_row["paper_ids"] or []
-                for pos, pid in enumerate(paper_ids):
-                    conn.execute(
-                        "INSERT OR IGNORE INTO project_papers (project_id, paper_id, position) VALUES (?, ?, ?)",
-                        (proj_id, pid, pos),
-                    )
+            conn.execute(
+                (_MIGRATIONS_DIR / "projects_migrate_paper_ids.sql").read_text()
+            )
             conn.execute(
                 (_MIGRATIONS_DIR / "projects_drop_paper_ids.sql").read_text()
             )
@@ -112,10 +106,8 @@ def _migrate_projects_db() -> None:
             conn.execute(
                 f"INSERT INTO projects_new ({keep_cols}) SELECT {keep_cols} FROM projects"
             )
-            conn.execute("DROP TABLE projects")
-            conn.execute("ALTER TABLE projects_new RENAME TO projects")
-            conn.execute(
-                "CREATE INDEX IF NOT EXISTS idx_projects_status ON projects(status)"
+            conn.executescript(
+                (_MIGRATIONS_DIR / "projects_rebuild_swap.sql").read_text()
             )
 
 

--- a/storage/projects.py
+++ b/storage/projects.py
@@ -104,9 +104,10 @@ def _migrate_projects_db() -> None:
             conn.execute(
                 (_MIGRATIONS_DIR / "projects_drop_paper_ids.sql").read_text()
             )
+            old_cols = {row[1] for row in conn.execute("PRAGMA table_info(projects)")}
             keep_cols = ", ".join(
-                row[1] for row in conn.execute("PRAGMA table_info(projects)")
-                if row[1] != "paper_ids"
+                row[1] for row in conn.execute("PRAGMA table_info(projects_new)")
+                if row[1] in old_cols
             )
             conn.execute(
                 f"INSERT INTO projects_new ({keep_cols}) SELECT {keep_cols} FROM projects"

--- a/storage/projects.py
+++ b/storage/projects.py
@@ -181,23 +181,6 @@ def _backfill_project_memberships() -> None:
             _sync_project_papers(conn, project_id, paper_ids)
 
 
-def _load_paper_ids(project_id: int) -> list[str]:
-    with _connect() as conn:
-        rows = conn.execute(
-            "SELECT paper_id FROM project_papers WHERE project_id = ? ORDER BY position ASC",
-            (project_id,),
-        ).fetchall()
-    return [row["paper_id"] for row in rows]
-
-
-def _save_paper_ids(conn, project_id: int, paper_ids: list[str]) -> None:
-    conn.execute("DELETE FROM project_papers WHERE project_id = ?", (project_id,))
-    conn.executemany(
-        "INSERT INTO project_papers(project_id, paper_id, position) VALUES (?, ?, ?)",
-        [(project_id, pid, idx) for idx, pid in enumerate(paper_ids)],
-    )
-
-
 def _sync_project_papers(conn, project_id: int, paper_ids: list[str]) -> None:
     deduped = list(dict.fromkeys(paper_ids))
     for pid in deduped:
@@ -373,7 +356,7 @@ class Project:
 
     def reorder_paper(self, paper_id: str, new_position: int) -> None:
         """Move a paper to a new index within the ordered list."""
-        if paper_id not in self.paper_ids:
+        if self.id is None or paper_id not in self.paper_ids:
             return
         self.paper_ids.remove(paper_id)
         self.paper_ids.insert(new_position, paper_id)

--- a/storage/projects.py
+++ b/storage/projects.py
@@ -100,11 +100,11 @@ def _migrate_projects_db() -> None:
             )
             old_cols = {row[1] for row in conn.execute("PRAGMA table_info(projects)")}
             keep_cols = ", ".join(
-                row[1] for row in conn.execute("PRAGMA table_info(projects_new)")
+                row[1] for row in conn.execute("PRAGMA table_info(projects_intermediate)")
                 if row[1] in old_cols
             )
             conn.execute(
-                f"INSERT INTO projects_new ({keep_cols}) SELECT {keep_cols} FROM projects"
+                f"INSERT INTO projects_intermediate ({keep_cols}) SELECT {keep_cols} FROM projects"
             )
             conn.executescript(
                 (_MIGRATIONS_DIR / "projects_rebuild_swap.sql").read_text()
@@ -134,12 +134,12 @@ def _ensure_project_membership_table() -> None:
     with _connect() as conn:
         conn.execute("""
             CREATE TABLE IF NOT EXISTS project_papers (
-                project_id INTEGER NOT NULL,
-                paper_id   TEXT    NOT NULL,
-                position   INTEGER NOT NULL,
-                PRIMARY KEY (project_id, paper_id),
-                FOREIGN KEY (project_id) REFERENCES projects(id) ON DELETE CASCADE,
-                FOREIGN KEY (paper_id) REFERENCES paper_roots(paper_id) ON DELETE CASCADE
+                project_id INTEGER   NOT NULL REFERENCES projects(id)          ON DELETE CASCADE,
+                paper_id   TEXT      NOT NULL REFERENCES paper_roots(paper_id) ON DELETE CASCADE,
+                position   INTEGER,
+                added_at   TIMESTAMP,
+                note       TEXT,
+                PRIMARY KEY (project_id, paper_id)
             )
         """)
         conn.execute(
@@ -151,6 +151,30 @@ def _ensure_project_membership_table() -> None:
         conn.execute(
             "CREATE INDEX IF NOT EXISTS idx_project_papers_paper_id ON project_papers(paper_id)"
         )
+
+        fks = {row["table"] for row in conn.execute("PRAGMA foreign_key_list(project_papers)")}
+        if "paper_roots" not in fks:
+            conn.execute("""
+                DELETE FROM project_papers
+                WHERE paper_id NOT IN (SELECT paper_id FROM paper_roots)
+            """)
+            conn.execute(
+                (_MIGRATIONS_DIR / "project_papers_add_fk.sql").read_text()
+            )
+            old_cols = {row[1] for row in conn.execute("PRAGMA table_info(project_papers)")}
+            keep_cols = ", ".join(
+                row[1] for row in conn.execute("PRAGMA table_info(project_papers_intermediate)")
+                if row[1] in old_cols
+            )
+            conn.execute(
+                f"INSERT INTO project_papers_intermediate ({keep_cols}) SELECT {keep_cols} FROM project_papers"
+            )
+            conn.executescript("""
+                DROP TABLE project_papers;
+                ALTER TABLE project_papers_intermediate RENAME TO project_papers;
+                CREATE INDEX IF NOT EXISTS idx_project_papers_project_pos ON project_papers(project_id, position);
+                CREATE INDEX IF NOT EXISTS idx_project_papers_paper_id ON project_papers(paper_id);
+            """)
 
 
 def _backfill_project_memberships() -> None:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -39,3 +39,14 @@ def tmp_db(tmp_path, monkeypatch):
     notes.init_notes_db()
 
     return db_file
+
+
+@pytest.fixture()
+def note_projects(tmp_db):
+    """Extend tmp_db with 10 pre-created projects so notes.project_id FK
+    constraints (REFERENCES projects(id)) are satisfied when tests use
+    hard-coded project IDs like 1, 2, 5, 7, 8."""
+    from storage.projects import Project
+    for i in range(10):
+        Project(name=f"Dummy {i + 1}").save()
+    return tmp_db

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -1,9 +1,10 @@
 """Tests for db.py — pure functions and DB round-trips."""
 import datetime
+import sqlite3
 import sys
 import os
 
-# import pytest
+import pytest
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
@@ -314,3 +315,444 @@ Hello world of transformers.
 
         result = extract_source(bad_path)
         assert result == ""
+
+
+# ---------------------------------------------------------------------------
+# set_has_pdf
+# ---------------------------------------------------------------------------
+
+class TestSetHasPdf:
+    def test_set_has_pdf_true(self, tmp_db):
+        db.save_paper(_make_result("2204.12985v1"))
+        db.set_has_pdf("2204.12985", 1, True)
+        row = db.get_paper("2204.12985", version=1)
+        assert row is not None
+        assert bool(row["has_pdf"]) is True
+
+    def test_set_has_pdf_false(self, tmp_db):
+        db.save_paper(_make_result("2204.12985v1"))
+        db.set_has_pdf("2204.12985", 1, True)
+        db.set_has_pdf("2204.12985", 1, False)
+        row = db.get_paper("2204.12985", version=1)
+        assert row is not None
+        assert bool(row["has_pdf"]) is False
+
+    def test_set_has_pdf_only_affects_target_version(self, tmp_db):
+        db.save_paper(_make_result("2204.12985v1"))
+        db.save_paper(_make_result("2204.12985v2"))
+        db.set_has_pdf("2204.12985", 1, True)
+        row_v2 = db.get_paper("2204.12985", version=2)
+        assert row_v2 is not None
+        assert not bool(row_v2["has_pdf"])
+
+    def test_set_has_pdf_default_is_false(self, tmp_db):
+        db.save_paper(_make_result("2204.12985v1"))
+        row = db.get_paper("2204.12985", version=1)
+        assert row is not None
+        assert not bool(row["has_pdf"])
+
+
+# ---------------------------------------------------------------------------
+# set_pdf_path
+# ---------------------------------------------------------------------------
+
+class TestSetPdfPath:
+    def test_set_pdf_path_single_version(self, tmp_db):
+        db.save_paper(_make_result("2204.12985v1"))
+        db.set_pdf_path("2204.12985", "/tmp/paper.pdf")
+        row = db.get_paper("2204.12985", version=1)
+        assert row is not None
+        assert row["pdf_path"] == "/tmp/paper.pdf"
+
+    def test_set_pdf_path_all_versions(self, tmp_db):
+        db.save_paper(_make_result("2204.12985v1"))
+        db.save_paper(_make_result("2204.12985v2"))
+        db.set_pdf_path("2204.12985", "/tmp/paper.pdf")
+        row_v1 = db.get_paper("2204.12985", version=1)
+        row_v2 = db.get_paper("2204.12985", version=2)
+        assert row_v1 is not None and row_v1["pdf_path"] == "/tmp/paper.pdf"
+        assert row_v2 is not None and row_v2["pdf_path"] == "/tmp/paper.pdf"
+
+    def test_set_pdf_path_overwrites_previous(self, tmp_db):
+        db.save_paper(_make_result("2204.12985v1"))
+        db.set_pdf_path("2204.12985", "/tmp/old.pdf")
+        db.set_pdf_path("2204.12985", "/tmp/new.pdf")
+        row = db.get_paper("2204.12985", version=1)
+        assert row is not None
+        assert row["pdf_path"] == "/tmp/new.pdf"
+
+    def test_set_pdf_path_does_not_affect_other_papers(self, tmp_db):
+        db.save_paper(_make_result("2204.12985v1"))
+        db.save_paper(_make_result("2301.00001v1"))
+        db.set_pdf_path("2204.12985", "/tmp/paper.pdf")
+        other = db.get_paper("2301.00001", version=1)
+        assert other is not None
+        assert other["pdf_path"] is None
+
+
+# ---------------------------------------------------------------------------
+# delete_paper
+# ---------------------------------------------------------------------------
+
+class TestDeletePaper:
+    def test_delete_removes_paper(self, tmp_db):
+        db.save_paper(_make_result("2204.12985v1"))
+        db.delete_paper("2204.12985")
+        assert db.get_paper("2204.12985") is None
+
+    def test_delete_removes_all_versions(self, tmp_db):
+        db.save_paper(_make_result("2204.12985v1"))
+        db.save_paper(_make_result("2204.12985v2"))
+        db.save_paper(_make_result("2204.12985v3"))
+        db.delete_paper("2204.12985")
+        assert db.get_all_versions("2204.12985") == []
+
+    def test_delete_only_affects_target_paper(self, tmp_db):
+        db.save_paper(_make_result("2204.12985v1"))
+        db.save_paper(_make_result("2301.00001v1"))
+        db.delete_paper("2204.12985")
+        assert db.get_paper("2301.00001") is not None
+
+    def test_delete_nonexistent_is_noop(self, tmp_db):
+        # Should not raise
+        db.delete_paper("0000.00000")
+
+    def test_delete_removes_from_list(self, tmp_db):
+        db.save_paper(_make_result("2204.12985v1"))
+        db.delete_paper("2204.12985")
+        rows = db.list_papers()
+        ids = [r["paper_id"] for r in rows]
+        assert "2204.12985" not in ids
+
+
+# ---------------------------------------------------------------------------
+# get_all_versions
+# ---------------------------------------------------------------------------
+
+class TestGetAllVersions:
+    def test_returns_empty_for_unknown_paper(self, tmp_db):
+        assert db.get_all_versions("0000.00000") == []
+
+    def test_returns_single_version(self, tmp_db):
+        db.save_paper(_make_result("2204.12985v1"))
+        rows = db.get_all_versions("2204.12985")
+        assert len(rows) == 1
+        assert rows[0]["version"] == 1
+
+    def test_returns_multiple_versions_oldest_first(self, tmp_db):
+        db.save_paper(_make_result("2204.12985v1"))
+        db.save_paper(_make_result("2204.12985v3"))
+        db.save_paper(_make_result("2204.12985v2"))
+        rows = db.get_all_versions("2204.12985")
+        versions = [r["version"] for r in rows]
+        assert versions == sorted(versions)
+
+    def test_does_not_return_other_papers(self, tmp_db):
+        db.save_paper(_make_result("2204.12985v1"))
+        db.save_paper(_make_result("2301.00001v1"))
+        rows = db.get_all_versions("2204.12985")
+        assert all(r["paper_id"] == "2204.12985" for r in rows)
+
+
+# ---------------------------------------------------------------------------
+# get_graph_data
+# ---------------------------------------------------------------------------
+
+class TestGetGraphData:
+    def test_empty_db_returns_empty_nodes_and_edges(self, tmp_db):
+        nodes, edges = db.get_graph_data()
+        assert nodes == []
+        assert edges == []
+
+    def test_paper_node_present(self, tmp_db):
+        db.save_paper(_make_result("2204.12985v1", title="My Paper"))
+        nodes, edges = db.get_graph_data()
+        paper_nodes = [n for n in nodes if n.get("type") == "paper"]
+        assert len(paper_nodes) == 1
+        assert paper_nodes[0]["id"] == "2204.12985"
+        assert paper_nodes[0]["label"] == "My Paper"
+
+    def test_author_node_present(self, tmp_db):
+        db.save_paper(_make_result("2204.12985v1", authors=["Alice Smith"]))
+        nodes, edges = db.get_graph_data()
+        author_nodes = [n for n in nodes if n.get("type") == "author"]
+        assert any(n["label"] == "Alice Smith" for n in author_nodes)
+
+    def test_edge_connects_paper_to_author(self, tmp_db):
+        db.save_paper(_make_result("2204.12985v1", authors=["Alice Smith"]))
+        nodes, edges = db.get_graph_data()
+        assert any(e["source"] == "2204.12985" and "Alice Smith" in e["target"] for e in edges)
+
+    def test_shared_author_has_single_node(self, tmp_db):
+        db.save_paper(_make_result("2204.12985v1", authors=["Shared Author"]))
+        db.save_paper(_make_result("2301.00001v1", authors=["Shared Author"]))
+        nodes, edges = db.get_graph_data()
+        author_nodes = [n for n in nodes if n.get("type") == "author" and n["label"] == "Shared Author"]
+        assert len(author_nodes) == 1
+
+    def test_paper_node_has_expected_fields(self, tmp_db):
+        db.save_paper(_make_result("2204.12985v1", primary_category="cs.LG"))
+        nodes, _ = db.get_graph_data()
+        paper_node = next(n for n in nodes if n.get("type") == "paper")
+        for key in ("id", "label", "type", "category", "tags", "has_pdf", "published"):
+            assert key in paper_node
+
+    def test_tags_defaults_to_empty_list_when_none(self, tmp_db):
+        db.save_paper(_make_result("2204.12985v1"))  # no tags
+        nodes, _ = db.get_graph_data()
+        paper_node = next(n for n in nodes if n.get("type") == "paper")
+        assert paper_node["tags"] == []
+
+
+# ---------------------------------------------------------------------------
+# get_categories
+# ---------------------------------------------------------------------------
+
+class TestGetCategories:
+    def test_empty_db_returns_empty_list(self, tmp_db):
+        assert db.get_categories() == []
+
+    def test_returns_distinct_categories(self, tmp_db):
+        db.save_paper(_make_result("2204.12985v1", primary_category="cs.LG"))
+        db.save_paper(_make_result("2301.00001v1", primary_category="math.CO"))
+        db.save_paper(_make_result("2301.00002v1", primary_category="cs.LG"))  # duplicate
+        cats = db.get_categories()
+        assert cats.count("cs.LG") == 1
+        assert "math.CO" in cats
+
+    def test_returns_sorted_list(self, tmp_db):
+        db.save_paper(_make_result("2204.12985v1", primary_category="stat.ML"))
+        db.save_paper(_make_result("2301.00001v1", primary_category="cs.LG"))
+        db.save_paper(_make_result("2301.00002v1", primary_category="math.CO"))
+        cats = db.get_categories()
+        assert cats == sorted(cats)
+
+    def test_only_latest_version_category_counted(self, tmp_db):
+        db.save_paper(_make_result("2204.12985v1", primary_category="cs.AI"))
+        db.save_paper(_make_result("2204.12985v2", primary_category="cs.LG"))
+        cats = db.get_categories()
+        # latest version is v2 with cs.LG; cs.AI should not appear
+        assert "cs.LG" in cats
+        assert "cs.AI" not in cats
+
+
+# ---------------------------------------------------------------------------
+# get_tags
+# ---------------------------------------------------------------------------
+
+class TestGetTags:
+    def test_empty_db_returns_empty_list(self, tmp_db):
+        assert db.get_tags() == []
+
+    def test_returns_distinct_tags(self, tmp_db):
+        db.save_paper(_make_result("2204.12985v1"), tags=["ml", "transformers"])
+        db.save_paper(_make_result("2301.00001v1"), tags=["ml", "diffusion"])
+        tags = db.get_tags()
+        assert tags.count("ml") == 1
+        assert "transformers" in tags
+        assert "diffusion" in tags
+
+    def test_returns_sorted_list(self, tmp_db):
+        db.save_paper(_make_result("2204.12985v1"), tags=["zoo", "alpha", "beta"])
+        tags = db.get_tags()
+        assert tags == sorted(tags)
+
+    def test_paper_without_tags_not_included(self, tmp_db):
+        db.save_paper(_make_result("2204.12985v1"), tags=["ml"])
+        db.save_paper(_make_result("2301.00001v1"))  # no tags
+        tags = db.get_tags()
+        assert tags == ["ml"]
+
+
+# ---------------------------------------------------------------------------
+# add_paper_tags
+# ---------------------------------------------------------------------------
+
+class TestAddPaperTags:
+    def test_add_tags_to_paper_without_tags(self, tmp_db):
+        db.save_paper(_make_result("2204.12985v1"))
+        result = db.add_paper_tags("2204.12985", ["ml", "transformers"])
+        assert "ml" in result
+        assert "transformers" in result
+
+    def test_add_tags_persisted_to_db(self, tmp_db):
+        db.save_paper(_make_result("2204.12985v1"))
+        db.add_paper_tags("2204.12985", ["ml"])
+        row = db.get_paper("2204.12985")
+        assert row is not None
+        assert "ml" in row["tags"]
+
+    def test_add_tags_deduplicates(self, tmp_db):
+        db.save_paper(_make_result("2204.12985v1"), tags=["ml"])
+        result = db.add_paper_tags("2204.12985", ["ml", "new_tag"])
+        assert result.count("ml") == 1
+        assert "new_tag" in result
+
+    def test_add_tags_preserves_existing(self, tmp_db):
+        db.save_paper(_make_result("2204.12985v1"), tags=["existing"])
+        result = db.add_paper_tags("2204.12985", ["new"])
+        assert "existing" in result
+        assert "new" in result
+
+    def test_add_tags_returns_updated_list(self, tmp_db):
+        db.save_paper(_make_result("2204.12985v1"), tags=["a"])
+        result = db.add_paper_tags("2204.12985", ["b", "c"])
+        assert set(result) == {"a", "b", "c"}
+
+    def test_add_tags_raises_for_unknown_paper(self, tmp_db):
+        with pytest.raises(KeyError):
+            db.add_paper_tags("0000.00000", ["ml"])
+
+
+# ---------------------------------------------------------------------------
+# remove_paper_tags
+# ---------------------------------------------------------------------------
+
+class TestRemovePaperTags:
+    def test_remove_tag_from_paper(self, tmp_db):
+        db.save_paper(_make_result("2204.12985v1"), tags=["ml", "transformers"])
+        result = db.remove_paper_tags("2204.12985", ["ml"])
+        assert "ml" not in result
+        assert "transformers" in result
+
+    def test_remove_tag_persisted_to_db(self, tmp_db):
+        db.save_paper(_make_result("2204.12985v1"), tags=["ml", "transformers"])
+        db.remove_paper_tags("2204.12985", ["ml"])
+        row = db.get_paper("2204.12985")
+        assert row is not None
+        assert "ml" not in row["tags"]
+
+    def test_remove_nonexistent_tag_is_noop(self, tmp_db):
+        db.save_paper(_make_result("2204.12985v1"), tags=["ml"])
+        result = db.remove_paper_tags("2204.12985", ["nonexistent"])
+        assert result == ["ml"]
+
+    def test_remove_multiple_tags(self, tmp_db):
+        db.save_paper(_make_result("2204.12985v1"), tags=["a", "b", "c"])
+        result = db.remove_paper_tags("2204.12985", ["a", "c"])
+        assert result == ["b"]
+
+    def test_remove_all_tags_leaves_empty_list(self, tmp_db):
+        db.save_paper(_make_result("2204.12985v1"), tags=["x"])
+        result = db.remove_paper_tags("2204.12985", ["x"])
+        assert result == []
+
+    def test_remove_tags_raises_for_unknown_paper(self, tmp_db):
+        with pytest.raises(KeyError):
+            db.remove_paper_tags("0000.00000", ["ml"])
+
+
+# ---------------------------------------------------------------------------
+# search_full_text
+# ---------------------------------------------------------------------------
+
+class TestSearchFullText:
+    def test_returns_empty_for_no_indexed_content(self, tmp_db):
+        db.save_paper(_make_result("2204.12985v1"))
+        # No full text set, FTS index empty
+        results = db.search_full_text("transformers")
+        assert results == []
+
+    def test_finds_paper_with_matching_content(self, tmp_db):
+        db.save_paper(_make_result("2204.12985v1"))
+        db.set_full_text("2204.12985", 1, "This paper studies transformers in NLP.")
+        results = db.search_full_text("transformers")
+        assert len(results) >= 1
+        assert any(r["paper_id"] == "2204.12985" for r in results)
+
+    def test_does_not_return_non_matching_paper(self, tmp_db):
+        db.save_paper(_make_result("2204.12985v1"))
+        db.save_paper(_make_result("2301.00001v1"))
+        db.set_full_text("2204.12985", 1, "This paper studies transformers.")
+        db.set_full_text("2301.00001", 1, "This paper is about diffusion models.")
+        results = db.search_full_text("transformers")
+        ids = [r["paper_id"] for r in results]
+        assert "2204.12985" in ids
+        assert "2301.00001" not in ids
+
+    def test_limit_parameter_respected(self, tmp_db):
+        for i in range(5):
+            pid = f"2204.1298{i}v1"
+            db.save_paper(_make_result(pid, title=f"Paper {i}"))
+            db.set_full_text(f"2204.1298{i}", 1, "quantum computing research paper")
+        results = db.search_full_text("quantum", limit=3)
+        assert len(results) <= 3
+
+    def test_multi_word_query(self, tmp_db):
+        db.save_paper(_make_result("2204.12985v1"))
+        db.set_full_text("2204.12985", 1, "attention mechanisms in neural networks.")
+        results = db.search_full_text("attention neural")
+        assert any(r["paper_id"] == "2204.12985" for r in results)
+
+
+# ---------------------------------------------------------------------------
+# Migration-path test
+# ---------------------------------------------------------------------------
+
+class TestMigrationPath:
+    def test_init_db_adds_missing_columns(self, tmp_path, monkeypatch):
+        """
+        Simulate a DB that only has the original minimal papers schema (no
+        extra columns). Calling init_db() should add all expected columns via
+        the ALTER TABLE migration logic.
+        """
+        import storage.db as db_module
+
+        db_file = str(tmp_path / "migrate_test.db")
+
+        # Patch _connect to point to our isolated test DB
+        real_connect = db_module._connect
+
+        def patched_connect(db_path=None):
+            del db_path
+            return real_connect(db_file)
+
+        monkeypatch.setattr(db_module, "_connect", patched_connect)
+
+        # Create a minimal papers table that is missing the newer columns
+        conn = sqlite3.connect(db_file, detect_types=sqlite3.PARSE_DECLTYPES)
+        conn.row_factory = sqlite3.Row
+        conn.execute("""
+            CREATE TABLE papers (
+                paper_id    TEXT    NOT NULL,
+                version     INTEGER NOT NULL,
+                title       TEXT    NOT NULL,
+                url         TEXT,
+                published   DATE,
+                category    TEXT,
+                summary     TEXT,
+                authors     LIST,
+                tags        LIST,
+                has_pdf     BOOL NOT NULL DEFAULT 0,
+                PRIMARY KEY (paper_id, version)
+            )
+        """)
+        conn.commit()
+        conn.close()
+
+        # Now call init_db() — it should run migration and add missing columns
+        db_module.init_db()
+
+        # Verify all expected columns are present.
+        # We only check columns that the migration loop adds; columns like
+        # `doi` that were never in the migration list won't be back-filled.
+        check_conn = sqlite3.connect(db_file)
+        col_names = {row[1] for row in check_conn.execute("PRAGMA table_info(papers)")}
+        check_conn.close()
+
+        # These are the columns the migration loop is responsible for adding
+        migrated_columns = {
+            "updated",
+            "categories",
+            "journal_ref",
+            "comment",
+            "tags",
+            "has_pdf",
+            "source",
+            "pdf_path",
+            "full_text",
+            "downloaded_source",
+        }
+        assert migrated_columns.issubset(col_names), (
+            f"Missing columns after migration: {migrated_columns - col_names}"
+        )

--- a/tests/test_notes.py
+++ b/tests/test_notes.py
@@ -12,6 +12,7 @@ from storage.notes import (
     get_notes,
     get_project_notes,
 )
+from storage.projects import Project
 
 
 # ---------------------------------------------------------------------------
@@ -48,12 +49,14 @@ class TestNoteSaveCreate:
         assert fetched.content == "Body text"
 
     def test_save_persists_project_id(self):
-        n = Note(paper_id="2204.12985", project_id=42)
+        p = Project(name="Test Project")
+        p.save()
+        n = Note(paper_id="2204.12985", project_id=p.id)
         n.save()
         assert n.id is not None
         fetched = get_note(n.id)
         assert fetched is not None
-        assert fetched.project_id == 42
+        assert fetched.project_id == p.id
 
     def test_save_null_project_id(self):
         n = Note(paper_id="2204.12985", project_id=None)
@@ -192,7 +195,7 @@ class TestGetNote:
 # get_notes
 # ---------------------------------------------------------------------------
 
-@pytest.mark.usefixtures("tmp_db")
+@pytest.mark.usefixtures("note_projects")
 class TestGetNotes:
     def test_empty_db_returns_empty_list(self):
         assert get_notes("2204.12985") == []
@@ -243,7 +246,7 @@ class TestGetNotes:
 # get_project_notes
 # ---------------------------------------------------------------------------
 
-@pytest.mark.usefixtures("tmp_db")
+@pytest.mark.usefixtures("note_projects")
 class TestGetProjectNotes:
     def test_empty_returns_empty_list(self):
         assert get_project_notes(99) == []
@@ -270,7 +273,7 @@ class TestGetProjectNotes:
 # count_project_notes
 # ---------------------------------------------------------------------------
 
-@pytest.mark.usefixtures("tmp_db")
+@pytest.mark.usefixtures("note_projects")
 class TestCountProjectNotes:
     def test_zero_for_empty(self):
         assert count_project_notes(1) == 0
@@ -294,7 +297,7 @@ class TestCountProjectNotes:
 # count_paper_notes
 # ---------------------------------------------------------------------------
 
-@pytest.mark.usefixtures("tmp_db")
+@pytest.mark.usefixtures("note_projects")
 class TestCountPaperNotes:
     def test_zero_for_empty(self):
         assert count_paper_notes("2204.12985") == 0

--- a/tests/test_notes.py
+++ b/tests/test_notes.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import sqlite3
+
 import pytest
 
 from storage.notes import (
@@ -324,3 +326,16 @@ class TestCountPaperNotes:
         assert count_paper_notes("Y") == 1
         n.delete()
         assert count_paper_notes("Y") == 0
+
+
+# ---------------------------------------------------------------------------
+# FK enforcement test (cross-cutting)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.usefixtures("tmp_db")
+def test_note_with_nonexistent_project_id_raises_integrity_error():
+    """notes.project_id has a FK → projects(id); inserting with a non-existent
+    project_id must raise sqlite3.IntegrityError."""
+    n = Note(paper_id="2204.12985", project_id=9999)
+    with pytest.raises(sqlite3.IntegrityError):
+        n.save()

--- a/tests/test_projects.py
+++ b/tests/test_projects.py
@@ -1,4 +1,5 @@
 """Tests for projects.py — pure functions, Q predicates, and DB round-trips."""
+import sqlite3
 import sys
 import os
 
@@ -232,3 +233,29 @@ class TestProjectAddPaper:
         assert p.paper_count == 1
         p.add_paper("2301.00001")
         assert p.paper_count == 2
+
+
+# ---------------------------------------------------------------------------
+# Project membership source-of-truth test (cross-cutting)
+# ---------------------------------------------------------------------------
+
+class TestProjectMembershipSourceOfTruth:
+    def test_add_paper_in_memory_and_db(self, tmp_db):
+        """After add_paper(), the paper_id must appear both in the in-memory
+        paper_ids list AND in the project_papers bridge table (single source of truth)."""
+        p = Project(name="Source of Truth Test")
+        p.save()
+        p.add_paper("2204.12985")
+
+        assert "2204.12985" in p.paper_ids
+
+        conn = sqlite3.connect(tmp_db)
+        conn.row_factory = sqlite3.Row
+        row = conn.execute(
+            "SELECT paper_id FROM project_papers WHERE project_id = ? AND paper_id = ?",
+            (p.id, "2204.12985"),
+        ).fetchone()
+        conn.close()
+
+        assert row is not None
+        assert row["paper_id"] == "2204.12985"


### PR DESCRIPTION
## Summary

- **Schema versioning** (`storage/db.py`): Replaces ad-hoc ALTER TABLE loop with `PRAGMA user_version` + `schema_migrations` table + versioned `_MIGRATIONS` registry. Migration v1 is idempotent and safe to run on any existing DB.
- **Named INSERT params** (`storage/db.py`): `_insert()` and `_insert_metadata()` converted from positional `?` to named `:param` bindings — column→value mapping is now explicit and immune to silent reordering bugs.
- **Dynamic rebuild** (`storage/db.py`): `_rebuild_papers_with_root_fk()` now generates the column list from `PRAGMA table_info(papers)` instead of hardcoding it — new columns can no longer be silently dropped.
- **notes FK + indexes** (`storage/notes.py`): `project_id` now has `REFERENCES projects(id) ON DELETE SET NULL`; three indexes added (`paper_id`, `project_id`, `created_at`). Migration guard handles existing DBs safely.
- **Eliminate dual storage** (`storage/projects.py`): `paper_ids` JSON column removed from projects table. `project_papers` bridge table is now the single source of truth. `_save_paper_ids()` / `_load_paper_ids()` helpers added. Migration guard detects old DBs with `paper_ids` column, migrates data, then rebuilds the table.
- **Indexes** (`storage/projects.py`): `idx_projects_status`, `idx_project_papers_paper_id`, and three notes indexes added.
- **Test coverage**: 10 previously untested functions now covered (`set_has_pdf`, `set_pdf_path`, `delete_paper`, `get_all_versions`, `get_graph_data`, `get_categories`, `get_tags`, `add_paper_tags`, `remove_paper_tags`, `search_full_text`). Migration path test, notes FK enforcement test, and project membership source-of-truth test added.
- **Bug fix**: `search_full_text()` SQL fixed — `WHERE fts MATCH` → `WHERE papers_fts MATCH` (SQLite FTS5 requires bare table name, not alias).

## Test plan

- [x] `uv run pytest tests/ -q` → **634 passed** on `db` branch
- [x] All three Wave 1 agents ran their target file's test suite before PR
- [x] Tests updated to satisfy new FK constraints (notes.project_id FK, project_papers FK)

## Out of scope (Wave 3; consumer hardening)
- GUI call sites that pass paper_ids to projects are not updated here

🤖 Generated with [Claude Code]