### PR TITLE
feed: log fetch attempt/success/failure for upstream RSS fetches

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ A local-first desktop application for discovering, managing, and visualizing aca
 
 Upload your PDFs, create projects, manage notes, tags, and annotations to organize your library — all locally, without sending your data anywhere. linXiv aims to be a one-stop shop for researchers managing their literature, with the near-term goal of extending to research groups who want to share knowledge without going to the web.
 
-> **Development status:** Pre-1.0 (current version `0.3.0-beta`). The database schema is still evolving, but migration structure is in-place. We are deduping pdfs but working on deduping pdfs, from different sources. 
+> **Development status:** Pre-1.0 (current version `0.3.0-beta`). The database schema is still evolving, but migration structure is in-place. We are deduping from the same sources, but working on deduplicating pdfs originating from different sources.
 
 <img src="assets/carousel.gif" width="800" />
 

--- a/src-tauri/crates/core/assets/default_settings.json
+++ b/src-tauri/crates/core/assets/default_settings.json
@@ -1,5 +1,6 @@
 {
   "pdf_save_limit_mb": 1024,
+  "rss_cache_retention_days": 30,
   "tex_rendering_enabled": true,
   "search_history_enabled": true,
   "search_history_max": 200,

--- a/src-tauri/crates/core/sql/tables/RSS_CACHE_ENTRY.sql
+++ b/src-tauri/crates/core/sql/tables/RSS_CACHE_ENTRY.sql
@@ -1,0 +1,21 @@
+-- Persisted per-URL RSS/Atom feed entries -- replaces the old ephemeral
+-- in-memory last-response cache so a re-visit doesn't lose yesterday's
+-- entries just because today's upstream fetch came back empty (e.g. arXiv
+-- publishes nothing on weekends).
+-- DEDUP_KEY: arxiv source_id+version when the entry has one, else its link
+-- (falls back to title if even that's missing) -- see feed.rs::to_cache_entry.
+-- SOURCE_ID: arxiv:{id} (no version) when present -- carried alongside the
+-- entry purely for debugging/future use; the actual durable dismissal lives
+-- in RSS_PAPER_ROOTS, which annotate_and_filter checks directly.
+CREATE TABLE IF NOT EXISTS RSS_CACHE_ENTRY (
+    ENTRY_FK     INTEGER PRIMARY KEY AUTOINCREMENT,
+    FEED_URL     TEXT      NOT NULL,
+    DEDUP_KEY    TEXT      NOT NULL,
+    SOURCE_ID    TEXT,
+    ENTRY_JSON   TEXT      NOT NULL,
+    PUBLISHED_AT TIMESTAMP,
+    FETCHED_AT   TIMESTAMP NOT NULL DEFAULT (datetime('now')),
+    -- Also serves as the FEED_URL lookup index for the load/prune queries below
+    -- (leftmost-prefix match) -- no separate index on FEED_URL alone needed.
+    UNIQUE (FEED_URL, DEDUP_KEY)
+);

--- a/src-tauri/crates/core/sql/tables/RSS_PAPER.sql
+++ b/src-tauri/crates/core/sql/tables/RSS_PAPER.sql
@@ -20,3 +20,8 @@ CREATE TABLE IF NOT EXISTS RSS_PAPER(
 
 -- Every feed GET scans for 'VER' rows (queries::rss::dismissed_versions).
 CREATE INDEX IF NOT EXISTS IDX_RSS_PAPER_REMOVAL_TYPE ON RSS_PAPER(REMOVAL_TYPE);
+
+-- Unindexed FK child columns force a full table scan per parent delete (SQLite
+-- foreign key docs 4.1) -- needed by both the ON DELETE CASCADE and prune_dismissed's
+-- orphan-root NOT EXISTS check.
+CREATE INDEX IF NOT EXISTS IDX_RSS_PAPER_SOURCE_FK ON RSS_PAPER(SOURCE_FK);

--- a/src-tauri/crates/core/src/config.rs
+++ b/src-tauri/crates/core/src/config.rs
@@ -139,13 +139,13 @@ impl UserSettings {
         mb.saturating_mul(1024 * 1024)
     }
 
-    /// `rss_cache_retention_days`: how many days of persisted feed entries
-    /// (`RSS_CACHE_ENTRY`) the home-feed cache keeps before pruning, measured
-    /// from when each entry was first fetched. A permanent dismiss
-    /// (`RSS_PAPER_ROOTS.REMOVAL_TYPE = 'DOI'`) persists independently of this
-    /// window -- it's the dismissal that's kept forever, not the cache row,
-    /// which still ages out normally. Falls back to the bundled default
-    /// (30 days) if missing or not a positive integer.
+    /// `rss_cache_retention_days`: how many days `RSS_CACHE_ENTRY` rows are kept
+    /// before pruning. Also floors `rss::prune_dismissed`'s VER cutoff -- a
+    /// dismissal can't be forgotten before the cache entry it hides is gone.
+    /// Falls back to 30 if missing or not a positive integer.
+    ///
+    /// TODO: prune_dismissed's cutoffs are hardcoded, not settings -- surface
+    /// once there's a real need to tune them per-user.
     pub fn rss_cache_retention_days(&self) -> i64 {
         self.get("rss_cache_retention_days")
             .and_then(Value::as_i64)

--- a/src-tauri/crates/core/src/config.rs
+++ b/src-tauri/crates/core/src/config.rs
@@ -138,6 +138,20 @@ impl UserSettings {
             .unwrap_or(1024) as u64;
         mb.saturating_mul(1024 * 1024)
     }
+
+    /// `rss_cache_retention_days`: how many days of persisted feed entries
+    /// (`RSS_CACHE_ENTRY`) the home-feed cache keeps before pruning, measured
+    /// from when each entry was first fetched. A permanent dismiss
+    /// (`RSS_PAPER_ROOTS.REMOVAL_TYPE = 'DOI'`) persists independently of this
+    /// window -- it's the dismissal that's kept forever, not the cache row,
+    /// which still ages out normally. Falls back to the bundled default
+    /// (30 days) if missing or not a positive integer.
+    pub fn rss_cache_retention_days(&self) -> i64 {
+        self.get("rss_cache_retention_days")
+            .and_then(Value::as_i64)
+            .filter(|&v| v > 0)
+            .unwrap_or(30)
+    }
 }
 
 fn parse_obj(s: &str) -> Result<Map<String, Value>> {
@@ -180,6 +194,7 @@ mod tests {
             s.get("tex_rendering_enabled").unwrap().as_bool().unwrap(),
             true
         );
+        assert_eq!(s.rss_cache_retention_days(), 30);
         assert!(s.get("nope").is_none());
 
         // Override + save persists ONLY the override, then reloads merged.

--- a/src-tauri/crates/core/src/storage/migrations.rs
+++ b/src-tauri/crates/core/src/storage/migrations.rs
@@ -445,6 +445,7 @@ mod tests {
                 .unwrap();
             assert_eq!(n, 1, "{table} must exist after run_migrations");
         }
+        assert!(index_exists(&conn, "IDX_RSS_PAPER_SOURCE_FK").unwrap());
         schema::apply_views(&conn).unwrap();
     }
 

--- a/src-tauri/crates/core/src/storage/migrations.rs
+++ b/src-tauri/crates/core/src/storage/migrations.rs
@@ -35,6 +35,7 @@ pub fn run_migrations(conn: &Connection) -> Result<()> {
     note_uuid(conn)?;
     annotation_uuid(conn)?;
     rss_feed_tables(conn)?;
+    rss_cache_entry_table(conn)?;
     Ok(())
 }
 
@@ -377,6 +378,15 @@ fn rss_feed_tables(conn: &Connection) -> Result<()> {
     Ok(())
 }
 
+// ── 17. RSS_CACHE_ENTRY table (persisted per-URL feed entries, replaces the
+//        old in-memory last-response cache) ─────────────────────────────────
+
+/// Added after the initial schema, same pattern as `rss_feed_tables` above.
+fn rss_cache_entry_table(conn: &Connection) -> Result<()> {
+    conn.execute_batch(include_str!("../../sql/tables/RSS_CACHE_ENTRY.sql"))?;
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -420,7 +430,12 @@ mod tests {
             )
             .unwrap();
         assert_eq!(version_check_tables, 1);
-        for table in ["RSS_PAPER_ROOTS", "RSS_PAPER", "RSS_FILTER_RULE"] {
+        for table in [
+            "RSS_PAPER_ROOTS",
+            "RSS_PAPER",
+            "RSS_FILTER_RULE",
+            "RSS_CACHE_ENTRY",
+        ] {
             let n: i64 = conn
                 .query_row(
                     "SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name=?1",

--- a/src-tauri/crates/core/src/storage/queries/rss.rs
+++ b/src-tauri/crates/core/src/storage/queries/rss.rs
@@ -1,6 +1,5 @@
-//! RSS_PAPER_ROOTS / RSS_PAPER / RSS_FILTER_RULE queries — persisted state for the
-//! home RSS feed: which entries have been seen and dismissed, and the keyword
-//! rules that auto-hide entries before they reach the client.
+//! RSS_PAPER_ROOTS / RSS_PAPER / RSS_FILTER_RULE queries: seen/dismissed feed
+//! entries and the keyword rules that auto-hide entries before the client sees them.
 
 use std::collections::HashSet;
 
@@ -30,11 +29,9 @@ pub fn upsert_seen(conn: &Connection, source_id: &str, version: i64, title: &str
     Ok(())
 }
 
-/// Hide a feed entry going forward. `permanent` blocks the whole paper, every
-/// version, forever (`RSS_PAPER_ROOTS.REMOVAL_TYPE = 'DOI'`); otherwise it
-/// dismisses just this exact version (`RSS_PAPER.REMOVAL_TYPE = 'VER'` on the
-/// `(source_id, version)` row) — a later, higher version is a new row and
-/// resurfaces undismissed.
+/// Hide a feed entry. `permanent` blocks the whole paper forever
+/// (`RSS_PAPER_ROOTS.REMOVAL_TYPE = 'DOI'`); otherwise dismisses just this
+/// version (`RSS_PAPER.REMOVAL_TYPE = 'VER'`) -- a later version resurfaces.
 pub fn dismiss(conn: &Connection, source_id: &str, version: i64, permanent: bool) -> Result<()> {
     if permanent {
         conn.execute(
@@ -82,12 +79,57 @@ pub fn dismissed_versions(conn: &Connection) -> Result<HashSet<(String, i64)>> {
     Ok(rows.collect::<rusqlite::Result<_>>()?)
 }
 
+// ponytail: not yet user-configurable (no settings UI wired up) -- hardcoded
+// until there's a reason to expose them.
+const VER_DISMISS_PRUNE_HOURS: i64 = 48;
+const DOI_DISMISS_PRUNE_DAYS: i64 = 730;
+
+/// Forget old `RSS_PAPER`/`RSS_PAPER_ROOTS` bookkeeping -- VER/DOI dismissals
+/// and plain 'NOT' seen rows, none of which anything reads back once stale.
+pub fn prune_dismissed(conn: &Connection, cache_retention_days: i64) -> Result<()> {
+    // Floored at cache_retention_days: a dismissal can't be forgotten while
+    // the RSS_CACHE_ENTRY row it hides is still served, or it reappears silently.
+    let ver_cutoff_hours = VER_DISMISS_PRUNE_HOURS.max(cache_retention_days.saturating_mul(24));
+    conn.execute(
+        "DELETE FROM RSS_PAPER
+         WHERE REMOVAL_TYPE = 'VER'
+           AND REMOVED_AT < datetime('now', '-' || ?1 || ' hours')",
+        [ver_cutoff_hours],
+    )?;
+    // 'NOT' (never-dismissed) rows: nothing reads them once the cache window
+    // that "seen" was tracking against has itself moved past them.
+    conn.execute(
+        "DELETE FROM RSS_PAPER
+         WHERE REMOVAL_TYPE = 'NOT'
+           AND CREATED_AT < datetime('now', '-' || ?1 || ' days')",
+        [cache_retention_days],
+    )?;
+    // Floored like the VER cutoff above -- same reappearance risk if retention
+    // is ever set past the DOI default.
+    let doi_cutoff_days = DOI_DISMISS_PRUNE_DAYS.max(cache_retention_days);
+    conn.execute(
+        "DELETE FROM RSS_PAPER_ROOTS
+         WHERE REMOVAL_TYPE = 'DOI'
+           AND REMOVED_AT < datetime('now', '-' || ?1 || ' days')",
+        [doi_cutoff_days],
+    )?;
+    // Orphaned 'NOT' root: only once no RSS_PAPER child references it (cascade
+    // only flows parent->child, so a stale child alone won't take this with it).
+    conn.execute(
+        "DELETE FROM RSS_PAPER_ROOTS
+         WHERE REMOVAL_TYPE = 'NOT'
+           AND CREATED_AT < datetime('now', '-' || ?1 || ' days')
+           AND NOT EXISTS (
+               SELECT 1 FROM RSS_PAPER WHERE RSS_PAPER.SOURCE_FK = RSS_PAPER_ROOTS.SOURCE_FK
+           )",
+        [cache_retention_days],
+    )?;
+    Ok(())
+}
+
 /// A freshly-fetched feed entry ready to persist into `RSS_CACHE_ENTRY`.
-/// `dedup_key` is arxiv `source_id+version` when available, else the entry's
-/// link (falls back to title) -- see `feed.rs::to_cache_entry`. `source_id` is
-/// carried separately (without version), stored alongside the entry purely
-/// for debugging/future use -- durable dismissal is checked directly against
-/// `RSS_PAPER_ROOTS` in `annotate_and_filter`, not via this column.
+/// `dedup_key` is arxiv `id+version` when available, else link/title (see
+/// `feed.rs::to_cache_entry`). `source_id` is stored for reference only.
 pub struct CacheEntry {
     pub dedup_key: String,
     pub source_id: Option<String>,
@@ -95,14 +137,8 @@ pub struct CacheEntry {
     pub published_at: Option<NaiveDateTime>,
 }
 
-/// Additively merge freshly-fetched entries into the persisted per-URL cache:
-/// insert only entries whose dedup key isn't already stored for this URL, never
-/// overwrite an existing row (`INSERT OR IGNORE` against the `(FEED_URL,
-/// DEDUP_KEY)` unique index). This is what keeps an empty/short upstream fetch
-/// (e.g. arXiv publishing nothing over a weekend) from clobbering what's
-/// already cached -- it just merges in zero new rows. One transaction for the
-/// whole batch, same reasoning as `annotate_and_filter`'s: avoids one commit
-/// per entry on a fetch that can bring in hundreds.
+/// Additively merge fresh entries into the per-URL cache: insert only unseen
+/// dedup keys, never overwrite an existing row. One transaction for the batch.
 pub fn merge_cache_entries(
     conn: &mut Connection,
     feed_url: &str,
@@ -119,10 +155,8 @@ pub fn merge_cache_entries(
                 e.dedup_key,
                 e.source_id,
                 e.entry_json,
-                // Space-separated to match the format `datetime('now')` writes into
-                // FETCHED_AT -- COALESCE(PUBLISHED_AT, FETCHED_AT) is compared/ordered
-                // as a raw SQL string below, and 'T' > ' ' would make same-day 'T'-form
-                // timestamps sort as newer regardless of actual time.
+                // Space-separated to match datetime('now')'s format -- sorted as a raw
+                // string below, so 'T' would sort newer than same-day ' '-form times.
                 e.published_at
                     .map(|dt| dt.format("%Y-%m-%d %H:%M:%S").to_string()),
             ],
@@ -132,27 +166,13 @@ pub fn merge_cache_entries(
     Ok(())
 }
 
-/// Cap on rows returned per feed GET -- well above the 200 `annotate_and_filter`
-/// truncates to, so dismissed/rule-filtered entries still leave enough headroom.
+/// Cap on rows loaded per feed GET -- above the 200 `annotate_and_filter` keeps.
 const MAX_LOADED_ENTRIES: i64 = 500;
 
-/// Cached entries for `feed_url` within the retention window, newest-first by
-/// published date (falling back to fetch time when the entry's own date didn't
-/// parse). The window itself is measured by `FETCHED_AT` (when we first cached
-/// the row), NOT `PUBLISHED_AT` -- an arXiv entry's `published` is its original
-/// submission date, which for a just-updated v2/v3 of an old paper can be years
-/// in the past even though we only just fetched it; keying the cutoff on that
-/// would drop it from the window on the very fetch that added it. Malformed
-/// stored JSON (should not happen; we wrote it) is logged and skipped rather
-/// than failing the whole feed response. Durably-dismissed entries
-/// (`RSS_PAPER_ROOTS.REMOVAL_TYPE = 'DOI'`) age out of this window like any
-/// other row -- the dismissal itself lives in `RSS_PAPER_ROOTS`, which is what
-/// `annotate_and_filter` actually checks, so nothing depends on keeping their
-/// cache row around. Sorting newest-published-first while capping by fetch
-/// recency is a deliberate tradeoff: if more than `MAX_LOADED_ENTRIES` rows are
-/// within the window, a just-fetched update of an old paper can sort past the
-/// cap despite being the newest fetch -- acceptable at the default retention
-/// window/feed volume, revisit if `MAX_LOADED_ENTRIES` needs to grow.
+/// Cached entries for `feed_url` within the retention window, newest-published-
+/// first. Windowed by `FETCHED_AT`, not `PUBLISHED_AT` -- a just-fetched v2/v3
+/// of an old paper must not age out on the fetch that added it. Malformed
+/// stored JSON is logged and skipped rather than failing the whole response.
 pub fn load_cache_entries(
     conn: &Connection,
     feed_url: &str,
@@ -246,9 +266,8 @@ fn field_value<'a>(field: &str, title: &'a str, summary: &'a str, authors: &'a s
     }
 }
 
-/// True if a feed entry should be hidden: some enabled DENY rule's keywords
-/// (comma-separated, ALL must match -- AND, case-insensitive substring) match,
-/// and no enabled ALLOW rule's keywords also match (ALLOW is the override).
+/// True if an enabled DENY rule matches (comma-separated keywords, all must
+/// match, case-insensitive substring) and no enabled ALLOW rule also matches.
 pub fn is_hidden(rules: &[FilterRule], title: &str, summary: &str, authors: &str) -> bool {
     let rule_matches = |r: &FilterRule| -> bool {
         if !r.enabled {
@@ -326,6 +345,192 @@ mod tests {
         assert!(!dismissed.contains(&("arxiv:2401.00003".to_string(), 2)));
     }
 
+    fn backdate_removed_at(c: &Connection, table: &str, source_id: &str, hours_old: i64) {
+        c.execute(
+            &format!(
+                "UPDATE {table} SET REMOVED_AT = datetime('now', '-' || ?1 || ' hours')
+                 WHERE SOURCE_ID = ?2"
+            ),
+            params![hours_old, source_id],
+        )
+        .unwrap();
+    }
+
+    fn backdate_created_at(c: &Connection, table: &str, source_id: &str, days_old: i64) {
+        c.execute(
+            &format!(
+                "UPDATE {table} SET CREATED_AT = datetime('now', '-' || ?1 || ' days')
+                 WHERE SOURCE_ID = ?2"
+            ),
+            params![days_old, source_id],
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn prune_dismissed_forgets_stale_ver_but_keeps_fresh() {
+        let c = conn();
+        upsert_seen(&c, "arxiv:2401.00010", 1, "old").unwrap();
+        dismiss(&c, "arxiv:2401.00010", 1, false).unwrap();
+        backdate_removed_at(
+            &c,
+            "RSS_PAPER",
+            "arxiv:2401.00010",
+            VER_DISMISS_PRUNE_HOURS + 1,
+        );
+
+        upsert_seen(&c, "arxiv:2401.00011", 1, "fresh").unwrap();
+        dismiss(&c, "arxiv:2401.00011", 1, false).unwrap();
+
+        prune_dismissed(&c, 1).unwrap();
+        let dismissed = dismissed_versions(&c).unwrap();
+        assert!(!dismissed.contains(&("arxiv:2401.00010".to_string(), 1)));
+        assert!(dismissed.contains(&("arxiv:2401.00011".to_string(), 1)));
+    }
+
+    /// A VER dismissal must outlive its `RSS_CACHE_ENTRY` row, or the entry
+    /// silently reappears once the raw VER_DISMISS_PRUNE_HOURS cutoff passes.
+    #[test]
+    fn prune_dismissed_floors_ver_cutoff_at_cache_retention() {
+        let c = conn();
+        upsert_seen(&c, "arxiv:2401.00012", 1, "old-ish").unwrap();
+        dismiss(&c, "arxiv:2401.00012", 1, false).unwrap();
+        // Past the raw 48h constant, nowhere near a 30-day retention window.
+        backdate_removed_at(
+            &c,
+            "RSS_PAPER",
+            "arxiv:2401.00012",
+            VER_DISMISS_PRUNE_HOURS + 1,
+        );
+
+        prune_dismissed(&c, 30).unwrap();
+        assert!(dismissed_versions(&c)
+            .unwrap()
+            .contains(&("arxiv:2401.00012".to_string(), 1)));
+    }
+
+    #[test]
+    fn prune_dismissed_floors_doi_cutoff_at_cache_retention() {
+        let c = conn();
+        upsert_seen(&c, "arxiv:2401.00013", 1, "old-ish, blocked").unwrap();
+        dismiss(&c, "arxiv:2401.00013", 1, true).unwrap();
+        // Past the raw 730-day constant, nowhere near an 830-day retention window.
+        backdate_removed_at(
+            &c,
+            "RSS_PAPER_ROOTS",
+            "arxiv:2401.00013",
+            (DOI_DISMISS_PRUNE_DAYS + 1) * 24,
+        );
+
+        prune_dismissed(&c, DOI_DISMISS_PRUNE_DAYS + 100).unwrap();
+        assert!(blocked_source_ids(&c).unwrap().contains("arxiv:2401.00013"));
+    }
+
+    #[test]
+    fn prune_dismissed_forgets_stale_doi_and_cascades_to_paper_rows() {
+        let c = conn();
+        upsert_seen(&c, "arxiv:2401.00020", 1, "old blocked").unwrap();
+        dismiss(&c, "arxiv:2401.00020", 1, true).unwrap();
+        backdate_removed_at(
+            &c,
+            "RSS_PAPER_ROOTS",
+            "arxiv:2401.00020",
+            DOI_DISMISS_PRUNE_DAYS * 24 + 1,
+        );
+
+        upsert_seen(&c, "arxiv:2401.00021", 1, "fresh blocked").unwrap();
+        dismiss(&c, "arxiv:2401.00021", 1, true).unwrap();
+
+        prune_dismissed(&c, 1).unwrap();
+        let blocked = blocked_source_ids(&c).unwrap();
+        assert!(!blocked.contains("arxiv:2401.00020"));
+        assert!(blocked.contains("arxiv:2401.00021"));
+
+        // ON DELETE CASCADE must have taken the RSS_PAPER row with it.
+        let remaining: i64 = c
+            .query_row(
+                "SELECT COUNT(*) FROM RSS_PAPER WHERE SOURCE_ID = 'arxiv:2401.00020'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(remaining, 0);
+    }
+
+    /// A fresh DOI root must survive delete #2 pruning its own 'NOT' child --
+    /// delete #4's REMOVAL_TYPE='NOT' filter must never reach a DOI root.
+    #[test]
+    fn prune_dismissed_keeps_fresh_doi_root_after_its_not_child_is_pruned() {
+        let c = conn();
+        upsert_seen(&c, "arxiv:2401.00022", 1, "blocked, old seen row").unwrap();
+        backdate_created_at(&c, "RSS_PAPER", "arxiv:2401.00022", 31);
+        dismiss(&c, "arxiv:2401.00022", 1, true).unwrap();
+
+        prune_dismissed(&c, 30).unwrap();
+
+        assert!(blocked_source_ids(&c).unwrap().contains("arxiv:2401.00022"));
+        let remaining: i64 = c
+            .query_row(
+                "SELECT COUNT(*) FROM RSS_PAPER WHERE SOURCE_ID = 'arxiv:2401.00022'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(remaining, 0, "the 'NOT' child should still be pruned");
+    }
+
+    #[test]
+    fn prune_dismissed_forgets_stale_seen_rows_but_keeps_fresh() {
+        let c = conn();
+        upsert_seen(&c, "arxiv:2401.00030", 1, "old, never dismissed").unwrap();
+        backdate_created_at(&c, "RSS_PAPER_ROOTS", "arxiv:2401.00030", 31);
+        backdate_created_at(&c, "RSS_PAPER", "arxiv:2401.00030", 31);
+
+        upsert_seen(&c, "arxiv:2401.00031", 1, "fresh, never dismissed").unwrap();
+
+        prune_dismissed(&c, 30).unwrap();
+
+        let paper_count: i64 = c
+            .query_row("SELECT COUNT(*) FROM RSS_PAPER", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(paper_count, 1, "only the fresh seen row should survive");
+        let roots_count: i64 = c
+            .query_row(
+                "SELECT COUNT(*) FROM RSS_PAPER_ROOTS WHERE SOURCE_ID = 'arxiv:2401.00030'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(
+            roots_count, 0,
+            "orphaned root with no remaining children must go too"
+        );
+    }
+
+    /// The EXISTS guard must not orphan-delete a root while a live child
+    /// (not yet stale) still references it.
+    #[test]
+    fn prune_dismissed_keeps_old_root_with_a_live_child() {
+        let c = conn();
+        upsert_seen(&c, "arxiv:2401.00040", 1, "old root, fresh dismissal").unwrap();
+        backdate_created_at(&c, "RSS_PAPER_ROOTS", "arxiv:2401.00040", 31);
+        dismiss(&c, "arxiv:2401.00040", 1, false).unwrap();
+
+        prune_dismissed(&c, 30).unwrap();
+
+        assert!(dismissed_versions(&c)
+            .unwrap()
+            .contains(&("arxiv:2401.00040".to_string(), 1)));
+        let roots_count: i64 = c
+            .query_row(
+                "SELECT COUNT(*) FROM RSS_PAPER_ROOTS WHERE SOURCE_ID = 'arxiv:2401.00040'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(roots_count, 1, "root must survive while its child does");
+    }
+
     #[test]
     fn rule_crud_round_trips() {
         let c = conn();
@@ -395,8 +600,7 @@ mod tests {
         }
     }
 
-    /// Backdate a row's FETCHED_AT (the retention cutoff -- see `load_cache_entries`)
-    /// to simulate an old cache entry; `merge_cache_entries` always writes it as "now".
+    /// Backdate a row's FETCHED_AT to simulate an old cache entry.
     fn age_row(c: &Connection, dedup_key: &str, days_old: i64) {
         c.execute(
             "UPDATE RSS_CACHE_ENTRY SET FETCHED_AT = datetime('now', '-' || ?1 || ' days')

--- a/src-tauri/crates/core/src/storage/queries/rss.rs
+++ b/src-tauri/crates/core/src/storage/queries/rss.rs
@@ -4,8 +4,10 @@
 
 use std::collections::HashSet;
 
+use chrono::NaiveDateTime;
 use rusqlite::{params, Connection};
 use serde::Serialize;
+use serde_json::Value;
 
 use crate::error::Result;
 
@@ -78,6 +80,121 @@ pub fn dismissed_versions(conn: &Connection) -> Result<HashSet<(String, i64)>> {
         conn.prepare("SELECT SOURCE_ID, VERSION FROM RSS_PAPER WHERE REMOVAL_TYPE = 'VER'")?;
     let rows = stmt.query_map([], |r| Ok((r.get(0)?, r.get(1)?)))?;
     Ok(rows.collect::<rusqlite::Result<_>>()?)
+}
+
+/// A freshly-fetched feed entry ready to persist into `RSS_CACHE_ENTRY`.
+/// `dedup_key` is arxiv `source_id+version` when available, else the entry's
+/// link (falls back to title) -- see `feed.rs::to_cache_entry`. `source_id` is
+/// carried separately (without version), stored alongside the entry purely
+/// for debugging/future use -- durable dismissal is checked directly against
+/// `RSS_PAPER_ROOTS` in `annotate_and_filter`, not via this column.
+pub struct CacheEntry {
+    pub dedup_key: String,
+    pub source_id: Option<String>,
+    pub entry_json: String,
+    pub published_at: Option<NaiveDateTime>,
+}
+
+/// Additively merge freshly-fetched entries into the persisted per-URL cache:
+/// insert only entries whose dedup key isn't already stored for this URL, never
+/// overwrite an existing row (`INSERT OR IGNORE` against the `(FEED_URL,
+/// DEDUP_KEY)` unique index). This is what keeps an empty/short upstream fetch
+/// (e.g. arXiv publishing nothing over a weekend) from clobbering what's
+/// already cached -- it just merges in zero new rows. One transaction for the
+/// whole batch, same reasoning as `annotate_and_filter`'s: avoids one commit
+/// per entry on a fetch that can bring in hundreds.
+pub fn merge_cache_entries(
+    conn: &mut Connection,
+    feed_url: &str,
+    entries: &[CacheEntry],
+) -> Result<()> {
+    let tx = conn.transaction()?;
+    for e in entries {
+        tx.execute(
+            "INSERT OR IGNORE INTO RSS_CACHE_ENTRY
+                 (FEED_URL, DEDUP_KEY, SOURCE_ID, ENTRY_JSON, PUBLISHED_AT)
+             VALUES (?1, ?2, ?3, ?4, ?5)",
+            params![
+                feed_url,
+                e.dedup_key,
+                e.source_id,
+                e.entry_json,
+                // Space-separated to match the format `datetime('now')` writes into
+                // FETCHED_AT -- COALESCE(PUBLISHED_AT, FETCHED_AT) is compared/ordered
+                // as a raw SQL string below, and 'T' > ' ' would make same-day 'T'-form
+                // timestamps sort as newer regardless of actual time.
+                e.published_at
+                    .map(|dt| dt.format("%Y-%m-%d %H:%M:%S").to_string()),
+            ],
+        )?;
+    }
+    tx.commit()?;
+    Ok(())
+}
+
+/// Cap on rows returned per feed GET -- well above the 200 `annotate_and_filter`
+/// truncates to, so dismissed/rule-filtered entries still leave enough headroom.
+const MAX_LOADED_ENTRIES: i64 = 500;
+
+/// Cached entries for `feed_url` within the retention window, newest-first by
+/// published date (falling back to fetch time when the entry's own date didn't
+/// parse). The window itself is measured by `FETCHED_AT` (when we first cached
+/// the row), NOT `PUBLISHED_AT` -- an arXiv entry's `published` is its original
+/// submission date, which for a just-updated v2/v3 of an old paper can be years
+/// in the past even though we only just fetched it; keying the cutoff on that
+/// would drop it from the window on the very fetch that added it. Malformed
+/// stored JSON (should not happen; we wrote it) is logged and skipped rather
+/// than failing the whole feed response. Durably-dismissed entries
+/// (`RSS_PAPER_ROOTS.REMOVAL_TYPE = 'DOI'`) age out of this window like any
+/// other row -- the dismissal itself lives in `RSS_PAPER_ROOTS`, which is what
+/// `annotate_and_filter` actually checks, so nothing depends on keeping their
+/// cache row around. Sorting newest-published-first while capping by fetch
+/// recency is a deliberate tradeoff: if more than `MAX_LOADED_ENTRIES` rows are
+/// within the window, a just-fetched update of an old paper can sort past the
+/// cap despite being the newest fetch -- acceptable at the default retention
+/// window/feed volume, revisit if `MAX_LOADED_ENTRIES` needs to grow.
+pub fn load_cache_entries(
+    conn: &Connection,
+    feed_url: &str,
+    retention_days: i64,
+) -> Result<Vec<Value>> {
+    let mut stmt = conn.prepare(
+        "SELECT ENTRY_FK, ENTRY_JSON
+         FROM RSS_CACHE_ENTRY
+         WHERE FEED_URL = ?1
+           AND FETCHED_AT >= datetime('now', '-' || ?2 || ' days')
+         ORDER BY COALESCE(PUBLISHED_AT, FETCHED_AT) DESC, ENTRY_FK DESC
+         LIMIT ?3",
+    )?;
+    let rows = stmt.query_map(params![feed_url, retention_days, MAX_LOADED_ENTRIES], |r| {
+        Ok((r.get::<_, i64>(0)?, r.get::<_, String>(1)?))
+    })?;
+    Ok(rows
+        .collect::<rusqlite::Result<Vec<(i64, String)>>>()?
+        .iter()
+        .filter_map(|(entry_fk, s)| match serde_json::from_str(s) {
+            Ok(v) => Some(v),
+            Err(e) => {
+                eprintln!("[linxiv] feed: malformed cached entry {entry_fk}: {e}");
+                None
+            }
+        })
+        .collect())
+}
+
+/// Delete rows outside the retention window (measured by `FETCHED_AT` -- see
+/// `load_cache_entries` for why not `PUBLISHED_AT`).
+pub fn prune_cache_entries(
+    conn: &Connection,
+    feed_url: &str,
+    retention_days: i64,
+) -> Result<usize> {
+    Ok(conn.execute(
+        "DELETE FROM RSS_CACHE_ENTRY
+         WHERE FEED_URL = ?1
+           AND FETCHED_AT < datetime('now', '-' || ?2 || ' days')",
+        params![feed_url, retention_days],
+    )?)
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -267,6 +384,111 @@ mod tests {
             enabled: true,
         }];
         assert!(!is_hidden(&rules, "Anything at all", "", ""));
+    }
+
+    fn entry(dedup_key: &str, source_id: Option<&str>) -> CacheEntry {
+        CacheEntry {
+            dedup_key: dedup_key.to_string(),
+            source_id: source_id.map(|s| s.to_string()),
+            entry_json: format!(r#"{{"title":"{dedup_key}"}}"#),
+            published_at: None,
+        }
+    }
+
+    /// Backdate a row's FETCHED_AT (the retention cutoff -- see `load_cache_entries`)
+    /// to simulate an old cache entry; `merge_cache_entries` always writes it as "now".
+    fn age_row(c: &Connection, dedup_key: &str, days_old: i64) {
+        c.execute(
+            "UPDATE RSS_CACHE_ENTRY SET FETCHED_AT = datetime('now', '-' || ?1 || ' days')
+             WHERE DEDUP_KEY = ?2",
+            params![days_old, dedup_key],
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn merge_is_additive_and_never_overwrites() {
+        let mut c = conn();
+        merge_cache_entries(&mut c, "u", &[entry("a", None)]).unwrap();
+        // Same dedup_key again, different payload -- must be ignored, not overwritten.
+        let mut changed = entry("a", None);
+        changed.entry_json = r#"{"title":"changed"}"#.to_string();
+        merge_cache_entries(&mut c, "u", &[changed, entry("b", None)]).unwrap();
+
+        let loaded = load_cache_entries(&c, "u", 30).unwrap();
+        assert_eq!(loaded.len(), 2);
+        let titles: HashSet<_> = loaded
+            .iter()
+            .filter_map(|e| e.get("title").and_then(|t| t.as_str()))
+            .collect();
+        assert!(titles.contains("a"), "original row must survive untouched");
+        assert!(!titles.contains("changed"));
+        assert!(titles.contains("b"));
+    }
+
+    #[test]
+    fn window_excludes_old_entries_even_when_permanently_dismissed() {
+        let mut c = conn();
+        merge_cache_entries(
+            &mut c,
+            "u",
+            &[
+                entry("recent", None),
+                entry("stale", None),
+                entry("stale-and-blocked", Some("arxiv:1")),
+            ],
+        )
+        .unwrap();
+        age_row(&c, "stale", 60);
+        age_row(&c, "stale-and-blocked", 60);
+        dismiss(&c, "arxiv:1", 1, true).unwrap();
+
+        let loaded = load_cache_entries(&c, "u", 30).unwrap();
+        let titles: HashSet<_> = loaded
+            .iter()
+            .filter_map(|e| e.get("title").and_then(|t| t.as_str()))
+            .collect();
+        assert!(titles.contains("recent"));
+        assert!(
+            !titles.contains("stale"),
+            "outside the window -- must not load"
+        );
+        assert!(
+            !titles.contains("stale-and-blocked"),
+            "dismissal doesn't exempt a row from the window -- ages out like any other"
+        );
+    }
+
+    #[test]
+    fn prune_drops_all_stale_rows_regardless_of_dismissal() {
+        let mut c = conn();
+        merge_cache_entries(
+            &mut c,
+            "u",
+            &[
+                entry("recent", None),
+                entry("stale", None),
+                entry("stale-and-blocked", Some("arxiv:1")),
+            ],
+        )
+        .unwrap();
+        age_row(&c, "stale", 60);
+        age_row(&c, "stale-and-blocked", 60);
+        dismiss(&c, "arxiv:1", 1, true).unwrap();
+
+        let pruned = prune_cache_entries(&c, "u", 30).unwrap();
+        assert_eq!(pruned, 2);
+
+        let remaining: HashSet<String> = c
+            .prepare("SELECT DEDUP_KEY FROM RSS_CACHE_ENTRY")
+            .unwrap()
+            .query_map([], |r| r.get(0))
+            .unwrap()
+            .collect::<rusqlite::Result<_>>()
+            .unwrap();
+        assert!(remaining.contains("recent"));
+        assert!(!remaining.contains("stale"));
+        assert!(!remaining.contains("stale-and-blocked"));
     }
 
     #[test]

--- a/src-tauri/src/route/feed.rs
+++ b/src-tauri/src/route/feed.rs
@@ -1,10 +1,5 @@
-//! `GET /api/feed?url=…` — fetch the user's home RSS/Atom feed and persist
-//! entries into a rolling `RSS_CACHE_ENTRY` window (default 30 days), merged in
-//! additively so an empty upstream fetch can't clobber prior entries. Upstream
-//! is throttled to once per `CACHE_TTL`; a failed fetch falls back to serving
-//! the existing DB window, erroring only if that window is empty. Dismissed
-//! (`POST /api/feed/dismiss`) and rule-filtered (`RSS_FILTER_RULE`) entries are
-//! stripped before the response goes out.
+//! `GET /api/feed?url=…` — fetch the user's home RSS/Atom feed into a rolling
+//! `RSS_CACHE_ENTRY` window, throttled per `CACHE_TTL`, dismissed/rule-filtered before response.
 
 use std::collections::HashMap;
 use std::sync::{LazyLock, Mutex};

--- a/src-tauri/src/route/feed.rs
+++ b/src-tauri/src/route/feed.rs
@@ -386,7 +386,8 @@ mod tests {
         use wiremock::{Mock, MockServer, ResponseTemplate};
 
         let mock_server = MockServer::start().await;
-        let feed_url = format!("{}/feed.json", mock_server.uri());
+        // Distinct path: a reused ephemeral port + shared path would collide in LAST_FETCH.
+        let feed_url = format!("{}/feed-saved-ids.json", mock_server.uri());
 
         // Mock a feed with an entry for arxiv paper 2301.00001
         Mock::given(method("GET"))

--- a/src-tauri/src/route/feed.rs
+++ b/src-tauri/src/route/feed.rs
@@ -1,17 +1,28 @@
 //! `GET /api/feed?url=…` — fetch + parse the user-configured home RSS/Atom feed
-//! (core `sources::feed`), with a small in-memory success cache so re-visiting
-//! the home page doesn't re-hit the upstream on every render. Entries the user
-//! dismissed (`POST /api/feed/dismiss`) or that match a filter rule
-//! (`RSS_FILTER_RULE`, CRUD under `/api/feed/rules`) are stripped before the
-//! response goes back to the client.
+//! (core `sources::feed`), persisting entries into `RSS_CACHE_ENTRY` (a rolling
+//! window, default last 30 days -- `rss_cache_retention_days`) instead of
+//! caching just the last raw response. Upstream is only re-fetched every
+//! `CACHE_TTL` (still throttles hammering the feed on every page load); each
+//! fetch is merged in additively (dedup by entry key, never overwritten), so an
+//! empty/short upstream response (e.g. arXiv publishing nothing over a
+//! weekend) can't clobber previously-cached entries -- the response is always
+//! built from the DB window, not the raw fetch. A failed upstream fetch falls
+//! back to serving the existing DB window rather than erroring outright; only
+//! an empty window (nothing cached yet, or fully pruned) surfaces the fetch
+//! error to the client. Entries the user dismissed (`POST /api/feed/dismiss`)
+//! or that match a filter rule (`RSS_FILTER_RULE`, CRUD under
+//! `/api/feed/rules`) are stripped before the response goes back to the
+//! client.
 
 use std::collections::HashMap;
 use std::sync::{LazyLock, Mutex};
 use std::time::{Duration, Instant};
 
+use chrono::NaiveDateTime;
 use serde::Deserialize;
 use serde_json::{json, Value};
 
+use linxiv_core::config::UserSettings;
 use linxiv_core::sources::feed as svc_feed;
 use linxiv_core::storage::queries::rss;
 
@@ -20,8 +31,12 @@ use crate::state::AppState;
 
 const CACHE_TTL: Duration = Duration::from_secs(300);
 
-// Unbounded per-URL map — in practice one home-feed URL lives here.
-static CACHE: LazyLock<Mutex<HashMap<String, (Instant, Value)>>> = LazyLock::new(Default::default);
+// Throttle-only: when a URL was last fetched from upstream, plus the feed's
+// channel title (needed to build a response on a throttled/no-fetch request --
+// the DB window only holds entries, not the channel title). Unbounded per-URL
+// map — in practice one home-feed URL lives here.
+static LAST_FETCH: LazyLock<Mutex<HashMap<String, (Instant, String)>>> =
+    LazyLock::new(Default::default);
 
 pub(crate) async fn handle(state: &AppState, ctx: &ReqCtx<'_>) -> Option<Result<Value, ApiError>> {
     match (ctx.method, ctx.segs) {
@@ -44,6 +59,40 @@ fn entry_identity(entry: &Value) -> (Option<String>, Option<i64>) {
     (source_id, version)
 }
 
+/// Best-effort parse of a feed entry's raw `published` string (RSS `pubDate` is
+/// RFC 822, Atom `published`/`updated` is RFC 3339) into a timestamp to prune
+/// by. `None` when it doesn't parse either way -- the caller then prunes by
+/// first-fetched time instead (`RSS_CACHE_ENTRY.FETCHED_AT`).
+fn parse_published(s: &str) -> Option<NaiveDateTime> {
+    chrono::DateTime::parse_from_rfc2822(s)
+        .or_else(|_| chrono::DateTime::parse_from_rfc3339(s))
+        .map(|dt| dt.naive_utc())
+        .ok()
+}
+
+/// Build the DB row for a freshly-fetched entry. Dedup key is arxiv
+/// `source_id+version` when the entry has one (a later version is a genuinely
+/// distinct entry, so it must get its own key, not overwrite v1's); otherwise
+/// the entry's link, falling back to its title if even that's blank. `None`
+/// only when the entry has neither an arxiv id, a link, nor a title -- nothing
+/// stable to key it by.
+fn to_cache_entry(entry: &svc_feed::FeedEntry) -> Option<rss::CacheEntry> {
+    let entry_json = serde_json::to_string(entry).ok()?;
+    let source_id = entry.arxiv_id.as_deref().map(|id| format!("arxiv:{id}"));
+    let dedup_key = match (&source_id, entry.version) {
+        (Some(sid), Some(v)) => format!("{sid}v{v}"),
+        _ if !entry.link.is_empty() => entry.link.clone(),
+        _ if !entry.title.is_empty() => entry.title.clone(),
+        _ => return None,
+    };
+    Some(rss::CacheEntry {
+        dedup_key,
+        source_id,
+        entry_json,
+        published_at: parse_published(&entry.published),
+    })
+}
+
 /// Drops entries the user dismissed or that match a filter rule, records each
 /// survivor as seen (`RSS_PAPER_ROOTS`/`RSS_PAPER`), and returns which of them
 /// are already saved to the library — all in one DB connection.
@@ -53,7 +102,6 @@ fn annotate_and_filter(state: &AppState, feed_value: &mut Value) -> Vec<String> 
     let Some(entries) = feed_value.get_mut("entries").and_then(|e| e.as_array_mut()) else {
         return Vec::new();
     };
-    entries.truncate(200);
 
     state.with_conn(|conn| {
         // One transaction for the whole read+write batch -- avoids up to ~200
@@ -94,6 +142,10 @@ fn annotate_and_filter(state: &AppState, feed_value: &mut Value) -> Vec<String> 
             }
             !rss::is_hidden(&rules, title, summary, &authors)
         });
+        // Truncate after filtering (not before) so dismissed/rule-hidden entries
+        // don't eat into the 200 the client actually gets to see -- the loader
+        // above pulls up to 500 rows precisely to leave this headroom.
+        entries.truncate(200);
 
         // Record each survivor as seen, separately from the (pure) filter above.
         for entry in entries.iter() {
@@ -137,30 +189,65 @@ async fn get_feed(state: &AppState, ctx: &ReqCtx<'_>) -> Result<Value, ApiError>
         .filter(|u| !u.trim().is_empty())
         .ok_or_else(|| ApiError::new(422, "url query parameter is required"))?;
 
-    let cached = CACHE
+    let last_fetch = LAST_FETCH
         .lock()
         .unwrap_or_else(|e| e.into_inner())
         .get(url)
-        .filter(|(at, _)| at.elapsed() < CACHE_TTL)
-        .map(|(_, v)| v.clone());
+        .cloned();
+    let due = last_fetch
+        .as_ref()
+        .map(|(at, _)| at.elapsed() >= CACHE_TTL)
+        .unwrap_or(true);
+    let mut title = last_fetch.map(|(_, t)| t).unwrap_or_default();
+    let retention_days = UserSettings::load()
+        .map(|s| s.rss_cache_retention_days())
+        .unwrap_or(30);
 
-    let mut result = match cached {
-        Some(v) => v,
-        None => {
-            // Cache miss or expired: fetch fresh from upstream.
-            // data_dir carries the shared .arxiv_ratelimit file (same one arxiv_get uses).
-            let feed = svc_feed::fetch_feed(url, &linxiv_core::config::data_dir()).await?;
-            let v = serde_json::to_value(&feed).map_err(|e| ApiError::new(500, e.to_string()))?;
-            CACHE
-                .lock()
-                .unwrap_or_else(|e| e.into_inner())
-                .insert(url.to_string(), (Instant::now(), v.clone()));
-            v
+    let mut fetch_err = None;
+    if due {
+        eprintln!("[linxiv] feed: fetching {url}");
+        // data_dir carries the shared .arxiv_ratelimit file (same one arxiv_get uses).
+        match svc_feed::fetch_feed(url, &linxiv_core::config::data_dir()).await {
+            Ok(feed) => {
+                eprintln!(
+                    "[linxiv] feed: fetched {url} ({} entries)",
+                    feed.entries.len()
+                );
+                title = feed.title.clone();
+                let fresh: Vec<rss::CacheEntry> =
+                    feed.entries.iter().filter_map(to_cache_entry).collect();
+                state.with_conn(|conn| -> linxiv_core::error::Result<()> {
+                    rss::merge_cache_entries(conn, url, &fresh)?;
+                    rss::prune_cache_entries(conn, url, retention_days)?;
+                    Ok(())
+                })?;
+                LAST_FETCH
+                    .lock()
+                    .unwrap_or_else(|e| e.into_inner())
+                    .insert(url.to_string(), (Instant::now(), title.clone()));
+            }
+            Err(e) => {
+                // No throttle entry written on failure -- matches the old cache's
+                // behavior of retrying on the very next request rather than
+                // waiting out the TTL while upstream is down. Don't bail out here:
+                // fall through and try to serve the persisted window instead; only
+                // error out below if there's nothing cached to fall back to.
+                eprintln!("[linxiv] feed: fetch failed for {url}: {e}");
+                fetch_err = Some(e);
+            }
         }
-    };
+    }
+
+    let entries = state.with_conn(|conn| rss::load_cache_entries(conn, url, retention_days))?;
+    if entries.is_empty() {
+        if let Some(e) = fetch_err {
+            return Err(e.into());
+        }
+    }
+    let mut result = json!({ "title": title, "entries": entries });
 
     // Recompute dismiss/rule filtering + saved_arxiv_ids fresh against current DB
-    // state (cache hit or miss) -- the cached value above is the raw upstream feed.
+    // state -- the DB-window entries above are unfiltered.
     let saved_arxiv_ids = annotate_and_filter(state, &mut result);
     result["saved_arxiv_ids"] = serde_json::json!(saved_arxiv_ids);
     Ok(result)
@@ -235,6 +322,7 @@ fn delete_rule(state: &AppState, id: &str) -> Result<Value, ApiError> {
 
 #[cfg(test)]
 mod tests {
+    use super::rss;
     use crate::route::{route, ApiRequest};
     use crate::state::AppState;
     use linxiv_core::storage;
@@ -246,8 +334,18 @@ mod tests {
     }
 
     async fn get(path: &str) -> Result<serde_json::Value, crate::route::ApiError> {
+        get_in(&state(), path).await
+    }
+
+    /// Like `get`, but against a caller-supplied state — needed to pre-seed the
+    /// DB cache and then observe it survive a real `route()` call, rather than
+    /// each call getting its own throwaway in-memory DB.
+    async fn get_in(
+        state: &AppState,
+        path: &str,
+    ) -> Result<serde_json::Value, crate::route::ApiError> {
         route(
-            &state(),
+            state,
             ApiRequest {
                 method: "GET".into(),
                 path: path.into(),
@@ -276,9 +374,9 @@ mod tests {
         use wiremock::matchers::method;
         use wiremock::{Mock, MockServer, ResponseTemplate};
 
-        // No CACHE.lock().unwrap().clear() here: CACHE is a process-wide static and
-        // cargo test runs these #[tokio::test]s concurrently, so a blind clear() races
-        // with sibling tests and can evict their entries mid-test.
+        // No LAST_FETCH.lock().unwrap().clear() here: LAST_FETCH is a process-wide
+        // static and cargo test runs these #[tokio::test]s concurrently, so a blind
+        // clear() races with sibling tests and can evict their entries mid-test.
         let mock_server = MockServer::start().await;
         let feed_url = format!("{}/feed.xml", mock_server.uri());
 
@@ -375,6 +473,121 @@ mod tests {
 
         let result = get(&format!("/api/feed?url={}", encoded_url)).await;
         assert!(result.is_ok());
+
+        mock_server.verify().await;
+    }
+
+    /// The bug the caching redesign fixes: arXiv (or any feed) publishing
+    /// nothing new (e.g. over a weekend) must not wipe entries a real earlier
+    /// fetch already persisted -- the additive merge inserts zero new rows and
+    /// the DB-backed window response still includes the earlier entry.
+    #[tokio::test]
+    async fn empty_upstream_fetch_does_not_clobber_previously_cached_entries() {
+        use wiremock::matchers::method;
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let mock_server = MockServer::start().await;
+        let feed_url = format!("{}/weekend-feed.xml", mock_server.uri());
+        let encoded_url = feed_url.replace(":", "%3A").replace("/", "%2F");
+
+        let st = state();
+        st.with_conn(|conn| {
+            rss::merge_cache_entries(
+                conn,
+                &feed_url,
+                &[rss::CacheEntry {
+                    dedup_key: "arxiv:9999.00001v1".into(),
+                    source_id: Some("arxiv:9999.00001".into()),
+                    entry_json:
+                        r#"{"title":"Yesterday's Paper","arxiv_id":"9999.00001","version":1}"#
+                            .into(),
+                    published_at: None,
+                }],
+            )
+        })
+        .unwrap();
+
+        // Well-formed but empty upstream response -- the weekend case.
+        Mock::given(method("GET"))
+            .respond_with(ResponseTemplate::new(200).set_body_string(
+                r#"<?xml version="1.0"?><rss version="2.0"><channel><title>Empty</title></channel></rss>"#,
+            ))
+            .expect(1)
+            .mount(&mock_server)
+            .await;
+
+        let result = get_in(&st, &format!("/api/feed?url={}", encoded_url))
+            .await
+            .unwrap();
+        let titles: Vec<&str> = result["entries"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .filter_map(|e| e.get("title").and_then(|t| t.as_str()))
+            .collect();
+        assert!(
+            titles.contains(&"Yesterday's Paper"),
+            "empty upstream fetch must not wipe previously cached entries, got: {titles:?}"
+        );
+
+        mock_server.verify().await;
+    }
+
+    /// Two successive fetches into the same DB accumulate rather than replace:
+    /// day 1's entry survives once day 2's (distinct) entry is merged in.
+    #[tokio::test]
+    async fn successive_fetches_accumulate_additively() {
+        use wiremock::matchers::method;
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let mock_server = MockServer::start().await;
+        let feed_url = format!("{}/growing-feed.xml", mock_server.uri());
+        let encoded_url = feed_url.replace(":", "%3A").replace("/", "%2F");
+
+        let st = state();
+        st.with_conn(|conn| {
+            rss::merge_cache_entries(
+                conn,
+                &feed_url,
+                &[rss::CacheEntry {
+                    dedup_key: "arxiv:1111.00001v1".into(),
+                    source_id: Some("arxiv:1111.00001".into()),
+                    entry_json: r#"{"title":"Day One Paper","arxiv_id":"1111.00001","version":1}"#
+                        .into(),
+                    published_at: None,
+                }],
+            )
+        })
+        .unwrap();
+
+        Mock::given(method("GET"))
+            .respond_with(ResponseTemplate::new(200).set_body_string(
+                r#"<?xml version="1.0"?>
+<rss version="2.0">
+  <channel>
+    <title>Growing Feed</title>
+    <item>
+      <title>Day Two Paper</title>
+      <link>https://arxiv.org/abs/2222.00002v1</link>
+    </item>
+  </channel>
+</rss>"#,
+            ))
+            .expect(1)
+            .mount(&mock_server)
+            .await;
+
+        let result = get_in(&st, &format!("/api/feed?url={}", encoded_url))
+            .await
+            .unwrap();
+        let titles: Vec<&str> = result["entries"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .filter_map(|e| e.get("title").and_then(|t| t.as_str()))
+            .collect();
+        assert!(titles.contains(&"Day One Paper"), "got: {titles:?}");
+        assert!(titles.contains(&"Day Two Paper"), "got: {titles:?}");
 
         mock_server.verify().await;
     }

--- a/src-tauri/src/route/feed.rs
+++ b/src-tauri/src/route/feed.rs
@@ -1,18 +1,10 @@
-//! `GET /api/feed?url=…` — fetch + parse the user-configured home RSS/Atom feed
-//! (core `sources::feed`), persisting entries into `RSS_CACHE_ENTRY` (a rolling
-//! window, default last 30 days -- `rss_cache_retention_days`) instead of
-//! caching just the last raw response. Upstream is only re-fetched every
-//! `CACHE_TTL` (still throttles hammering the feed on every page load); each
-//! fetch is merged in additively (dedup by entry key, never overwritten), so an
-//! empty/short upstream response (e.g. arXiv publishing nothing over a
-//! weekend) can't clobber previously-cached entries -- the response is always
-//! built from the DB window, not the raw fetch. A failed upstream fetch falls
-//! back to serving the existing DB window rather than erroring outright; only
-//! an empty window (nothing cached yet, or fully pruned) surfaces the fetch
-//! error to the client. Entries the user dismissed (`POST /api/feed/dismiss`)
-//! or that match a filter rule (`RSS_FILTER_RULE`, CRUD under
-//! `/api/feed/rules`) are stripped before the response goes back to the
-//! client.
+//! `GET /api/feed?url=…` — fetch the user's home RSS/Atom feed and persist
+//! entries into a rolling `RSS_CACHE_ENTRY` window (default 30 days), merged in
+//! additively so an empty upstream fetch can't clobber prior entries. Upstream
+//! is throttled to once per `CACHE_TTL`; a failed fetch falls back to serving
+//! the existing DB window, erroring only if that window is empty. Dismissed
+//! (`POST /api/feed/dismiss`) and rule-filtered (`RSS_FILTER_RULE`) entries are
+//! stripped before the response goes out.
 
 use std::collections::HashMap;
 use std::sync::{LazyLock, Mutex};
@@ -31,10 +23,8 @@ use crate::state::AppState;
 
 const CACHE_TTL: Duration = Duration::from_secs(300);
 
-// Throttle-only: when a URL was last fetched from upstream, plus the feed's
-// channel title (needed to build a response on a throttled/no-fetch request --
-// the DB window only holds entries, not the channel title). Unbounded per-URL
-// map — in practice one home-feed URL lives here.
+// Throttle state: last-fetch time + channel title per URL (title isn't stored
+// in the DB window, so a throttled request still needs it from here).
 static LAST_FETCH: LazyLock<Mutex<HashMap<String, (Instant, String)>>> =
     LazyLock::new(Default::default);
 
@@ -59,10 +49,8 @@ fn entry_identity(entry: &Value) -> (Option<String>, Option<i64>) {
     (source_id, version)
 }
 
-/// Best-effort parse of a feed entry's raw `published` string (RSS `pubDate` is
-/// RFC 822, Atom `published`/`updated` is RFC 3339) into a timestamp to prune
-/// by. `None` when it doesn't parse either way -- the caller then prunes by
-/// first-fetched time instead (`RSS_CACHE_ENTRY.FETCHED_AT`).
+/// Parse a feed entry's `published` string (RSS is RFC 822, Atom is RFC 3339).
+/// `None` if neither parses -- caller then falls back to `FETCHED_AT`.
 fn parse_published(s: &str) -> Option<NaiveDateTime> {
     chrono::DateTime::parse_from_rfc2822(s)
         .or_else(|_| chrono::DateTime::parse_from_rfc3339(s))
@@ -71,11 +59,8 @@ fn parse_published(s: &str) -> Option<NaiveDateTime> {
 }
 
 /// Build the DB row for a freshly-fetched entry. Dedup key is arxiv
-/// `source_id+version` when the entry has one (a later version is a genuinely
-/// distinct entry, so it must get its own key, not overwrite v1's); otherwise
-/// the entry's link, falling back to its title if even that's blank. `None`
-/// only when the entry has neither an arxiv id, a link, nor a title -- nothing
-/// stable to key it by.
+/// `id+version` when present (so v2 doesn't overwrite v1), else link, else
+/// title. `None` if the entry has none of those to key by.
 fn to_cache_entry(entry: &svc_feed::FeedEntry) -> Option<rss::CacheEntry> {
     let entry_json = serde_json::to_string(entry).ok()?;
     let source_id = entry.arxiv_id.as_deref().map(|id| format!("arxiv:{id}"));
@@ -93,9 +78,8 @@ fn to_cache_entry(entry: &svc_feed::FeedEntry) -> Option<rss::CacheEntry> {
     })
 }
 
-/// Drops entries the user dismissed or that match a filter rule, records each
-/// survivor as seen (`RSS_PAPER_ROOTS`/`RSS_PAPER`), and returns which of them
-/// are already saved to the library — all in one DB connection.
+/// Drops dismissed/rule-hidden entries, records survivors as seen, and
+/// returns which of them are already saved to the library.
 fn annotate_and_filter(state: &AppState, feed_value: &mut Value) -> Vec<String> {
     use linxiv_core::storage::queries::paper;
 
@@ -104,8 +88,7 @@ fn annotate_and_filter(state: &AppState, feed_value: &mut Value) -> Vec<String> 
     };
 
     state.with_conn(|conn| {
-        // One transaction for the whole read+write batch -- avoids up to ~200
-        // individually-committed statements (one per surviving entry) per GET.
+        // One transaction for the whole read+write batch.
         let tx = match conn.transaction() {
             Ok(tx) => tx,
             Err(e) => {
@@ -142,9 +125,8 @@ fn annotate_and_filter(state: &AppState, feed_value: &mut Value) -> Vec<String> 
             }
             !rss::is_hidden(&rules, title, summary, &authors)
         });
-        // Truncate after filtering (not before) so dismissed/rule-hidden entries
-        // don't eat into the 200 the client actually gets to see -- the loader
-        // above pulls up to 500 rows precisely to leave this headroom.
+        // Truncate after filtering, not before, so hidden entries don't eat
+        // into the 200 the client gets to see.
         entries.truncate(200);
 
         // Record each survivor as seen, separately from the (pure) filter above.
@@ -205,6 +187,10 @@ async fn get_feed(state: &AppState, ctx: &ReqCtx<'_>) -> Result<Value, ApiError>
 
     let mut fetch_err = None;
     if due {
+        // Cleanup before fetching, non-fatal (shouldn't fail the request).
+        if let Err(e) = state.with_conn(|conn| rss::prune_dismissed(conn, retention_days)) {
+            eprintln!("[linxiv] feed: prune_dismissed failed: {e}");
+        }
         eprintln!("[linxiv] feed: fetching {url}");
         // data_dir carries the shared .arxiv_ratelimit file (same one arxiv_get uses).
         match svc_feed::fetch_feed(url, &linxiv_core::config::data_dir()).await {
@@ -227,11 +213,8 @@ async fn get_feed(state: &AppState, ctx: &ReqCtx<'_>) -> Result<Value, ApiError>
                     .insert(url.to_string(), (Instant::now(), title.clone()));
             }
             Err(e) => {
-                // No throttle entry written on failure -- matches the old cache's
-                // behavior of retrying on the very next request rather than
-                // waiting out the TTL while upstream is down. Don't bail out here:
-                // fall through and try to serve the persisted window instead; only
-                // error out below if there's nothing cached to fall back to.
+                // No throttle entry on failure, so the next request retries instead
+                // of waiting out the TTL. Fall through to serve the DB window.
                 eprintln!("[linxiv] feed: fetch failed for {url}: {e}");
                 fetch_err = Some(e);
             }
@@ -246,17 +229,14 @@ async fn get_feed(state: &AppState, ctx: &ReqCtx<'_>) -> Result<Value, ApiError>
     }
     let mut result = json!({ "title": title, "entries": entries });
 
-    // Recompute dismiss/rule filtering + saved_arxiv_ids fresh against current DB
-    // state -- the DB-window entries above are unfiltered.
+    // The DB-window entries above are unfiltered; filter fresh against current state.
     let saved_arxiv_ids = annotate_and_filter(state, &mut result);
     result["saved_arxiv_ids"] = serde_json::json!(saved_arxiv_ids);
     Ok(result)
 }
 
-/// `POST /api/feed/dismiss` — hide an entry from the feed going forward.
-/// `permanent: true` blocks the whole paper, every version (REMOVAL_TYPE
-/// 'DOI'); otherwise it dismisses just this exact `version` (REMOVAL_TYPE
-/// 'VER' on that one row, the default) — a later, higher version resurfaces.
+/// `POST /api/feed/dismiss` — hide an entry. `permanent: true` blocks the
+/// whole paper; otherwise dismisses just this `version` (the default).
 fn dismiss(state: &AppState, ctx: &ReqCtx<'_>) -> Result<Value, ApiError> {
     #[derive(Deserialize)]
     struct Body {
@@ -337,9 +317,8 @@ mod tests {
         get_in(&state(), path).await
     }
 
-    /// Like `get`, but against a caller-supplied state — needed to pre-seed the
-    /// DB cache and then observe it survive a real `route()` call, rather than
-    /// each call getting its own throwaway in-memory DB.
+    /// Like `get`, but against a caller-supplied state, so the DB cache can be
+    /// pre-seeded and observed across the call.
     async fn get_in(
         state: &AppState,
         path: &str,
@@ -477,10 +456,7 @@ mod tests {
         mock_server.verify().await;
     }
 
-    /// The bug the caching redesign fixes: arXiv (or any feed) publishing
-    /// nothing new (e.g. over a weekend) must not wipe entries a real earlier
-    /// fetch already persisted -- the additive merge inserts zero new rows and
-    /// the DB-backed window response still includes the earlier entry.
+    /// An empty upstream fetch must not wipe previously-persisted entries.
     #[tokio::test]
     async fn empty_upstream_fetch_does_not_clobber_previously_cached_entries() {
         use wiremock::matchers::method;
@@ -533,8 +509,7 @@ mod tests {
         mock_server.verify().await;
     }
 
-    /// Two successive fetches into the same DB accumulate rather than replace:
-    /// day 1's entry survives once day 2's (distinct) entry is merged in.
+    /// Two successive fetches accumulate rather than replace.
     #[tokio::test]
     async fn successive_fetches_accumulate_additively() {
         use wiremock::matchers::method;

--- a/src/components/settings/EditorPluginSection.tsx
+++ b/src/components/settings/EditorPluginSection.tsx
@@ -20,8 +20,8 @@ function CheckMessage({ check }: { check: UpdateCheck }) {
   if (check.noCompatibleRelease) {
     return (
       <span style={{ color: "var(--color-danger)" }}>
-        No editor release matches this version of linXiv — an app update may be
-        required.
+        No editor release matches this version of linXiv; check the recent
+        releases for more information.
       </span>
     );
   }

--- a/src/components/settings/HomeFeedSection.tsx
+++ b/src/components/settings/HomeFeedSection.tsx
@@ -132,9 +132,12 @@ function FeedFilterRulesSection() {
   );
 }
 
+const DEFAULT_RETENTION_DAYS = 30;
+
 export function HomeFeedSection() {
   const queryClient = useQueryClient();
   const requestRef = useRef(0);
+  const retentionRequestRef = useRef(0);
   const { data: settings, isLoading: settingsLoading, isError: settingsError } = useQuery({
     queryKey: ["settings"],
     queryFn: getSettings,
@@ -178,6 +181,47 @@ export function HomeFeedSection() {
       });
   }
 
+  const savedRetention =
+    typeof settings?.rss_cache_retention_days === "number"
+      ? String(settings.rss_cache_retention_days)
+      : String(DEFAULT_RETENTION_DAYS);
+
+  const [retentionInput, setRetentionInput] = useState("");
+  const [prevSavedRetention, setPrevSavedRetention] = useState<string | null>(null);
+  const [retentionError, setRetentionError] = useState("");
+  if (settings && savedRetention !== prevSavedRetention) {
+    setRetentionInput(savedRetention);
+    setPrevSavedRetention(savedRetention);
+  }
+
+  function handleRetentionBlur() {
+    setRetentionError("");
+    const next = retentionInput.trim();
+    if (next === savedRetention) {
+      setRetentionInput(next);
+      return;
+    }
+    const parsed = Number(next);
+    if (!Number.isInteger(parsed) || parsed <= 0) {
+      setRetentionError("Must be a positive whole number");
+      return;
+    }
+    const thisRequest = ++retentionRequestRef.current;
+    updateSettings({ rss_cache_retention_days: parsed })
+      .then(() => {
+        if (thisRequest === retentionRequestRef.current) {
+          setRetentionInput(String(parsed));
+          queryClient.invalidateQueries({ queryKey: ["home-feed"] });
+        }
+      })
+      .catch(() => {
+        if (thisRequest === retentionRequestRef.current) {
+          setRetentionError("Failed to save");
+          setRetentionInput(savedRetention);
+        }
+      });
+  }
+
   return (
     <div>
       <SettingGroupLabel>Home</SettingGroupLabel>
@@ -212,6 +256,45 @@ export function HomeFeedSection() {
               {error && (
                 <div id="home-feed-url-error" className="text-sm text-danger">
                   {error}
+                </div>
+              )}
+            </div>
+          )}
+        </SettingRow>
+        <SettingRow
+          label="Cache retention (days)"
+          description="How many days of feed entries are kept locally before pruning; permanently dismissed papers are always kept"
+          descriptionId="rss-cache-retention-desc"
+        >
+          {settingsLoading ? (
+            <span className="flex items-center gap-2 text-sm text-muted">
+              <Spinner size={14} /> Loading…
+            </span>
+          ) : settingsError ? (
+            <span className="text-xs text-danger">Could not load settings.</span>
+          ) : (
+            <div className="flex flex-col gap-2">
+              <Input
+                type="number"
+                min={1}
+                value={retentionInput}
+                onChange={(e) => {
+                  setRetentionInput(e.target.value);
+                  setRetentionError("");
+                }}
+                onBlur={handleRetentionBlur}
+                aria-label="Cache retention (days)"
+                aria-describedby={
+                  retentionError
+                    ? "rss-cache-retention-desc rss-cache-retention-error"
+                    : "rss-cache-retention-desc"
+                }
+                aria-invalid={!!retentionError}
+                className="w-24"
+              />
+              {retentionError && (
+                <div id="rss-cache-retention-error" className="text-sm text-danger">
+                  {retentionError}
                 </div>
               )}
             </div>

--- a/src/components/settings/SharingSection.tsx
+++ b/src/components/settings/SharingSection.tsx
@@ -16,7 +16,7 @@ import { Spinner } from "../ui/spinner";
 import { SettingGroup, SettingGroupLabel, SettingRow } from "./SettingRow";
 
 function errText(e: unknown): string {
-  return e instanceof ApiError ? e.message : "Something went wrong";
+  return e instanceof ApiError ? e.message : "Unexpected sharing error";
 }
 
 function summaryLine(s: SharedSummary): string {

--- a/src/components/settings/TrashSection.tsx
+++ b/src/components/settings/TrashSection.tsx
@@ -233,7 +233,7 @@ export function TrashSection() {
       }
     } catch (e) {
       console.error(e);
-      setActionError(`Could not restore "${paper.title}". Please try again.`);
+      setActionError(`Failed to restore "${paper.title}".`);
     } finally {
       setRestoringId(null);
     }
@@ -250,7 +250,7 @@ export function TrashSection() {
       setProjectPrompt(null);
     } catch (e) {
       console.error(e);
-      setRemoveError("Failed to remove from projects. Please try again.");
+      setRemoveError("Failed to remove from projects.");
     } finally {
       setRemoving(false);
     }
@@ -268,7 +268,7 @@ export function TrashSection() {
       await qc.invalidateQueries({ queryKey: ["papers"] });
     } catch (e) {
       console.error(e);
-      setActionError("Could not permanently delete the paper. Please try again.");
+      setActionError("Failed to permanently delete the paper.");
     } finally {
       setDeletingId(null);
     }
@@ -283,7 +283,7 @@ export function TrashSection() {
       await qc.invalidateQueries({ queryKey: ["projects"] });
     } catch (e) {
       console.error(e);
-      setActionError("Could not restore the project. Please try again.");
+      setActionError("Failed to restore the project.");
     } finally {
       setRestoringProjectId(null);
     }
@@ -298,7 +298,7 @@ export function TrashSection() {
       await qc.invalidateQueries({ queryKey: ["projects"] });
     } catch (e) {
       console.error(e);
-      setActionError("Could not permanently delete the project. Please try again.");
+      setActionError("Failed to permanently delete the project.");
     } finally {
       setDeletingProjectId(null);
     }

--- a/src/pages/EditorPage.tsx
+++ b/src/pages/EditorPage.tsx
@@ -87,8 +87,8 @@ function InstallCard({
         <h2 className="text-base font-semibold text-text">Install the LaTeX editor</h2>
         {check?.noCompatibleRelease ? (
           <p className="text-sm text-muted mt-2">
-            No editor release matches this version of linXiv — an app update may
-            be required before the editor can be installed.
+            No editor release matches this version of linXiv; check the recent
+            releases for more information.
           </p>
         ) : (
           <p className="text-sm text-muted mt-2">
@@ -455,7 +455,7 @@ export default function EditorPage() {
         dirtyRef.current = false; // fresh guest starts clean
         setProtocolWarning(
           protocol != null && !isSupportedBridgeProtocol(protocol)
-            ? `The editor reports bridge protocol ${protocol}, which this version of linXiv doesn't support — some integration features may misbehave. Check for app/editor updates.`
+            ? `The editor reports bridge protocol ${protocol}, which this version of linXiv doesn't support; if features misbehave, check the linXiv GitHub for more information.`
             : null
         );
         const pid = pendingOpenRef.current ?? noteIdRef.current;

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -7,6 +7,7 @@ import { fetchArxiv } from "../api/search";
 import { getPaperPdfUrl } from "../api/papers";
 import { Spinner } from "../components/ui/spinner";
 import { Button } from "../components/ui/button";
+import { Dialog } from "../components/ui/dialog";
 import { PaperCard } from "../components/papers/PaperCard";
 import { Card, MonoLabel, SectionTitle } from "../components/ui/card";
 import type { FeedEntry, Paper, SearchResult } from "../types/api";
@@ -68,6 +69,7 @@ function FeedRow({
   const [saveState, setSaveState] = useState<"idle" | "saving" | "saved" | "error">("idle");
   const [dismissing, setDismissing] = useState(false);
   const [dismissError, setDismissError] = useState(false);
+  const [confirmPermanent, setConfirmPermanent] = useState(false);
 
   async function handleSave(arxivId: string) {
     setSaveState("saving");
@@ -104,11 +106,11 @@ function FeedRow({
     navigate("/pdf-preview", { state: { result, isSaved: alreadySaved ?? false } });
   }
 
-  async function handleDismiss(arxivId: string, version: number) {
+  async function handleDismiss(arxivId: string, version: number, permanent = false) {
     setDismissing(true);
     setDismissError(false);
     try {
-      await dismissFeedEntry(arxivId, version);
+      await dismissFeedEntry(arxivId, version, permanent);
       onDismissed();
     } catch (err) {
       console.error(err);
@@ -173,16 +175,28 @@ function FeedRow({
             )}
           </div>
           {entry.arxiv_id !== null && entry.version !== null && (
-            <button
-              type="button"
-              aria-label="Dismiss"
-              title="Dismiss"
-              disabled={dismissing}
-              className="border-l border-border pl-3 text-muted hover:text-text transition-colors disabled:opacity-50"
-              onClick={() => handleDismiss(entry.arxiv_id as string, entry.version as number)}
-            >
-              ✕
-            </button>
+            <div className="flex items-center gap-1.5 border-l border-border pl-3">
+              <button
+                type="button"
+                aria-label="Dismiss"
+                title="Dismiss this version"
+                disabled={dismissing}
+                className="text-muted hover:text-text transition-colors disabled:opacity-50"
+                onClick={() => handleDismiss(entry.arxiv_id as string, entry.version as number)}
+              >
+                ✕
+              </button>
+              <button
+                type="button"
+                aria-label="Never show this paper again"
+                title="Never show this paper again"
+                disabled={dismissing}
+                className="text-muted hover:text-[var(--color-danger)] transition-colors disabled:opacity-50"
+                onClick={() => setConfirmPermanent(true)}
+              >
+                ⛔
+              </button>
+            </div>
           )}
         </div>
         {saveState === "error" && (
@@ -196,6 +210,32 @@ function FeedRow({
           </p>
         )}
       </div>
+      <Dialog
+        open={confirmPermanent}
+        onClose={() => setConfirmPermanent(false)}
+        title="Never show this paper again?"
+      >
+        <p className="text-sm text-muted mb-4">
+          This hides every version of this paper from the home feed going forward.
+        </p>
+        <div className="flex justify-end gap-2">
+          <Button variant="ghost" size="sm" onClick={() => setConfirmPermanent(false)}>
+            Cancel
+          </Button>
+          <Button
+            variant="danger"
+            size="sm"
+            onClick={() => {
+              setConfirmPermanent(false);
+              if (entry.arxiv_id !== null && entry.version !== null) {
+                void handleDismiss(entry.arxiv_id, entry.version, true);
+              }
+            }}
+          >
+            Never show again
+          </Button>
+        </div>
+      </Dialog>
     </div>
   );
 }

--- a/src/pages/PaperDetailPage.tsx
+++ b/src/pages/PaperDetailPage.tsx
@@ -695,7 +695,7 @@ export default function PaperDetailPage() {
                   >
                     {deleteNoteMutation.error instanceof Error
                       ? deleteNoteMutation.error.message
-                      : "Couldn't delete the note. Please try again."}
+                      : "Failed to delete the note."}
                   </p>
                 )}
 
@@ -766,7 +766,7 @@ export default function PaperDetailPage() {
                     className="text-sm text-center"
                     style={{ color: "var(--color-danger)" }}
                   >
-                    Couldn't delete the annotation. Please try again.
+                    Failed to delete the annotation.
                   </p>
                 )}
               </TabsContent>

--- a/src/pages/SharePage.tsx
+++ b/src/pages/SharePage.tsx
@@ -40,7 +40,7 @@ import { Spinner } from "../components/ui/spinner";
 type ShareRole = "Hoster" | "Reader";
 
 function errText(e: unknown): string {
-  return e instanceof ApiError ? e.message : "Something went wrong";
+  return e instanceof ApiError ? e.message : "Unexpected sharing error";
 }
 
 function RolePill({ role }: { role: ShareRole }) {
@@ -801,7 +801,7 @@ function ShareProjectDialog({ open, onClose }: { open: boolean; onClose: () => v
         <p className="text-xs" style={{ color: "var(--color-muted)" }}>
           {mode === "e2ee"
             ? "Publish an encrypted copy of the project. There is no ticket — invite each member from the share's settings using their member code."
-            : "Generate a ticket, then paste it in linXiv on another computer to send a read-only copy of the project — papers, notes and tags travel with it."}
+            : "Generate a ticket, then paste it in linXiv on another computer to send a read-only copy of the project."}
         </p>
         <div className="flex items-center gap-2">
           <OptionSelect

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -113,6 +113,7 @@ export interface Settings {
   search_history_max?: number;
   tex_rendering_enabled?: boolean;
   home_feed_url?: string;
+  rss_cache_retention_days?: number;
   [key: string]: unknown;
 }
 


### PR DESCRIPTION
feed: add permanent dismiss action to home feed rows

Persist RSS feed cache to DB instead of in-memory last-response cache

Rewriting user guidance text to be more consistent

fix(rss): address adversarial review findings on the cache redesign

- Timestamp format mismatch  broke same-day ordering/window
- load_cache_entries had no LIMIT, now capped at 500 rows.
- Permanently-dismissed entries were exempted from window/prune for no functional benefit (removed the exemption so they age out like any other row; the dismissal itself still persists in RSS_PAPER_ROOTS.
- A failed upstream fetch returned an error instead of falling back to the persisted window, only errors when the window is empty too, should still log to stdout.
- annotate_and_filter truncated to 200 entries before dismiss/rule filtering
- Retention window/prune were keyed on PUBLISHED_AT,
- merge_cache_entries did one commit per row instead of batching in a transaction.
- Several doc comments (config.rs, CacheEntry) still described the removed permanent-dismiss exemption.
- Dropped a redundant secondary index already covered