### PR TITLE
Add Windows support to fetch_pdfium.sh

### DIFF
--- a/scripts/fetch_pdfium.sh
+++ b/scripts/fetch_pdfium.sh
@@ -13,10 +13,16 @@ ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 DEST="$ROOT/src-tauri/vendor/pdfium"
 
 case "$(uname -s)-$(uname -m)" in
-  Linux-x86_64)  ASSET=pdfium-linux-x64.tgz   SHA=e07bc44c4e422c50eb01da742dc1ec59ad6780ce64ed91955533da8e9fe1a363 ;;
-  Linux-aarch64) ASSET=pdfium-linux-arm64.tgz SHA= ;;
-  Darwin-x86_64) ASSET=pdfium-mac-x64.tgz     SHA= ;;
-  Darwin-arm64)  ASSET=pdfium-mac-arm64.tgz   SHA= ;;
+  Linux-x86_64)   ASSET=pdfium-linux-x64.tgz ASSET_LIB_DIR=lib SHA=e07bc44c4e422c50eb01da742dc1ec59ad6780ce64ed91955533da8e9fe1a363 ;;
+  Linux-aarch64)  ASSET=pdfium-linux-arm64.tgz ASSET_LIB_DIR=lib SHA= ;;
+  Darwin-x86_64)  ASSET=pdfium-mac-x64.tgz   ASSET_LIB_DIR=lib SHA= ;;
+  Darwin-arm64)   ASSET=pdfium-mac-arm64.tgz ASSET_LIB_DIR=lib SHA= ;;
+  # Git Bash / MSYS2 report uname -s as MINGW64_NT-*, MSYS_NT-*, or CYGWIN_NT-*.
+  # bblanchon packages the Windows DLL under bin/, not lib/, so it's staged into
+  # $DEST/lib after extraction to match the layout the other platforms use (and
+  # what tauri.conf.json's `vendor/pdfium/lib/` resource path expects).
+  MINGW*-x86_64 | MSYS*-x86_64 | CYGWIN*-x86_64)
+    ASSET=pdfium-win-x64.tgz ASSET_LIB_DIR=bin SHA=a60740ba8e9bddefa5a53113e25f62364995383d2eed032bcfc60f17209afe47 ;;
   *) echo "unsupported host $(uname -s)-$(uname -m); see github.com/bblanchon/pdfium-binaries/releases" >&2; exit 1 ;;
 esac
 
@@ -33,4 +39,10 @@ fi
 
 tar xzf "$DEST/$ASSET" -C "$DEST"
 rm -f "$DEST/$ASSET"
+
+if [ "$ASSET_LIB_DIR" != "lib" ]; then
+  mkdir -p "$DEST/lib"
+  mv -f "$DEST/$ASSET_LIB_DIR"/* "$DEST/lib/"
+fi
+
 echo "[fetch_pdfium] done: $(find "$DEST" -name 'libpdfium*' -o -name 'pdfium.dll' | head)"


### PR DESCRIPTION
## Summary
- `scripts/fetch_pdfium.sh` only matched `Linux-*`/`Darwin-*` in its `uname` case statement, so a fresh Windows checkout hit `unsupported host` and `exit 1`. Since `tauri.conf.json` validates the `vendor/pdfium/lib` resource path at compile time, this blocked `cargo check`/`cargo build`/`tauri build` entirely on Windows, not just the final bundle step.
- Adds a `MINGW*/MSYS*/CYGWIN*-x86_64` case (Git Bash/MSYS2's `uname -s` values) that pulls the pinned release's `pdfium-win-x64.tgz` (sha256 verified by downloading and hashing it directly).
- bblanchon's Windows tarball ships the DLL under `bin/pdfium.dll`, while Linux/mac ship `lib/lib pdfium.*` directly at the tarball root - so after extraction, `bin/`'s contents are moved into `lib/` to match the layout the resource path and `pdfium_lib_path()` in `pdf_metadata.rs` both expect.

Verified end-to-end on Windows: `bash scripts/fetch_pdfium.sh` -> `npm run build:sidecar` -> `npm run tauri build` all succeed and produce a working MSI/NSIS installer.

## Test plan
- [x] Ran `bash scripts/fetch_pdfium.sh` on Windows (Git Bash) - correctly downloads `pdfium-win-x64.tgz` and stages `pdfium.dll` at `src-tauri/vendor/pdfium/lib/pdfium.dll`
- [x] Ran full `npm run build:all` on Windows - sidecars staged, `tauri build` produced `linXiv_0.2.0_x64_en-US.msi` and `linXiv_0.2.0_x64-setup.exe`
- [ ] CI (Linux) unaffected - existing cases unchanged