### PR TITLE
Prevent startup hang from duplicate desktop instances

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3941,6 +3941,7 @@ dependencies = [
  "tauri-plugin-fs",
  "tauri-plugin-opener",
  "tauri-plugin-process",
+ "tauri-plugin-single-instance",
  "tauri-plugin-texbrain",
  "tauri-plugin-updater",
  "tempfile",
@@ -7355,6 +7356,22 @@ checksum = "d55511a7bf6cd70c8767b02c97bf8134fa434daf3926cfc1be0a0f94132d165a"
 dependencies = [
  "tauri",
  "tauri-plugin",
+]
+
+[[package]]
+name = "tauri-plugin-single-instance"
+version = "2.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3214becf9ef5783c0ae99a3bb25adf5353a7a16ebf53e74b909e29205735c6c"
+dependencies = [
+ "serde",
+ "serde_json",
+ "tauri",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "windows-sys 0.60.2",
+ "zbus 5.15.0",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -103,6 +103,9 @@ wiremock = "0.6"
 [target.'cfg(windows)'.dependencies]
 winreg = "0.52"
 
+[target.'cfg(any(target_os = "macos", windows, target_os = "linux"))'.dependencies]
+tauri-plugin-single-instance = "2"
+
 [profile.release]
 codegen-units = 1
 lto = true

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -131,6 +131,17 @@ fn passphrase_dek() -> Option<[u8; 32]> {
 
 fn main() {
     tauri::Builder::default()
+        // Prevent a second linXiv process from opening shared resources such as
+        // the P2P blob database. Focus the existing window instead.
+        .plugin(tauri_plugin_single_instance::init(
+            |app, _args, _cwd| {
+                if let Some(window) = app.get_webview_window("main") {
+                    let _ = window.unminimize();
+                    let _ = window.show();
+                    let _ = window.set_focus();
+                }
+             },
+        ))
         // linxiv:// serves PDF bytes to the webview and bridges the graph iframe's
         // /api/* GETs — the in-process replacement for what invoke() can't stream.
         .register_asynchronous_uri_scheme_protocol(protocol::SCHEME, protocol::handler)


### PR DESCRIPTION
## Summary

- add Tauri's single-instance plugin
- register it before the remaining plugins and application setup
- restore and focus the existing main window when linXiv is launched again
- prevent duplicate processes from reopening the same P2P/Beelay storage

## Problem

Launching linXiv while another desktop instance is already running can cause the second process to hang during startup on Windows.

Instead of exiting cleanly or focusing the existing window, the second process becomes unresponsive and Windows reports an `AppHangB1` event.

## Reproduction before this change

1. Start linXiv and leave it running:

   ```bash
   npm run tauri dev
   ```

2. Open another terminal in the repository root.

3. Launch the compiled executable directly:

   ```bash
   ./src-tauri/target/debug/linxiv-app.exe
   ```

4. Observe that the second process remains stuck during startup and Windows eventually reports that linXiv is not responding.

Running processes can be checked with:

```bash
tasklist | grep -i linxiv
```

## Diagnosis

The startup path was narrowed down through the following checks:

1. Browser development mode worked correctly, indicating that the React frontend, Rust core, API routing, SQLite access, and existing library data were functional.

2. Temporarily skipping P2P initialization allowed the native Tauri application to open normally, isolating the hang to the P2P startup path.

3. Windows keychain access completed successfully in approximately 5 ms, so DEK retrieval was not the blocking operation.

4. Additional startup checkpoints confirmed that all of the following completed successfully:

   - device identity loading
   - authentication identity loading
   - Keyhive state loading
   - iroh endpoint binding

5. Startup then stalled while preparing the disk-backed Beelay state and blob store.

6. Running with a fresh data directory completed the entire P2P initialization successfully:

   ```bash
   LINXIV_DATA_DIR='C:/dev/linxiv-debug-data' npm run tauri dev
   ```

7. While the first linXiv instance was still running, attempting to copy the existing P2P data failed on:

   ```text
   %APPDATA%\com.linxiv.app\p2p\beelay\blobs\blobs.db
   ```

   with:

   ```text
   Device or resource busy
   ```

8. `tasklist` confirmed that an existing `linxiv-app.exe` process still owned the resource. After terminating that process, linXiv started normally using the original data directory.

These results are consistent with the second process waiting while trying to open the same disk-backed P2P/Beelay blob store already owned by the first instance.

Because P2P initialization currently runs synchronously during Tauri setup, this wait prevents the desktop event loop from becoming responsive and causes the application hang.

## Solution

Register Tauri's single-instance plugin before the remaining plugins and application setup.

When linXiv is launched while another instance is already running, the second process now:

1. detects the existing instance
2. restores the existing main window if it is minimized
3. shows and focuses the existing window
4. exits cleanly before opening shared database or P2P resources

## Behavior change

linXiv now runs as a single desktop instance per user/application identifier.

Launching linXiv again focuses the existing window instead of starting another independent desktop process.

## Validation

Tested on Windows:

1. Started the first instance:

   ```bash
   npm run tauri dev
   ```

2. Left the application running and launched the executable again:

   ```bash
   ./src-tauri/target/debug/linxiv-app.exe
   ```

3. Confirmed that:

   - no second window was created
   - the existing window was restored and focused
   - the second process exited immediately with code `0`
   - only one `linxiv-app.exe` process remained
   - the previous P2P/Beelay startup hang did not occur

Verification commands:

```bash
echo "second instance exit code: $?"
tasklist | grep -i linxiv
```