### PR TITLE
core hardening

### DIFF
--- a/src-tauri/crates/core/src/config.rs
+++ b/src-tauri/crates/core/src/config.rs
@@ -65,24 +65,30 @@ pub fn vault_dir() -> PathBuf {
     data_dir().join("vaults")
 }
 
-/// OpenAlex polite-pool address (`OPENALEX_MAILTO`); CR/LF are stripped downstream
-/// in `openalex::user_agent`, matching `OpenAlexSource`.
+/// OpenAlex polite-pool address (`OPENALEX_MAILTO`).
+pub fn openalex_mailto() -> String {
+    mailto_setting("OPENALEX_MAILTO")
+}
+
+/// CrossRef polite-pool address (`CROSSREF_MAILTO`).
+pub fn crossref_mailto() -> String {
+    mailto_setting("CROSSREF_MAILTO")
+}
+
+/// A polite-pool address; CR/LF are stripped downstream in
+/// `sources::http::polite_user_agent`.
 ///
 /// The env var wins; a user-settings override is the fallback. Only the app sets the
 /// env var (`PATCH /api/env`), and it sets it on its own process — so without this
 /// fallback the CLI and MCP server, which run as separate processes, read the value
-/// as empty no matter what was configured, and `settings update OPENALEX_MAILTO`
-/// wrote a key nothing ever read.
-pub fn openalex_mailto() -> String {
-    match std::env::var("OPENALEX_MAILTO") {
+/// as empty no matter what was configured, and `settings update <KEY>` wrote a key
+/// nothing ever read.
+fn mailto_setting(key: &str) -> String {
+    match std::env::var(key) {
         Ok(v) if !v.is_empty() => v,
         _ => UserSettings::load()
             .ok()
-            .and_then(|s| {
-                s.get("OPENALEX_MAILTO")
-                    .and_then(Value::as_str)
-                    .map(String::from)
-            })
+            .and_then(|s| s.get(key).and_then(Value::as_str).map(String::from))
             .unwrap_or_default(),
     }
 }

--- a/src-tauri/crates/core/src/formats.rs
+++ b/src-tauri/crates/core/src/formats.rs
@@ -338,7 +338,7 @@ mod tests {
             source: None,
             full_text: None,
             downloaded_source: false,
-            source_fk: None,
+            source_fk: 1,
         }
     }
 

--- a/src-tauri/crates/core/src/lib.rs
+++ b/src-tauri/crates/core/src/lib.rs
@@ -7,4 +7,6 @@ pub mod service;
 pub mod sources;
 pub mod storage;
 #[cfg(test)]
+pub(crate) mod test_support;
+#[cfg(test)]
 mod ts_bindings;

--- a/src-tauri/crates/core/src/models.rs
+++ b/src-tauri/crates/core/src/models.rs
@@ -237,8 +237,9 @@ pub struct PaperDetails {
     pub full_text: Option<String>,
     #[serde(default)]
     pub downloaded_source: bool,
-    #[serde(default)]
-    pub source_fk: Option<i64>,
+    /// Never null: PAPER.SOURCE_FK is NOT NULL and every reader selects from
+    /// the `papers` view.
+    pub source_fk: i64,
 }
 
 /// Aggregate view of a paper across all stored versions (PaperDetailsAll).
@@ -395,7 +396,9 @@ pub struct ProjectDetails {
 // `source_ids` and renders `color` as `color_hex`.
 #[derive(Debug, Clone, Serialize, TS)]
 pub struct ProjectOut {
-    pub id: Option<i64>,
+    /// Never null: `ProjectDetails.id` is optional only because that struct
+    /// doubles as the pre-insert shape; `to_out` refuses a row without an id.
+    pub id: i64,
     pub name: String,
     pub description: String,
     pub color_hex: Option<String>,
@@ -415,8 +418,9 @@ pub struct ProjectOut {
 
 #[derive(Debug, Clone, Serialize, Deserialize, TS)]
 pub struct NoteDetails {
+    /// NOTE_SK is the primary key; a read row always has one.
     #[serde(rename = "id")]
-    pub note_id: Option<i64>,
+    pub note_id: i64,
     /// Stable identity (uuid v4) surviving export/import + share.
     #[serde(default)]
     pub uuid: String,
@@ -761,7 +765,7 @@ mod tests {
     #[test]
     fn note_id_field_serializes_as_id() {
         let n = NoteDetails {
-            note_id: Some(7),
+            note_id: 7,
             uuid: "u-7".into(),
             source_fk: 1,
             paper_id_fk: None,
@@ -779,7 +783,7 @@ mod tests {
     #[test]
     fn project_out_wire_shape_is_pinned() {
         let p = ProjectOut {
-            id: Some(5),
+            id: 5,
             name: "n".into(),
             description: String::new(),
             color_hex: Some("#00ff00".into()),

--- a/src-tauri/crates/core/src/service/author.rs
+++ b/src-tauri/crates/core/src/service/author.rs
@@ -233,7 +233,7 @@ pub fn count_paper_links(conn: &Connection, author_id: i64) -> Result<i64> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::storage::{db::open_in_memory, init_db};
+    use crate::test_support::db;
     use rusqlite::params;
 
     // One active paper root, two linked authors. Returns (paper_id, bob, alice).
@@ -277,15 +277,9 @@ mod tests {
         (pid, bob, alice)
     }
 
-    fn mem() -> Connection {
-        let conn = open_in_memory().unwrap();
-        init_db(&conn).unwrap();
-        conn
-    }
-
     #[test]
     fn get_resolves_by_id_then_orcid() {
-        let conn = mem();
+        let conn = db();
         let (_pid, bob, alice) = seed(&conn);
 
         // by id
@@ -339,7 +333,7 @@ mod tests {
 
     #[test]
     fn get_many_filters() {
-        let conn = mem();
+        let conn = db();
         let (pid, bob, _alice) = seed(&conn);
 
         // all, ordered by full name -> Alice, Bob
@@ -409,7 +403,7 @@ mod tests {
 
     #[test]
     fn create_update_delete() {
-        let mut conn = mem();
+        let mut conn = db();
         let id = create(
             &conn,
             &AuthorIn {
@@ -496,7 +490,7 @@ mod tests {
 
     #[test]
     fn merge_repoints_papers_and_removes_duplicate() {
-        let mut conn = mem();
+        let mut conn = db();
         // Shared paper (both authors) + one paper each, to exercise dedupe.
         let (shared, bob, alice) = seed(&conn);
         conn.execute("INSERT INTO PAPER_ROOTS (SOURCE_ID) VALUES ('arxiv:2')", [])
@@ -553,7 +547,7 @@ mod tests {
 
     #[test]
     fn links_previews_and_counts() {
-        let conn = mem();
+        let conn = db();
         let (pid, bob, _alice) = seed(&conn);
 
         assert_eq!(count_paper_links(&conn, bob).unwrap(), 1);
@@ -576,7 +570,7 @@ mod tests {
     /// Wire-shape pin: the composite is the flattened author + paper_count + papers.
     #[test]
     fn author_with_papers_wire_shape() {
-        let conn = mem();
+        let conn = db();
         let (_pid, bob, _alice) = seed(&conn);
         let v = serde_json::to_value(get_with_papers(&conn, bob).unwrap().unwrap()).unwrap();
         let keys: Vec<&str> = v.as_object().unwrap().keys().map(String::as_str).collect();
@@ -606,7 +600,7 @@ mod tests {
 
     #[test]
     fn delete_rejects_missing_and_still_linked_authors() {
-        let conn = mem();
+        let conn = db();
         let (pid, bob, _alice) = seed(&conn);
 
         assert_eq!(
@@ -623,7 +617,7 @@ mod tests {
 
     #[test]
     fn update_fields_rejects_missing_author_and_empty_patch() {
-        let conn = mem();
+        let conn = db();
         let (_pid, bob, _alice) = seed(&conn);
 
         let e = update_fields(&conn, 99_999, Some("X"), None, None, None).unwrap_err();

--- a/src-tauri/crates/core/src/service/editor_project.rs
+++ b/src-tauri/crates/core/src/service/editor_project.rs
@@ -325,14 +325,7 @@ pub fn delete_note(conn: &rusqlite::Connection, vault_dir: &Path, note_id: i64) 
 mod tests {
     use super::*;
     use crate::error::CoreError;
-    use crate::storage::db::open_in_memory;
-    use crate::storage::init_db;
-
-    fn db() -> rusqlite::Connection {
-        let conn = open_in_memory().unwrap();
-        init_db(&conn).unwrap();
-        conn
-    }
+    use crate::test_support::db;
 
     #[test]
     fn parse_frontmatter_variants() {

--- a/src-tauri/crates/core/src/service/editor_project.rs
+++ b/src-tauri/crates/core/src/service/editor_project.rs
@@ -106,7 +106,7 @@ fn is_editor_project(meta: &HashMap<String, String>) -> bool {
 #[derive(Debug, Clone, Serialize, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct EditorProjectSummary {
-    pub note_id: Option<i64>,
+    pub note_id: i64,
     pub project_name: String,
     pub main_file: String,
     pub source_fk: i64,
@@ -121,7 +121,7 @@ fn to_summary(note: &NoteDetails, meta: &HashMap<String, String>) -> EditorProje
         .filter(|s| !s.is_empty())
         .cloned()
         .or_else(|| Some(note.title.clone()).filter(|s| !s.is_empty()))
-        .unwrap_or_else(|| format!("project {}", note.note_id.unwrap_or_default()));
+        .unwrap_or_else(|| format!("project {}", note.note_id));
     let main_file = meta
         .get("mainFile")
         .filter(|s| !s.is_empty())
@@ -459,8 +459,7 @@ mod tests {
             .into_iter()
             .find(|n| n.title == "plain")
             .unwrap()
-            .note_id
-            .unwrap();
+            .note_id;
         let stray = vault.path().join(format!("note_{plain_id}"));
         std::fs::create_dir_all(&stray).unwrap();
 
@@ -564,8 +563,8 @@ mod tests {
             .into_iter()
             .find(|n| n.title == "plain")
             .unwrap();
-        assert!(get_meta(&conn, plain.note_id.unwrap()).unwrap().is_none());
-        assert!(get_doc(&conn, Path::new("/nope"), plain.note_id.unwrap())
+        assert!(get_meta(&conn, plain.note_id).unwrap().is_none());
+        assert!(get_doc(&conn, Path::new("/nope"), plain.note_id)
             .unwrap()
             .is_none());
     }

--- a/src-tauri/crates/core/src/service/export_import.rs
+++ b/src-tauri/crates/core/src/service/export_import.rs
@@ -739,14 +739,8 @@ pub fn commit_import(
 mod tests {
     use super::*;
     use crate::models::{AnnotationIn, Status};
-    use crate::storage::{self, db};
+    use crate::test_support::db;
     use chrono::NaiveDate;
-
-    fn mem() -> Connection {
-        let conn = db::open_in_memory().unwrap();
-        storage::init_db(&conn).unwrap();
-        conn
-    }
 
     fn meta(source_id: &str, version: i64, title: &str, tags: &[&str]) -> PaperMetadata {
         PaperMetadata {
@@ -812,7 +806,7 @@ mod tests {
 
     #[test]
     fn build_and_commit_round_trip_annotations() {
-        let mut conn = mem();
+        let mut conn = db();
         let tmp = tempfile::tempdir().unwrap();
 
         // Seed a paper + project + a project-scoped annotation on it.
@@ -849,7 +843,7 @@ mod tests {
         assert_eq!(exported_uuid.len(), 36);
 
         // Commit into a fresh DB and confirm the annotation lands project-scoped.
-        let mut conn2 = mem();
+        let mut conn2 = db();
         let new_pid =
             commit_from_manifest(&mut conn2, &m, &[], OnConflict::Merge, tmp.path()).unwrap();
         let anns = annotation::get_many(
@@ -868,7 +862,7 @@ mod tests {
 
     #[test]
     fn build_manifest_round_trips_project_papers_notes_and_pdfs() {
-        let mut conn = mem();
+        let mut conn = db();
         let tmp = tempfile::tempdir().unwrap();
         let pdf_dir = tmp.path();
 
@@ -935,7 +929,7 @@ mod tests {
 
     #[test]
     fn build_manifest_missing_project_is_typed_not_found() {
-        let conn = mem();
+        let conn = db();
         let tmp = tempfile::tempdir().unwrap();
         assert!(matches!(
             build_manifest(&conn, 999, false, tmp.path()).unwrap_err(),
@@ -966,7 +960,7 @@ mod tests {
 
     #[test]
     fn commit_creates_project_links_papers_notes_and_writes_pdf() {
-        let mut conn = mem();
+        let mut conn = db();
         let tmp = tempfile::tempdir().unwrap();
         let pdf_dir = tmp.path();
 
@@ -1049,7 +1043,7 @@ mod tests {
 
         // MERGE: pre-existing paper keeps its stored title, still gets linked.
         {
-            let mut conn = mem();
+            let mut conn = db();
             paper::save_paper_metadata(&mut conn, &meta("arxiv:1", 1, "Stored Title", &[]), None)
                 .unwrap();
             let pid =
@@ -1081,7 +1075,7 @@ mod tests {
         }
         // OVERWRITE: stored paper is repaired to the archive's title.
         {
-            let mut conn = mem();
+            let mut conn = db();
             paper::save_paper_metadata(&mut conn, &meta("arxiv:1", 1, "Stored Title", &[]), None)
                 .unwrap();
             commit_from_manifest(&mut conn, &manifest, &[], OnConflict::Overwrite, tmp.path())
@@ -1104,7 +1098,7 @@ mod tests {
 
     #[test]
     fn commit_restores_soft_deleted_paper_on_merge() {
-        let mut conn = mem();
+        let mut conn = db();
         let tmp = tempfile::tempdir().unwrap();
         paper::save_paper_metadata(&mut conn, &meta("arxiv:1", 1, "T", &[]), None).unwrap();
         paper::delete(
@@ -1127,7 +1121,7 @@ mod tests {
 
     #[test]
     fn commit_rolls_back_project_when_a_paper_cannot_be_linked() {
-        let mut conn = mem();
+        let mut conn = db();
         let tmp = tempfile::tempdir().unwrap();
         // Whitespace in the source_id: it's saved verbatim, but add_papers trims it,
         // so the membership lookup misses -> link fails -> whole project rolled back.
@@ -1164,7 +1158,7 @@ mod tests {
 
     #[test]
     fn import_pdfs_skips_unknown_version_and_removes_file() {
-        let mut conn = mem();
+        let mut conn = db();
         let tmp = tempfile::tempdir().unwrap();
         let pdf_dir = tmp.path();
         paper::save_paper_metadata(&mut conn, &meta("arxiv:1", 1, "T", &[]), None).unwrap();
@@ -1199,7 +1193,7 @@ mod tests {
 
     #[test]
     fn zip_export_then_import_round_trips_to_a_fresh_db() {
-        let mut conn = mem();
+        let mut conn = db();
         let tmp = tempfile::tempdir().unwrap();
         let export_pdf_dir = tmp.path().join("export_pdfs");
         std::fs::create_dir_all(&export_pdf_dir).unwrap();
@@ -1262,7 +1256,7 @@ mod tests {
         assert!(preview.has_pdfs);
 
         // Commit into a FRESH db + fresh pdf dir.
-        let mut conn2 = mem();
+        let mut conn2 = db();
         let import_pdf_dir = tmp.path().join("import_pdfs");
         let new_pid =
             commit_import(&mut conn2, &written, OnConflict::Merge, &import_pdf_dir).unwrap();
@@ -1324,7 +1318,7 @@ mod tests {
 
     #[test]
     fn build_and_commit_round_trip_author_orcids() {
-        let mut conn = mem();
+        let mut conn = db();
         let tmp = tempfile::tempdir().unwrap();
 
         let mut m = meta("arxiv:1", 1, "P", &[]);
@@ -1352,7 +1346,7 @@ mod tests {
         );
 
         // Commit into a fresh DB and confirm AUTHOR_ORCID lands (fill-if-null).
-        let mut conn2 = mem();
+        let mut conn2 = db();
         commit_from_manifest(&mut conn2, &manifest, &[], OnConflict::Merge, tmp.path()).unwrap();
         fn orcid(conn: &Connection, name: &str) -> Option<String> {
             conn.query_row(
@@ -1368,7 +1362,7 @@ mod tests {
 
     #[test]
     fn commit_merge_unions_tags_onto_existing_paper() {
-        let mut conn = mem();
+        let mut conn = db();
         let tmp = tempfile::tempdir().unwrap();
 
         // Pre-existing paper carries tag A.
@@ -1444,7 +1438,7 @@ mod tests {
 
     #[test]
     fn commit_adopts_valid_share_id() {
-        let mut conn = mem();
+        let mut conn = db();
         let tmp = tempfile::tempdir().unwrap();
 
         let share_id = "3f2b8c1a-9d4e-4f6a-8b2c-1d5e7f9a0b3c";
@@ -1471,7 +1465,7 @@ mod tests {
 
     #[test]
     fn commit_rejects_invalid_share_id() {
-        let mut conn = mem();
+        let mut conn = db();
         let tmp = tempfile::tempdir().unwrap();
 
         // Traversal, absolute, and dotfile share_ids must NOT be adopted.
@@ -1502,7 +1496,7 @@ mod tests {
 
     #[test]
     fn commit_rejects_duplicate_share_id() {
-        let mut conn = mem();
+        let mut conn = db();
         let tmp = tempfile::tempdir().unwrap();
 
         let share_id = "7a1c4e2d-6b3f-4a8e-9c0d-2e5f7a9b1c4d";

--- a/src-tauri/crates/core/src/service/paper.rs
+++ b/src-tauri/crates/core/src/service/paper.rs
@@ -759,7 +759,7 @@ pub fn full_text_backfill_count(conn: &Connection) -> Result<i64> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::storage::{db::open_in_memory, init_db};
+    use crate::test_support::db;
 
     fn meta(source_id: &str, version: i64, category: &str, tags: &[&str]) -> PaperMetadata {
         PaperMetadata {
@@ -782,17 +782,11 @@ mod tests {
         }
     }
 
-    fn mem() -> Connection {
-        let conn = open_in_memory().unwrap();
-        init_db(&conn).unwrap();
-        conn
-    }
-
     /// The fail-if-absent half of the pair every Note/Annotation consumer shares:
     /// resolving an unknown paper errors instead of creating a root.
     #[test]
     fn resolve_source_fk_fails_without_creating_a_root() {
-        let mut conn = mem();
+        let mut conn = db();
         let err = resolve_source_fk(&conn, "arxiv:404").unwrap_err();
         assert_eq!(err.http_status(), 404);
         assert!(store::get_paper_root(&conn, "arxiv:404").unwrap().is_none());
@@ -806,7 +800,7 @@ mod tests {
     /// namespaced or not — the CLI used to assume `arxiv:` and lost DOI/BibTeX rows.
     #[test]
     fn canonical_source_id_tries_verbatim_then_each_namespace() {
-        let mut conn = mem();
+        let mut conn = db();
         for sid in ["arxiv:2204.12985", "doi:10.1000/beta", "10.1000/alpha"] {
             ensure_paper_root(&mut conn, sid).unwrap();
         }
@@ -864,7 +858,7 @@ mod tests {
 
     #[test]
     fn get_dispatch_priority_and_version_handling() {
-        let mut conn = mem();
+        let mut conn = db();
         let (fk, v1, v2) = seed_two_versions(&mut conn);
 
         // source_fk -> latest version.
@@ -956,7 +950,7 @@ mod tests {
 
     #[test]
     fn get_all_aggregates_across_versions_each_dispatch() {
-        let mut conn = mem();
+        let mut conn = db();
         let (fk, v1, _v2) = seed_two_versions(&mut conn);
 
         for key in [
@@ -999,7 +993,7 @@ mod tests {
 
     #[test]
     fn get_many_filters() {
-        let mut conn = mem();
+        let mut conn = db();
         save_paper_metadata(&mut conn, &meta("arxiv:A", 1, "cs.LG", &["ml"]), None).unwrap();
         save_paper_metadata(&mut conn, &meta("arxiv:B", 1, "math.CO", &["theory"]), None).unwrap();
         let fk_a = ensure_paper_root(&mut conn, "arxiv:A").unwrap();
@@ -1080,7 +1074,7 @@ mod tests {
 
     #[test]
     fn upsert_roundtrip_and_categories_and_by_tag() {
-        let mut conn = mem();
+        let mut conn = db();
         let p = PaperIn {
             title: "Manual".into(),
             published: NaiveDate::from_ymd_opt(2024, 5, 1).unwrap(),
@@ -1126,7 +1120,7 @@ mod tests {
 
     #[test]
     fn get_papers_by_tag_tiebreaks_same_date_by_paper_id_desc() {
-        let mut conn = mem();
+        let mut conn = db();
         // Two papers share the same published date (version 1 -> 2024-01-01) and tag.
         save_paper_metadata(&mut conn, &meta("arxiv:A", 1, "cs.LG", &["shared"]), None).unwrap();
         save_paper_metadata(&mut conn, &meta("arxiv:B", 1, "cs.LG", &["shared"]), None).unwrap();
@@ -1142,7 +1136,7 @@ mod tests {
 
     #[test]
     fn require_trashed_rejects_active_and_missing_papers() {
-        let mut conn = mem();
+        let mut conn = db();
         let (fk, _v1, _v2) = seed_two_versions(&mut conn);
         // Active (never-trashed) and unknown papers both 404 out of trash-only ops.
         assert_eq!(
@@ -1168,7 +1162,7 @@ mod tests {
 
     #[test]
     fn delete_restore_hard_delete_resolve_via_keys() {
-        let mut conn = mem();
+        let mut conn = db();
         let (fk, v1, _v2) = seed_two_versions(&mut conn);
         // Link to a project so restore returns its membership.
         conn.execute(
@@ -1231,7 +1225,7 @@ mod tests {
 
     #[test]
     fn pdf_and_fulltext_setters() {
-        let mut conn = mem();
+        let mut conn = db();
         save_paper_metadata(&mut conn, &meta("arxiv:p", 1, "cs.LG", &[]), None).unwrap();
 
         set_has_pdf(&conn, "arxiv:p", 1, true).unwrap();
@@ -1285,7 +1279,7 @@ mod tests {
     #[test]
     fn set_full_text_feeds_search_full_text() {
         use crate::storage::queries::search::search_full_text;
-        let mut conn = mem();
+        let mut conn = db();
         save_paper_metadata(&mut conn, &meta("arxiv:ft", 1, "cs.LG", &[]), None).unwrap();
         assert!(search_full_text(&conn, "zephyranthes", 10)
             .unwrap()
@@ -1328,7 +1322,7 @@ mod tests {
     /// indexes — `extract_source` returns "" for a corrupt download too.
     #[test]
     fn should_store_full_text_refuses_to_clobber_with_empty() {
-        let mut conn = mem();
+        let mut conn = db();
         save_paper_metadata(&mut conn, &meta("arxiv:clob", 1, "cs.LG", &[]), None).unwrap();
         let key = Paper {
             source_id: Some("arxiv:clob".into()),
@@ -1354,7 +1348,7 @@ mod tests {
 
     #[test]
     fn backfill_candidates_lists_only_unfetched_papers() {
-        let mut conn = mem();
+        let mut conn = db();
         let fetchable = |sid: &str| PaperMetadata {
             url: Some(format!("http://arxiv.org/pdf/{sid}v1")),
             ..meta(sid, 1, "cs.LG", &[])
@@ -1383,7 +1377,7 @@ mod tests {
         // Everything source_fetch_url would refuse has to stay off the list:
         // the backfill would hand each one to the fetcher on every rebuild, and
         // the count backing the UI's progress line would never reach zero.
-        let mut conn = mem();
+        let mut conn = db();
         let other_provider = PaperMetadata {
             url: Some("http://arxiv.org/pdf/1234v1".into()),
             source: Some("openalex".into()),
@@ -1413,7 +1407,7 @@ mod tests {
         // The work-list SQL and source_fetch_url must answer "is this arXiv"
         // identically on rows where the id namespace and the PROVIDER column
         // disagree — otherwise backfill queues papers the fetcher then skips.
-        let mut conn = mem();
+        let mut conn = db();
         let row = |sid: &str, provider: &str, url: &str| PaperMetadata {
             url: Some(url.into()),
             source: Some(provider.into()),
@@ -1469,7 +1463,7 @@ mod tests {
 
     #[test]
     fn source_fetch_url_takes_arxiv_pdf_links_only() {
-        let mut conn = mem();
+        let mut conn = db();
         let fetch_url_of = |conn: &Connection, sid: &str| {
             let p = get(
                 conn,
@@ -1513,7 +1507,7 @@ mod tests {
 
     #[test]
     fn root_and_id_helpers() {
-        let mut conn = mem();
+        let mut conn = db();
         save_paper_metadata(&mut conn, &meta("arxiv:v", 1, "cs.LG", &[]), None).unwrap();
         let fk = ensure_paper_root(&mut conn, "arxiv:v").unwrap();
         assert_eq!(
@@ -1530,7 +1524,7 @@ mod tests {
     // tokenization misses (substring) must still come back.
     #[test]
     fn search_library_merges_note_substring_hits() {
-        let mut conn = mem();
+        let mut conn = db();
         save_paper_metadata(&mut conn, &meta("arxiv:N", 1, "cs.LG", &[]), None).unwrap();
         ensure_paper_root(&mut conn, "arxiv:N").unwrap();
         conn.execute(
@@ -1556,7 +1550,7 @@ mod tests {
     // content the FTS tokenizer can't reach. Both must return, FTS hit first.
     #[test]
     fn search_library_returns_full_text_and_note_hits_together() {
-        let mut conn = mem();
+        let mut conn = db();
         save_paper_metadata(&mut conn, &meta("arxiv:ftA", 1, "cs.LG", &[]), None).unwrap();
         set_full_text(&mut conn, "arxiv:ftA", 1, "a study of zephyranthes blooms").unwrap();
 
@@ -1587,7 +1581,7 @@ mod tests {
     // Repair input rules live behind the service seam, not in one caller.
     #[test]
     fn repair_paper_validates_and_normalizes() {
-        let mut conn = mem();
+        let mut conn = db();
         save_paper_metadata(&mut conn, &meta("arxiv:R", 1, "cs.LG", &[]), None).unwrap();
         let fk = ensure_paper_root(&mut conn, "arxiv:R").unwrap();
 

--- a/src-tauri/crates/core/src/service/paper_import.rs
+++ b/src-tauri/crates/core/src/service/paper_import.rs
@@ -451,19 +451,12 @@ fn unique_token() -> String {
 mod tests {
     use super::*;
     use crate::service::paper;
-    use crate::storage::{db::open_in_memory, init_db};
-    use chrono::NaiveDate;
+    use crate::test_support::{db, meta};
     use tempfile::tempdir;
 
     /// A generous cap for tests that aren't exercising the size limit itself —
     /// every fixture PDF here is a few bytes.
     const NO_LIMIT: u64 = 1_000_000;
-
-    fn mem() -> Connection {
-        let conn = open_in_memory().unwrap();
-        init_db(&conn).unwrap();
-        conn
-    }
 
     /// The storage cap, at the three points that matter. Only `.pdf` files count
     /// toward it (`files::pdf_storage_bytes`), and the comparison is `>`, so landing
@@ -496,27 +489,6 @@ mod tests {
         assert!(check_pdf_storage_quota(empty.path(), 101, 100).is_err());
     }
 
-    fn meta(source_id: &str, version: i64) -> PaperMetadata {
-        PaperMetadata {
-            source_id: source_id.into(),
-            version,
-            title: format!("Title of {source_id} v{version}"),
-            authors: vec!["Alice".into()],
-            published: NaiveDate::from_ymd_opt(2024, 1, 1).unwrap(),
-            updated: None,
-            summary: "s".into(),
-            category: Some("cs.LG".into()),
-            categories: Some(vec!["cs.LG".into()]),
-            doi: None,
-            journal_ref: None,
-            comment: None,
-            url: None,
-            tags: None,
-            source: Some("arxiv".into()),
-            author_orcids: None,
-        }
-    }
-
     /// Resolver that hands back a fixed (meta, external).
     fn resolver(
         m: PaperMetadata,
@@ -529,7 +501,7 @@ mod tests {
     /// the regression here would be surfaces paying for the resolve first.
     #[test]
     fn precheck_import_pdf_rejects_missing_project_and_passes_none() {
-        let conn = mem();
+        let conn = db();
         assert!(matches!(
             precheck_import_pdf(&conn, Some(999)),
             Err(CoreError::ProjectNotFound(999))
@@ -539,7 +511,7 @@ mod tests {
 
     #[test]
     fn happy_path_new_paper_writes_db_and_file() {
-        let mut conn = mem();
+        let mut conn = db();
         let dir = tempdir().unwrap();
         let res = import_pdf(
             &mut conn,
@@ -582,7 +554,7 @@ mod tests {
 
     #[test]
     fn import_pdf_within_total_storage_limit_is_saved() {
-        let mut conn = mem();
+        let mut conn = db();
         let dir = tempdir().unwrap();
         // Existing PDFs consume part of the total-storage quota.
         let seed = b"already-saved pdf bytes";
@@ -603,7 +575,7 @@ mod tests {
 
     #[test]
     fn import_pdf_over_total_storage_limit_is_rejected_and_writes_nothing() {
-        let mut conn = mem();
+        let mut conn = db();
         let dir = tempdir().unwrap();
         // Existing PDFs consume most of the quota; the new file alone would fit,
         // but existing + new pushes the TOTAL over → rejected.
@@ -643,7 +615,7 @@ mod tests {
 
     #[test]
     fn resolve_failure_is_pdf_import_and_leaves_nothing() {
-        let mut conn = mem();
+        let mut conn = db();
         let dir = tempdir().unwrap();
         let bad = |_: &[u8]| Err(CoreError::Internal("corrupt pdf".into()));
         let err = import_pdf(&mut conn, dir.path(), b"junk", None, NO_LIMIT, bad).unwrap_err();
@@ -657,7 +629,7 @@ mod tests {
 
     #[test]
     fn adopt_existing_active_root_dedupes_identity() {
-        let mut conn = mem();
+        let mut conn = db();
         let dir = tempdir().unwrap();
         // Pre-existing arxiv root + v1.
         paper::save_paper_metadata(&mut conn, &meta("arxiv:2204.0001", 1), None).unwrap();
@@ -685,7 +657,7 @@ mod tests {
         // "Imported earlier" case: the arxiv root does NOT yet exist when the PDF
         // is imported. The import keys on the resolved arxiv identity, not the
         // content hash.
-        let mut conn = mem();
+        let mut conn = db();
         let dir = tempdir().unwrap();
 
         let res = import_pdf(
@@ -715,7 +687,7 @@ mod tests {
 
     #[test]
     fn reimport_preserves_existing_pdf_on_disk() {
-        let mut conn = mem();
+        let mut conn = db();
         let dir = tempdir().unwrap();
         paper::save_paper_metadata(&mut conn, &meta("arxiv:keep", 1), None).unwrap();
         // A PDF already sits at the canonical path with known bytes.
@@ -746,7 +718,7 @@ mod tests {
 
     #[test]
     fn rollback_brand_new_root_hard_deletes() {
-        let mut conn = mem();
+        let mut conn = db();
         let dir = tempdir().unwrap();
         block_final_path(dir.path(), "local_newv1.pdf");
 
@@ -785,7 +757,7 @@ mod tests {
 
     #[test]
     fn rollback_restored_deleted_root_re_soft_deletes() {
-        let mut conn = mem();
+        let mut conn = db();
         let dir = tempdir().unwrap();
         // A soft-deleted root with NO version (so pre_existing_version is false
         // and the failure-injection dir doesn't trip preserve-existing).
@@ -815,7 +787,7 @@ mod tests {
         // Wiring check: the convenience entry resolves first (junk bytes extract
         // no arXiv/DOI/title, so enrichment makes no network call), then mints a
         // deterministic local:<sha> identity (None external).
-        let mut conn = mem();
+        let mut conn = db();
         let dir = tempdir().unwrap();
         let data_dir = tempdir().unwrap();
         let res = import_pdf_default(
@@ -843,7 +815,7 @@ mod tests {
 
     #[test]
     fn project_link_membership_guards() {
-        let mut conn = mem();
+        let mut conn = db();
         let dir = tempdir().unwrap();
 
         // Missing project → ProjectNotFound, before any import work.

--- a/src-tauri/crates/core/src/service/paper_import.rs
+++ b/src-tauri/crates/core/src/service/paper_import.rs
@@ -172,6 +172,9 @@ pub fn precheck_import_pdf(conn: &Connection, project_id: Option<i64>) -> Result
 /// the `pdf_save_limit_mb` quota precheck (fail before the expensive pdfium
 /// parse; `import_pdf` re-checks it under the lock) and the network metadata
 /// resolve. Hand the result to [`commit_import_pdf`] under the caller's lock.
+///
+/// The CrossRef polite-pool address is read here, at the service seam, for the
+/// same reason `service::source` reads it: `sources::` stays pure DI.
 pub async fn resolve_import_pdf(
     pdf_dir: &Path,
     content: &[u8],
@@ -179,7 +182,12 @@ pub async fn resolve_import_pdf(
     data_dir: &Path,
 ) -> Result<ResolvedPdf> {
     check_pdf_storage_quota(pdf_dir, content.len(), max_total_bytes)?;
-    crate::sources::pdf_metadata::resolve_pdf_metadata(content, data_dir).await
+    crate::sources::pdf_metadata::resolve_pdf_metadata(
+        content,
+        data_dir,
+        &crate::config::crossref_mailto(),
+    )
+    .await
 }
 
 /// PDF bytes → the metadata JSON record the out-of-process `pdf-meta` worker

--- a/src-tauri/crates/core/src/service/project.rs
+++ b/src-tauri/crates/core/src/service/project.rs
@@ -151,7 +151,8 @@ pub fn remove_project_tags(
 pub fn to_out(conn: &Connection, p: ProjectDetails) -> Result<ProjectOut> {
     let source_ids = crate::service::paper::sfks_to_source_ids(conn, &p.source_fks)?;
     Ok(ProjectOut {
-        id: p.id
+        id: p
+            .id
             .ok_or_else(|| CoreError::Internal("Project has no id".into()))?,
         name: p.name,
         description: p.description,

--- a/src-tauri/crates/core/src/service/project.rs
+++ b/src-tauri/crates/core/src/service/project.rs
@@ -151,7 +151,8 @@ pub fn remove_project_tags(
 pub fn to_out(conn: &Connection, p: ProjectDetails) -> Result<ProjectOut> {
     let source_ids = crate::service::paper::sfks_to_source_ids(conn, &p.source_fks)?;
     Ok(ProjectOut {
-        id: p.id,
+        id: p.id
+            .ok_or_else(|| CoreError::Internal("Project has no id".into()))?,
         name: p.name,
         description: p.description,
         color_hex: p.color.map(color_to_hex),

--- a/src-tauri/crates/core/src/service/source.rs
+++ b/src-tauri/crates/core/src/service/source.rs
@@ -4,8 +4,8 @@
 //! `sources::` at all).
 //!
 //! The config read lives here rather than in `sources::`, which stays pure DI.
-//! `config::openalex_mailto()` prefers the env var and falls back to user
-//! settings, so the CLI and MCP processes keep the polite pool.
+//! `config::{openalex,crossref}_mailto()` prefer the env var and fall back to
+//! user settings, so the CLI and MCP processes keep the polite pools.
 //!
 //! Every call here is network I/O: `.await` it with no DB lock held, then commit
 //! through `service::paper::save_paper_metadata`.
@@ -33,7 +33,11 @@ pub async fn fetch_by_id(source: &str, paper_id: &str) -> Result<PaperMetadata> 
                 .fetch_by_id(paper_id)
                 .await
         }
-        "crossref" => CrossRef.fetch_by_id(paper_id).await,
+        "crossref" => {
+            CrossRef::new(config::crossref_mailto())
+                .fetch_by_id(paper_id)
+                .await
+        }
         other => Err(unknown_source(other)),
     }
 }
@@ -57,7 +61,11 @@ pub async fn search(
                 .search(query, max_results, sort)
                 .await
         }
-        "crossref" => CrossRef.search(query, max_results, sort).await,
+        "crossref" => {
+            CrossRef::new(config::crossref_mailto())
+                .search(query, max_results, sort)
+                .await
+        }
         other => Err(unknown_source(other)),
     }
 }
@@ -65,7 +73,7 @@ pub async fn search(
 /// DOI → metadata via the three-strategy ladder. Outside `PaperSource` on
 /// purpose: one operation spanning several Providers, not a Provider of its own.
 pub async fn resolve_doi(doi: &str) -> Result<PaperMetadata> {
-    doi_resolve::resolve_doi(doi, &config::data_dir()).await
+    doi_resolve::resolve_doi(doi, &config::data_dir(), &config::crossref_mailto()).await
 }
 
 /// Every record CrossRef and OpenAlex hold for one DOI, plus whether either
@@ -73,10 +81,9 @@ pub async fn resolve_doi(doi: &str) -> Result<PaperMetadata> {
 /// an ORCID backfill pass. Order is CrossRef first: `service::orcid_backfill`
 /// takes the first ORCID it finds.
 pub async fn orcid_records_for_doi(doi: &str) -> (Vec<PaperMetadata>, bool) {
-    let mailto = config::openalex_mailto();
     fold_doi_results(
-        crossref::fetch_by_doi_checked(doi).await,
-        openalex::fetch_by_doi(doi, &mailto).await,
+        crossref::fetch_by_doi_checked(doi, &config::crossref_mailto()).await,
+        openalex::fetch_by_doi(doi, &config::openalex_mailto()).await,
     )
 }
 

--- a/src-tauri/crates/core/src/service/trash.rs
+++ b/src-tauri/crates/core/src/service/trash.rs
@@ -139,7 +139,7 @@ mod tests {
             }],
             projects: vec![TrashedProjectRow {
                 project: crate::models::ProjectOut {
-                    id: Some(5),
+                    id: 5,
                     name: "P".into(),
                     description: String::new(),
                     color_hex: None,

--- a/src-tauri/crates/core/src/service/version_monitor.rs
+++ b/src-tauri/crates/core/src/service/version_monitor.rs
@@ -92,35 +92,7 @@ pub fn apply_results(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::storage::{db::open_in_memory, init_db};
-    use chrono::NaiveDate;
-
-    fn mem() -> Connection {
-        let conn = open_in_memory().unwrap();
-        init_db(&conn).unwrap();
-        conn
-    }
-
-    fn meta(source_id: &str, version: i64) -> PaperMetadata {
-        PaperMetadata {
-            source_id: source_id.into(),
-            version,
-            title: format!("Title of {source_id} v{version}"),
-            authors: vec!["Alice".into()],
-            published: NaiveDate::from_ymd_opt(2024, 1, 1).unwrap(),
-            updated: None,
-            summary: "s".into(),
-            category: Some("cs.LG".into()),
-            categories: Some(vec!["cs.LG".into()]),
-            doi: None,
-            journal_ref: None,
-            comment: None,
-            url: None,
-            tags: None,
-            source: Some("arxiv".into()),
-            author_orcids: None,
-        }
-    }
+    use crate::test_support::{db, meta};
 
     fn save(conn: &mut Connection, source_id: &str, version: i64) {
         store::save_paper_metadata(conn, &meta(source_id, version), None).unwrap();
@@ -135,7 +107,7 @@ mod tests {
 
     #[test]
     fn stale_candidates_selects_arxiv_never_checked_then_oldest() {
-        let mut conn = mem();
+        let mut conn = db();
         save(&mut conn, "arxiv:a", 1);
         save(&mut conn, "arxiv:b", 2);
         save(&mut conn, "arxiv:c", 1);
@@ -168,7 +140,7 @@ mod tests {
 
     #[test]
     fn apply_results_captures_only_newer_and_rotates_all() {
-        let mut conn = mem();
+        let mut conn = db();
         save(&mut conn, "arxiv:up", 1);
         save(&mut conn, "arxiv:same", 3);
         save(&mut conn, "arxiv:silent", 1); // arXiv returns nothing for it
@@ -208,7 +180,7 @@ mod tests {
 
     #[test]
     fn apply_results_skips_deleted_candidates_no_fk_crash() {
-        let mut conn = mem();
+        let mut conn = db();
         save(&mut conn, "arxiv:live", 1);
         save(&mut conn, "arxiv:deleted", 1);
 
@@ -236,7 +208,7 @@ mod tests {
     /// too, instead of being left committed with the flag never set.
     #[test]
     fn save_and_record_check_are_one_atomic_transaction() {
-        let mut conn = mem();
+        let mut conn = db();
         save(&mut conn, "arxiv:x", 1);
         let good_fk = fk(&conn, "arxiv:x");
         let bad_fk = good_fk + 999; // no matching PAPER_ROOTS row -> FK violation

--- a/src-tauri/crates/core/src/sources/crossref.rs
+++ b/src-tauri/crates/core/src/sources/crossref.rs
@@ -6,7 +6,9 @@
 //! wiremock-tested below; the `PaperSource` adapter over them is covered in
 //! `tests/paper_source.rs`.
 //!
-//! Plan §5.4. No auth required; `api.crossref.org` only.
+//! Plan §5.4. No auth required; `api.crossref.org` only. Every request carries
+//! the polite-pool `User-Agent` built by `http::polite_user_agent` from the
+//! `mailto` DI param (shared with OpenAlex — same header, same CR/LF stripping).
 
 use chrono::NaiveDate;
 use serde_json::Value;
@@ -189,14 +191,15 @@ pub fn parse_search_body(body: &[u8]) -> Vec<PaperMetadata> {
 
 /// Fetch CrossRef metadata for a DOI. `None` on any non-200 / network / parse
 /// error, matching the Python `except Exception: return None`.
-pub async fn fetch_by_doi(doi: &str) -> Option<PaperMetadata> {
-    fetch_by_doi_checked(doi).await.ok().flatten()
+/// `mailto` selects CrossRef's polite pool (DI param, not env).
+pub async fn fetch_by_doi(doi: &str, mailto: &str) -> Option<PaperMetadata> {
+    fetch_by_doi_checked(doi, mailto).await.ok().flatten()
 }
 
 /// Like `fetch_by_doi`, but distinguishes "no work found" (`Ok(None)`) from a
 /// transport/HTTP/malformed-body failure (`Err`).
-pub async fn fetch_by_doi_checked(doi: &str) -> Result<Option<PaperMetadata>> {
-    fetch_by_doi_checked_at(CROSSREF_BASE, ALLOW, doi).await
+pub async fn fetch_by_doi_checked(doi: &str, mailto: &str) -> Result<Option<PaperMetadata>> {
+    fetch_by_doi_checked_at(CROSSREF_BASE, ALLOW, doi, mailto).await
 }
 
 /// `fetch_by_doi_checked` against an injected base URL + host allowlist (the
@@ -205,9 +208,11 @@ async fn fetch_by_doi_checked_at(
     base: &str,
     allow: &[&str],
     doi: &str,
+    mailto: &str,
 ) -> Result<Option<PaperMetadata>> {
     let url = format!("{base}/{doi}");
-    let resp = http::get_guarded(&url, allow).await?;
+    let ua = http::polite_user_agent(mailto);
+    let resp = http::get_guarded_with(&url, allow, &[("User-Agent", &ua)]).await?;
     if resp.status() == reqwest::StatusCode::NOT_FOUND {
         return Ok(None);
     }
@@ -249,11 +254,12 @@ fn sort_params(sort: &str) -> Result<(&'static str, &'static str)> {
 }
 
 /// Search CrossRef by title, relevance-ordered. Empty vec on any error.
-pub async fn search_by_title(title: &str, limit: u32) -> Vec<PaperMetadata> {
+pub async fn search_by_title(title: &str, limit: u32, mailto: &str) -> Vec<PaperMetadata> {
     let Ok(url) = search_url(title, limit, "relevance") else {
         return Vec::new();
     };
-    let Ok(resp) = http::get_guarded(url.as_str(), ALLOW).await else {
+    let ua = http::polite_user_agent(mailto);
+    let Ok(resp) = http::get_guarded_with(url.as_str(), ALLOW, &[("User-Agent", &ua)]).await else {
         return Vec::new();
     };
     if resp.status() != reqwest::StatusCode::OK {
@@ -287,9 +293,11 @@ pub async fn search_by_title_checked(
     title: &str,
     limit: u32,
     sort: &str,
+    mailto: &str,
 ) -> Result<Vec<PaperMetadata>> {
     let url = search_url(title, limit, sort)?;
-    let resp = http::get_guarded(url.as_str(), ALLOW).await?;
+    let ua = http::polite_user_agent(mailto);
+    let resp = http::get_guarded_with(url.as_str(), ALLOW, &[("User-Agent", &ua)]).await?;
     if resp.status() != reqwest::StatusCode::OK {
         return Err(CoreError::Upstream(format!(
             "CrossRef search failed: HTTP {}",
@@ -511,11 +519,38 @@ mod tests {
             .mount(&server)
             .await;
 
-        let m = fetch_by_doi_checked_at(&server.uri(), &["127.0.0.1"], "10.1000/xyz")
+        let m = fetch_by_doi_checked_at(&server.uri(), &["127.0.0.1"], "10.1000/xyz", "")
             .await
             .expect("200 is Ok")
             .expect("title present is Some");
         assert_eq!(m.source_id, "doi:10.1000/xyz");
+    }
+
+    /// CROSSREF_MAILTO is a user-editable settings field, so this pins both that
+    /// the polite-pool UA reaches CrossRef at all (it used to read the setting
+    /// nowhere) and that a CR/LF in the address can't split it into a second header.
+    #[tokio::test]
+    async fn sends_polite_ua_with_crlf_stripped_mailto() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/10.1000/xyz"))
+            .and(wiremock::matchers::header(
+                "User-Agent",
+                "linXiv/1.0 (mailto:me@x.ioX-Evil: 1)",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_bytes(WORK_BODY))
+            .mount(&server)
+            .await;
+
+        fetch_by_doi_checked_at(
+            &server.uri(),
+            &["127.0.0.1"],
+            "10.1000/xyz",
+            "me@x.io\r\nX-Evil: 1",
+        )
+        .await
+        .expect("the mock only matches when the sanitized polite UA is sent")
+        .expect("title present is Some");
     }
 
     #[tokio::test]
@@ -527,7 +562,7 @@ mod tests {
             .mount(&server)
             .await;
 
-        let m = fetch_by_doi_checked_at(&server.uri(), &["127.0.0.1"], "10.1000/missing")
+        let m = fetch_by_doi_checked_at(&server.uri(), &["127.0.0.1"], "10.1000/missing", "")
             .await
             .expect("404 is Ok, not Err");
         assert!(m.is_none());
@@ -542,7 +577,7 @@ mod tests {
             .mount(&server)
             .await;
 
-        let err = fetch_by_doi_checked_at(&server.uri(), &["127.0.0.1"], "10.1000/xyz")
+        let err = fetch_by_doi_checked_at(&server.uri(), &["127.0.0.1"], "10.1000/xyz", "")
             .await
             .expect_err(
                 "malformed 200 body must be Err, matching OpenAlex's json-parse-error path",
@@ -559,7 +594,7 @@ mod tests {
             .mount(&server)
             .await;
 
-        let err = fetch_by_doi_checked_at(&server.uri(), &["127.0.0.1"], "10.1000/xyz")
+        let err = fetch_by_doi_checked_at(&server.uri(), &["127.0.0.1"], "10.1000/xyz", "")
             .await
             .expect_err("503 must be Err, not Ok(None)");
         assert!(matches!(err, CoreError::Upstream(_)), "got {err}");

--- a/src-tauri/crates/core/src/sources/doi_resolve.rs
+++ b/src-tauri/crates/core/src/sources/doi_resolve.rs
@@ -227,10 +227,11 @@ async fn try_semantic_scholar(doi: &str, data_dir: &Path) -> Result<Option<Paper
 }
 
 /// Resolve a DOI to `PaperMetadata`, trying arXiv -> Semantic Scholar ->
-/// CrossRef in order. `data_dir` (DI) feeds the arXiv rate-limit cool-down.
+/// CrossRef in order. `data_dir` (DI) feeds the arXiv rate-limit cool-down and
+/// `mailto` (DI) the CrossRef polite pool.
 /// Errors are user-facing: empty input, a propagated arXiv 429, or "could not
 /// resolve" when every strategy comes up empty.
-pub async fn resolve_doi(doi: &str, data_dir: &Path) -> Result<PaperMetadata> {
+pub async fn resolve_doi(doi: &str, data_dir: &Path, mailto: &str) -> Result<PaperMetadata> {
     let doi = strip_doi_url(doi);
     if doi.is_empty() {
         return Err(CoreError::BadRequest("Please enter a DOI.".to_string()));
@@ -242,7 +243,7 @@ pub async fn resolve_doi(doi: &str, data_dir: &Path) -> Result<PaperMetadata> {
     if let Some(m) = try_semantic_scholar(&doi, data_dir).await? {
         return Ok(m);
     }
-    if let Some(m) = crossref::fetch_by_doi(&doi).await {
+    if let Some(m) = crossref::fetch_by_doi(&doi, mailto).await {
         return Ok(m);
     }
 
@@ -387,7 +388,7 @@ mod tests {
     #[tokio::test]
     async fn resolve_rejects_empty_doi() {
         let dir = tempfile::tempdir().unwrap();
-        let err = resolve_doi("", dir.path())
+        let err = resolve_doi("", dir.path(), "")
             .await
             .expect_err("empty DOI must error");
         assert_eq!(err.http_status(), 400);
@@ -397,7 +398,7 @@ mod tests {
     #[tokio::test]
     async fn resolve_rejects_doi_url_that_strips_to_empty() {
         let dir = tempfile::tempdir().unwrap();
-        let err = resolve_doi("https://doi.org/", dir.path())
+        let err = resolve_doi("https://doi.org/", dir.path(), "")
             .await
             .expect_err("a bare doi.org URL strips to empty");
         assert!(err.to_string().contains("Please enter a DOI"), "got {err}");

--- a/src-tauri/crates/core/src/sources/http.rs
+++ b/src-tauri/crates/core/src/sources/http.rs
@@ -302,10 +302,10 @@ mod tests {
             "",
             "me@x.io",
             "me@x.io\r\nX-Evil: 1",
-            "me@uni.es\u{00A0}",  // trailing NBSP: the copy-paste-off-a-webpage case
+            "me@uni.es\u{00A0}", // trailing NBSP: the copy-paste-off-a-webpage case
             "jos\u{00E9}@uni.es", // accented address
-            "a\u{0007}b@x.io",    // control char
-            "\u{00A0}\u{00A0}",   // nothing but non-ASCII -> must fall back to bare
+            "a\u{0007}b@x.io",   // control char
+            "\u{00A0}\u{00A0}",  // nothing but non-ASCII -> must fall back to bare
             "  me@x.io  ",
         ] {
             let ua = polite_user_agent(raw);
@@ -319,7 +319,10 @@ mod tests {
             polite_user_agent("me@uni.es\u{00A0}"),
             "linXiv/1.0 (mailto:me@uni.es)"
         );
-        assert_eq!(polite_user_agent("  me@x.io  "), "linXiv/1.0 (mailto:me@x.io)");
+        assert_eq!(
+            polite_user_agent("  me@x.io  "),
+            "linXiv/1.0 (mailto:me@x.io)"
+        );
         // Nothing usable left -> bare UA, not a mangled empty mailto.
         assert_eq!(polite_user_agent("\u{00A0}\u{00A0}"), "linXiv/1.0");
     }

--- a/src-tauri/crates/core/src/sources/http.rs
+++ b/src-tauri/crates/core/src/sources/http.rs
@@ -32,6 +32,21 @@ const MAX_REDIRECTS: usize = 10;
 pub(crate) const USER_AGENT: &str =
     "linXiv/0.2 (+https://github.com/jakeuribe/linXiv; mailto:jake.uribe@gmail.com)";
 
+/// Base UA for the polite pools (OpenAlex and CrossRef both key off the mailto).
+const POLITE_USER_AGENT: &str = "linXiv/1.0";
+
+/// Polite-pool UA: `linXiv/1.0 (mailto:<addr>)`, or the bare UA when no address.
+/// CR/LF stripped so a tainted mailto — it comes from a user-editable settings
+/// field — can't inject extra request headers.
+pub(crate) fn polite_user_agent(mailto: &str) -> String {
+    let addr: String = mailto.chars().filter(|&c| c != '\r' && c != '\n').collect();
+    if addr.is_empty() {
+        POLITE_USER_AGENT.to_string()
+    } else {
+        format!("{POLITE_USER_AGENT} (mailto:{addr})")
+    }
+}
+
 /// Shared, sensibly-configured async client (UA + timeouts). Cheap to clone.
 ///
 /// Redirects are disabled at the client level: `get_guarded` follows them by
@@ -257,6 +272,17 @@ mod tests {
     use super::*;
     use wiremock::matchers::{method, path};
     use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    #[test]
+    fn polite_ua_carries_mailto_and_strips_crlf() {
+        assert_eq!(polite_user_agent(""), "linXiv/1.0");
+        assert_eq!(polite_user_agent("me@x.io"), "linXiv/1.0 (mailto:me@x.io)");
+        // CR/LF stripped so a tainted address can't inject a header break.
+        assert_eq!(
+            polite_user_agent("me@x.io\r\nX-Evil: 1"),
+            "linXiv/1.0 (mailto:me@x.ioX-Evil: 1)"
+        );
+    }
 
     #[test]
     fn host_allow_exact_and_subdomain() {

--- a/src-tauri/crates/core/src/sources/http.rs
+++ b/src-tauri/crates/core/src/sources/http.rs
@@ -36,10 +36,19 @@ pub(crate) const USER_AGENT: &str =
 const POLITE_USER_AGENT: &str = "linXiv/1.0";
 
 /// Polite-pool UA: `linXiv/1.0 (mailto:<addr>)`, or the bare UA when no address.
-/// CR/LF stripped so a tainted mailto — it comes from a user-editable settings
-/// field — can't inject extra request headers.
+///
+/// The mailto comes from a user-editable settings field, so it is reduced to
+/// visible ASCII: CR/LF would inject extra headers, and anything outside
+/// 0x20..=0x7E (a pasted NBSP, an accented address) is rejected by
+/// `HeaderValue`, which would poison the RequestBuilder and fail *every*
+/// request to that pool — silently, where a caller maps the error to an empty
+/// result.
 pub(crate) fn polite_user_agent(mailto: &str) -> String {
-    let addr: String = mailto.chars().filter(|&c| c != '\r' && c != '\n').collect();
+    let addr: String = mailto
+        .chars()
+        .filter(|&c| (' '..='~').contains(&c))
+        .collect();
+    let addr = addr.trim();
     if addr.is_empty() {
         POLITE_USER_AGENT.to_string()
     } else {
@@ -282,6 +291,37 @@ mod tests {
             polite_user_agent("me@x.io\r\nX-Evil: 1"),
             "linXiv/1.0 (mailto:me@x.ioX-Evil: 1)"
         );
+    }
+
+    /// Every UA this builds must survive `HeaderValue`, or the RequestBuilder is
+    /// poisoned and *all* requests to that pool fail — silently, where the caller
+    /// maps the error to an empty result.
+    #[test]
+    fn polite_ua_is_always_a_valid_header_value() {
+        for raw in [
+            "",
+            "me@x.io",
+            "me@x.io\r\nX-Evil: 1",
+            "me@uni.es\u{00A0}",  // trailing NBSP: the copy-paste-off-a-webpage case
+            "jos\u{00E9}@uni.es", // accented address
+            "a\u{0007}b@x.io",    // control char
+            "\u{00A0}\u{00A0}",   // nothing but non-ASCII -> must fall back to bare
+            "  me@x.io  ",
+        ] {
+            let ua = polite_user_agent(raw);
+            assert!(
+                reqwest::header::HeaderValue::try_from(&ua).is_ok(),
+                "UA from {raw:?} is not a valid header value: {ua:?}"
+            );
+        }
+        // The common paste artifact keeps the address rather than losing the pool.
+        assert_eq!(
+            polite_user_agent("me@uni.es\u{00A0}"),
+            "linXiv/1.0 (mailto:me@uni.es)"
+        );
+        assert_eq!(polite_user_agent("  me@x.io  "), "linXiv/1.0 (mailto:me@x.io)");
+        // Nothing usable left -> bare UA, not a mangled empty mailto.
+        assert_eq!(polite_user_agent("\u{00A0}\u{00A0}"), "linXiv/1.0");
     }
 
     #[test]

--- a/src-tauri/crates/core/src/sources/openalex.rs
+++ b/src-tauri/crates/core/src/sources/openalex.rs
@@ -18,23 +18,11 @@ use crate::models::{
 use crate::sources::http;
 
 const BASE_URL: &str = "https://api.openalex.org";
-const USER_AGENT: &str = "linXiv/1.0";
 const ALLOW: &[&str] = &["api.openalex.org"];
 
 /// Fixed `select` field list — only the fields `work_to_metadata` reads.
 const WORK_FIELDS: &str =
     "id,title,authorships,publication_date,doi,primary_topic,abstract_inverted_index";
-
-/// Polite-pool UA: `linXiv/1.0 (mailto:<addr>)`, or bare UA when no address.
-/// CR/LF stripped so a tainted mailto can't inject extra request headers.
-fn user_agent(mailto: &str) -> String {
-    let addr: String = mailto.chars().filter(|&c| c != '\r' && c != '\n').collect();
-    if addr.is_empty() {
-        USER_AGENT.to_string()
-    } else {
-        format!("{USER_AGENT} (mailto:{addr})")
-    }
-}
 
 /// OpenAlex reads `| ! * ?` in `search` as query operators (HTTP 400 on free
 /// text); replace each with a space and collapse the resulting whitespace.
@@ -214,8 +202,8 @@ async fn search_at(
         return Ok(Vec::new());
     }
     // Polite-pool UA carried as a per-request header (Python sends it on every
-    // request); CR/LF already stripped in `user_agent`.
-    let ua = user_agent(mailto);
+    // request); CR/LF already stripped in `http::polite_user_agent`.
+    let ua = http::polite_user_agent(mailto);
     let url = reqwest::Url::parse_with_params(
         &format!("{base_url}/works"),
         &[
@@ -269,7 +257,7 @@ async fn fetch_by_id_at(
             "Invalid OpenAlex work ID '{bare}': expected 'W' followed by digits."
         )));
     }
-    let ua = user_agent(mailto);
+    let ua = http::polite_user_agent(mailto);
     let url = reqwest::Url::parse_with_params(
         &format!("{base_url}/works/{bare}"),
         &[("select", WORK_FIELDS)],
@@ -308,7 +296,7 @@ async fn fetch_by_doi_at(
     doi: &str,
     mailto: &str,
 ) -> Result<PaperMetadata> {
-    let ua = user_agent(mailto);
+    let ua = http::polite_user_agent(mailto);
     let filter = format!("doi:{doi}");
     let url = reqwest::Url::parse_with_params(
         &format!("{base_url}/works"),
@@ -420,17 +408,9 @@ mod tests {
         assert_eq!(sanitize_search_query("|||"), "");
     }
 
-    // ── user_agent (polite pool, CRLF-stripped) ───────────────────────────
-    #[test]
-    fn user_agent_polite_pool_and_crlf_strip() {
-        assert_eq!(user_agent(""), "linXiv/1.0");
-        assert_eq!(user_agent("me@x.io"), "linXiv/1.0 (mailto:me@x.io)");
-        // CR/LF stripped so a tainted address can't inject a header break.
-        assert_eq!(
-            user_agent("me@x.io\r\nX-Evil: 1"),
-            "linXiv/1.0 (mailto:me@x.ioX-Evil: 1)"
-        );
-    }
+    // The polite-pool UA builder is shared with CrossRef and unit-tested in
+    // `http`; `search_200_parses_results_and_sends_polite_ua` below pins that
+    // OpenAlex actually sends it.
 
     // ── is_work_id ────────────────────────────────────────────────────────
     #[test]

--- a/src-tauri/crates/core/src/sources/pdf_metadata.rs
+++ b/src-tauri/crates/core/src/sources/pdf_metadata.rs
@@ -605,11 +605,13 @@ fn pdf_source_id(bytes: &[u8]) -> String {
 /// matched, else None.
 ///
 /// Async because enrichment hits the network (arXiv/DOI/CrossRef); `data_dir`
-/// threads through to `arxiv_get`'s rate-limit file. When no upstream matches it
+/// threads through to `arxiv_get`'s rate-limit file and `mailto` to the CrossRef
+/// polite pool. When no upstream matches it
 /// returns the partial-from-extraction record + `None` (Python's fallthrough).
 pub async fn resolve_pdf_metadata(
     bytes: &[u8],
     data_dir: &Path,
+    mailto: &str,
 ) -> Result<(PaperMetadata, Option<(String, i64)>)> {
     // Blocking work (child-process wait, or native FFI on the in-process
     // fallback) — off the executor onto the blocking pool.
@@ -622,7 +624,7 @@ pub async fn resolve_pdf_metadata(
     // Enrich from an upstream record when an arXiv id / DOI / title matches.
     // external_identity = (enriched.source_id, version) so the importer can
     // dedupe against an existing root; the returned meta keeps the local id.
-    if let Some(enriched) = enrich_external(&raw, data_dir).await {
+    if let Some(enriched) = enrich_external(&raw, data_dir, mailto).await {
         let external = (!enriched.source_id.is_empty())
             .then(|| (enriched.source_id.clone(), enriched.version));
         let meta = PaperMetadata {
@@ -693,19 +695,19 @@ pub async fn resolve_pdf_metadata(
 /// DOI -> doi_resolve::resolve_doi, title -> CrossRef title search. Every source
 /// error is swallowed and the next is tried (Python catches and falls through);
 /// `None` means nothing matched and the caller keeps the partial record.
-async fn enrich_external(raw: &Extracted, data_dir: &Path) -> Option<PaperMetadata> {
+async fn enrich_external(raw: &Extracted, data_dir: &Path, mailto: &str) -> Option<PaperMetadata> {
     if let Some(id) = &raw.arxiv_id {
         if let Ok(m) = arxiv::fetch_by_id(id, data_dir).await {
             return Some(m);
         }
     }
     if let Some(doi) = &raw.doi {
-        if let Ok(m) = doi_resolve::resolve_doi(doi, data_dir).await {
+        if let Ok(m) = doi_resolve::resolve_doi(doi, data_dir, mailto).await {
             return Some(m);
         }
     }
     if let Some(title) = &raw.title {
-        if let Some(m) = try_crossref_title(title, data_dir).await {
+        if let Some(m) = try_crossref_title(title, data_dir, mailto).await {
             return Some(m);
         }
     }
@@ -715,11 +717,11 @@ async fn enrich_external(raw: &Extracted, data_dir: &Path) -> Option<PaperMetada
 /// CrossRef title search (Python `_try_crossref_title`): take the first candidate
 /// whose title is >= 0.5 Jaccard-similar; if it carries a DOI, upgrade via
 /// `resolve_doi` (gets the arXiv record when available), else return it as-is.
-async fn try_crossref_title(title: &str, data_dir: &Path) -> Option<PaperMetadata> {
-    for candidate in crossref::search_by_title(title, 3).await {
+async fn try_crossref_title(title: &str, data_dir: &Path, mailto: &str) -> Option<PaperMetadata> {
+    for candidate in crossref::search_by_title(title, 3, mailto).await {
         if !candidate.title.is_empty() && title_similarity(title, &candidate.title) >= 0.5 {
             if let Some(doi) = &candidate.doi {
-                if let Ok(m) = doi_resolve::resolve_doi(doi, data_dir).await {
+                if let Ok(m) = doi_resolve::resolve_doi(doi, data_dir, mailto).await {
                     return Some(m);
                 }
             }
@@ -947,7 +949,7 @@ mod tests {
     #[tokio::test]
     async fn resolve_partial_record_shape() {
         let dir = tempfile::tempdir().unwrap();
-        let (m, ext) = resolve_pdf_metadata(b"some pdf bytes", dir.path())
+        let (m, ext) = resolve_pdf_metadata(b"some pdf bytes", dir.path(), "")
             .await
             .unwrap();
         assert_eq!(ext, None);
@@ -1067,7 +1069,7 @@ mod tests {
                 // Each call exercises resolve_pdf_metadata's full path (extraction + enrichment).
                 // Result value is irrelevant here — only completion (no deadlock) matters.
                 let bytes = format!("%PDF junk {i}").into_bytes();
-                let _ = resolve_pdf_metadata(&bytes, &data_dir_path).await;
+                let _ = resolve_pdf_metadata(&bytes, &data_dir_path, "").await;
             }));
         }
         let join_all = async {
@@ -1148,7 +1150,7 @@ mod tests {
         // resolve still yields a partial record (deterministic local id); no
         // arXiv/DOI/title extracted, so enrichment makes no network call.
         let dir = tempfile::tempdir().unwrap();
-        let (meta, ext) = resolve_pdf_metadata(b"%PDF junk", dir.path())
+        let (meta, ext) = resolve_pdf_metadata(b"%PDF junk", dir.path(), "")
             .await
             .unwrap();
         assert!(meta.source_id.starts_with("local:"));

--- a/src-tauri/crates/core/src/sources/provider.rs
+++ b/src-tauri/crates/core/src/sources/provider.rs
@@ -3,8 +3,8 @@
 //! union-parameter match.
 //!
 //! Each adapter carries its own configuration — arXiv's `data_dir` (the
-//! `.arxiv_ratelimit` pacing file `sources::http` keeps there), OpenAlex's
-//! polite-pool `mailto` — so a caller no longer passes every Provider's
+//! `.arxiv_ratelimit` pacing file `sources::http` keeps there), OpenAlex's and
+//! CrossRef's polite-pool `mailto` — so a caller no longer passes every Provider's
 //! parameters regardless of which one it picked. Construction stays DI: nothing
 //! here reads `config`, that happens once at the service seam
 //! (`service::source`).
@@ -109,8 +109,18 @@ impl PaperSource for OpenAlex {
     }
 }
 
-/// CrossRef. No configuration — no key, no pool, one host.
-pub struct CrossRef;
+/// CrossRef. Holds the polite-pool address; empty means the anonymous pool.
+pub struct CrossRef {
+    mailto: String,
+}
+
+impl CrossRef {
+    pub fn new(mailto: impl Into<String>) -> Self {
+        Self {
+            mailto: mailto.into(),
+        }
+    }
+}
 
 impl PaperSource for CrossRef {
     fn name(&self) -> &'static str {
@@ -122,9 +132,11 @@ impl PaperSource for CrossRef {
     /// the not-found one keeping the message `fetch.rs` used to build inline.
     async fn fetch_by_id(&self, paper_id: &str) -> Result<PaperMetadata> {
         let doi = strip_provider_prefix(paper_id, DOI_ID_PREFIX);
-        crossref::fetch_by_doi_checked(doi).await?.ok_or_else(|| {
-            CoreError::Validation(format!("CrossRef: no record found for DOI '{paper_id}'"))
-        })
+        crossref::fetch_by_doi_checked(doi, &self.mailto)
+            .await?
+            .ok_or_else(|| {
+                CoreError::Validation(format!("CrossRef: no record found for DOI '{paper_id}'"))
+            })
     }
 
     async fn search(
@@ -133,6 +145,6 @@ impl PaperSource for CrossRef {
         max_results: u32,
         sort: &str,
     ) -> Result<Vec<PaperMetadata>> {
-        crossref::search_by_title_checked(query, max_results, sort).await
+        crossref::search_by_title_checked(query, max_results, sort, &self.mailto).await
     }
 }

--- a/src-tauri/crates/core/src/storage/queries/note.rs
+++ b/src-tauri/crates/core/src/storage/queries/note.rs
@@ -17,7 +17,7 @@ fn note_from_row(row: &Row) -> rusqlite::Result<NoteDetails> {
     let created: String = row.get("CREATED_AT")?;
     let updated: String = row.get("UPDATED_AT")?;
     Ok(NoteDetails {
-        note_id: row.get::<_, Option<i64>>("NOTE_SK")?,
+        note_id: row.get("NOTE_SK")?,
         uuid: row
             .get::<_, Option<String>>("NOTE_UUID")?
             .unwrap_or_default(),
@@ -318,7 +318,7 @@ mod tests {
         assert_eq!(n.project_id, Some(10));
         assert_eq!(n.title, "proj");
         assert_eq!(n.content, "project note");
-        assert!(n.note_id.is_some());
+        assert!(n.note_id > 0);
         assert_eq!(
             n.created_at,
             Some(

--- a/src-tauri/crates/core/src/storage/queries/version_check.rs
+++ b/src-tauri/crates/core/src/storage/queries/version_check.rs
@@ -102,3 +102,286 @@ pub fn ack(conn: &Connection, source_fk: i64) -> Result<bool> {
     )?;
     Ok(n > 0)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::storage::{self, db};
+
+    /// Insert an active root + one PAPER row per version. Returns the SOURCE_FK.
+    fn seed_root(conn: &Connection, source_id: &str, versions: &[i64]) -> i64 {
+        conn.execute(
+            "INSERT INTO PAPER_ROOTS (SOURCE_ID) VALUES (?1)",
+            [source_id],
+        )
+        .unwrap();
+        let fk = conn.last_insert_rowid();
+        for v in versions {
+            conn.execute(
+                "INSERT INTO PAPER (SOURCE_ID, VERSION, TITLE, SOURCE_FK)
+                 VALUES (?1, ?2, ?3, ?4)",
+                params![source_id, v, format!("{source_id} v{v}"), fk],
+            )
+            .unwrap();
+        }
+        fk
+    }
+
+    fn candidate_ids(conn: &Connection) -> Vec<String> {
+        stale_candidates(conn, MAX_VERSION_CHECK_BATCH)
+            .unwrap()
+            .into_iter()
+            .map(|c| c.source_id)
+            .collect()
+    }
+
+    /// The `GLOB 'arxiv:*'` filter is an ANCHORED, CASE-SENSITIVE prefix match.
+    ///
+    /// This is the test that fails if anyone "simplifies" GLOB back to
+    /// `LIKE 'arxiv:%'`: SQLite's LIKE is ASCII-case-insensitive, so the
+    /// `ARXIV:` / `arXiv:` roots below would start being polled as arXiv papers.
+    /// The `doi:` row carries `arxiv:` mid-string to pin that the match is
+    /// anchored (a bare `%arxiv:%` / `*arxiv:*` would sweep it in), and the
+    /// `arxiv-sanity:` / `arxivlike:` rows pin that the colon is part of the
+    /// prefix rather than the start of a wildcard run.
+    #[test]
+    fn stale_candidates_matches_arxiv_prefix_anchored_and_case_sensitively() {
+        let conn = db::open_in_memory().unwrap();
+        storage::init_db(&conn).unwrap();
+
+        seed_root(&conn, "arxiv:2401.00001", &[1]);
+        for reject in [
+            "ARXIV:2401.00002",             // LIKE would match this; GLOB must not
+            "arXiv:2401.00003",             // the canonical arXiv branding spelling
+            "doi:10.1000/arxiv:2401.00004", // contains the prefix, doesn't start with it
+            "arxiv-sanity:2401.00005",      // near-miss prefix, no colon after `arxiv`
+            "arxivlike:2401.00006",         // near-miss prefix, no separator at all
+            "openalex:W123",
+            "local:deadbeef",
+            ":arxiv:2401.00007", // prefix present but not at position 0
+        ] {
+            seed_root(&conn, reject, &[1]);
+        }
+
+        assert_eq!(candidate_ids(&conn), vec!["arxiv:2401.00001".to_string()]);
+    }
+
+    /// GLOB's own metacharacters (`*`, `?`, `[…]`) live in the PATTERN, never in
+    /// the data — a stored id containing them is matched literally, and a stored
+    /// id is never treated as a pattern itself.
+    #[test]
+    fn stale_candidates_treats_wildcard_chars_in_data_literally() {
+        let conn = db::open_in_memory().unwrap();
+        storage::init_db(&conn).unwrap();
+
+        seed_root(&conn, "arxiv:*", &[1]); // in-prefix: matched, but only literally
+        seed_root(&conn, "arxi?:2401.00001", &[1]); // `?` must not stand in for `v`
+        seed_root(&conn, "[a]rxiv:2401.00002", &[1]); // `[…]` must not act as a class
+
+        assert_eq!(candidate_ids(&conn), vec!["arxiv:*".to_string()]);
+    }
+
+    /// Deleted roots and roots with no stored PAPER row (nothing to compare a
+    /// poll result against) are both excluded; `known_version` is the newest
+    /// stored version, not the first or the count.
+    #[test]
+    fn stale_candidates_excludes_deleted_and_versionless_roots() {
+        let conn = db::open_in_memory().unwrap();
+        storage::init_db(&conn).unwrap();
+
+        seed_root(&conn, "arxiv:kept", &[1, 3, 2]);
+        seed_root(&conn, "arxiv:no-versions", &[]);
+        let deleted = seed_root(&conn, "arxiv:deleted", &[1]);
+        conn.execute(
+            "UPDATE PAPER_ROOTS SET STATUS = 'deleted' WHERE SOURCE_FK = ?1",
+            [deleted],
+        )
+        .unwrap();
+
+        let got = stale_candidates(&conn, MAX_VERSION_CHECK_BATCH).unwrap();
+        assert_eq!(got.len(), 1);
+        assert_eq!(got[0].source_id, "arxiv:kept");
+        assert_eq!(
+            got[0].known_version, 3,
+            "known_version must be MAX(VERSION)"
+        );
+    }
+
+    /// Never-checked roots come first, then the stalest LAST_CHECKED_AT; ties
+    /// (including the never-checked bucket) break on SOURCE_FK so the rotation
+    /// is deterministic rather than whatever order the join happens to emit.
+    #[test]
+    fn stale_candidates_orders_never_checked_first_then_stalest() {
+        let conn = db::open_in_memory().unwrap();
+        storage::init_db(&conn).unwrap();
+
+        let recent = seed_root(&conn, "arxiv:recent", &[1]);
+        let old = seed_root(&conn, "arxiv:old", &[1]);
+        let fresh_a = seed_root(&conn, "arxiv:fresh-a", &[1]);
+        let fresh_b = seed_root(&conn, "arxiv:fresh-b", &[1]);
+
+        // datetime('now') has second resolution, so pin the timestamps explicitly
+        // rather than relying on two record_check calls landing apart.
+        for (fk, at) in [
+            (recent, "2026-01-02 00:00:00"),
+            (old, "2026-01-01 00:00:00"),
+        ] {
+            record_check(&conn, fk, None).unwrap();
+            conn.execute(
+                "UPDATE VERSION_CHECK SET LAST_CHECKED_AT = ?2 WHERE SOURCE_FK = ?1",
+                params![fk, at],
+            )
+            .unwrap();
+        }
+
+        let got: Vec<i64> = stale_candidates(&conn, MAX_VERSION_CHECK_BATCH)
+            .unwrap()
+            .into_iter()
+            .map(|c| c.source_fk)
+            .collect();
+        assert_eq!(got, vec![fresh_a, fresh_b, old, recent]);
+    }
+
+    /// `limit` is clamped into `1..=MAX_VERSION_CHECK_BATCH` — a caller passing 0
+    /// or a negative must still make progress, and one passing a huge number must
+    /// not drag the whole library into a single poll pass.
+    #[test]
+    fn stale_candidates_clamps_limit() {
+        let conn = db::open_in_memory().unwrap();
+        storage::init_db(&conn).unwrap();
+        for i in 0..3 {
+            seed_root(&conn, &format!("arxiv:{i}"), &[1]);
+        }
+
+        assert_eq!(stale_candidates(&conn, 0).unwrap().len(), 1);
+        assert_eq!(stale_candidates(&conn, -7).unwrap().len(), 1);
+        assert_eq!(stale_candidates(&conn, 2).unwrap().len(), 2);
+        assert_eq!(stale_candidates(&conn, i64::MAX).unwrap().len(), 3);
+    }
+
+    /// A repeat check bumps LAST_CHECKED_AT but must not silently drop a flag the
+    /// user hasn't acknowledged yet (the COALESCE in the upsert) — that's the
+    /// difference between "you have a new version" and a badge that vanishes on
+    /// the next poll pass.
+    #[test]
+    fn record_check_upserts_and_preserves_unacked_flag() {
+        let conn = db::open_in_memory().unwrap();
+        storage::init_db(&conn).unwrap();
+        let fk = seed_root(&conn, "arxiv:2401.00001", &[1, 2]);
+
+        record_check(&conn, fk, None).unwrap();
+        let flag: Option<i64> = conn
+            .query_row("SELECT NEW_VERSION FROM VERSION_CHECK", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(flag, None);
+
+        record_check(&conn, fk, Some(2)).unwrap();
+        conn.execute(
+            "UPDATE VERSION_CHECK SET LAST_CHECKED_AT = '2026-01-01 00:00:00'",
+            [],
+        )
+        .unwrap();
+
+        // A later no-discovery pass keeps the un-acked 2 and still bumps the clock.
+        record_check(&conn, fk, None).unwrap();
+        let (flag, checked): (Option<i64>, String) = conn
+            .query_row(
+                "SELECT NEW_VERSION, LAST_CHECKED_AT FROM VERSION_CHECK",
+                [],
+                |r| Ok((r.get(0)?, r.get(1)?)),
+            )
+            .unwrap();
+        assert_eq!(flag, Some(2), "an un-acked flag must survive a quiet pass");
+        assert_ne!(checked, "2026-01-01 00:00:00");
+
+        // Exactly one row per root: the ON CONFLICT is an update, not an insert.
+        let rows: i64 = conn
+            .query_row("SELECT COUNT(*) FROM VERSION_CHECK", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(rows, 1);
+    }
+
+    /// The badge list shows only un-acked discoveries on active roots whose new
+    /// version was actually captured as a PAPER row, newest check first.
+    #[test]
+    fn list_new_versions_filters_and_orders() {
+        let conn = db::open_in_memory().unwrap();
+        storage::init_db(&conn).unwrap();
+
+        let a = seed_root(&conn, "arxiv:a", &[1, 2]);
+        let b = seed_root(&conn, "arxiv:b", &[1, 5]);
+        let acked = seed_root(&conn, "arxiv:acked", &[1, 2]);
+        let deleted = seed_root(&conn, "arxiv:deleted", &[1, 2]);
+        let uncaptured = seed_root(&conn, "arxiv:uncaptured", &[1]);
+
+        for (fk, v, at) in [
+            (a, 2, "2026-01-01 00:00:00"),
+            (b, 5, "2026-01-02 00:00:00"),
+            (acked, 2, "2026-01-03 00:00:00"),
+            (deleted, 2, "2026-01-04 00:00:00"),
+            (uncaptured, 2, "2026-01-05 00:00:00"), // flagged, no PAPER row at v2
+        ] {
+            record_check(&conn, fk, Some(v)).unwrap();
+            conn.execute(
+                "UPDATE VERSION_CHECK SET LAST_CHECKED_AT = ?2 WHERE SOURCE_FK = ?1",
+                params![fk, at],
+            )
+            .unwrap();
+        }
+        assert!(ack(&conn, acked).unwrap());
+        conn.execute(
+            "UPDATE PAPER_ROOTS SET STATUS = 'deleted' WHERE SOURCE_FK = ?1",
+            [deleted],
+        )
+        .unwrap();
+
+        let got = list_new_versions(&conn).unwrap();
+        assert_eq!(
+            got.iter().map(|n| n.source_id.as_str()).collect::<Vec<_>>(),
+            vec!["arxiv:b", "arxiv:a"],
+            "newest check first; acked / deleted / uncaptured excluded"
+        );
+        assert_eq!(got[0].version, 5);
+        assert_eq!(got[0].source_fk, b);
+        assert_eq!(
+            got[0].title, "arxiv:b v5",
+            "title comes from the new version"
+        );
+    }
+
+    #[test]
+    fn ack_clears_once_and_reports_whether_it_did() {
+        let conn = db::open_in_memory().unwrap();
+        storage::init_db(&conn).unwrap();
+        let fk = seed_root(&conn, "arxiv:2401.00001", &[1, 2]);
+
+        assert!(!ack(&conn, fk).unwrap(), "no VERSION_CHECK row yet");
+        record_check(&conn, fk, None).unwrap();
+        assert!(!ack(&conn, fk).unwrap(), "row exists but nothing flagged");
+
+        record_check(&conn, fk, Some(2)).unwrap();
+        assert!(ack(&conn, fk).unwrap());
+        assert!(!ack(&conn, fk).unwrap(), "second ack is a no-op");
+        assert!(list_new_versions(&conn).unwrap().is_empty());
+        assert!(!ack(&conn, 9999).unwrap(), "unknown root");
+    }
+
+    /// VERSION_CHECK rows are per-root bookkeeping, not user data: hard-deleting
+    /// the root must take the poll state with it (ON DELETE CASCADE), or the next
+    /// root to reuse that SOURCE_FK inherits a stale flag.
+    #[test]
+    fn version_check_row_cascades_with_its_root() {
+        let conn = db::open_in_memory().unwrap();
+        storage::init_db(&conn).unwrap();
+        let fk = seed_root(&conn, "arxiv:2401.00001", &[1, 2]);
+        record_check(&conn, fk, Some(2)).unwrap();
+
+        conn.execute("DELETE FROM PAPER_ROOTS WHERE SOURCE_FK = ?1", [fk])
+            .unwrap();
+
+        let rows: i64 = conn
+            .query_row("SELECT COUNT(*) FROM VERSION_CHECK", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(rows, 0);
+    }
+}

--- a/src-tauri/crates/core/src/storage/schema.rs
+++ b/src-tauri/crates/core/src/storage/schema.rs
@@ -60,3 +60,198 @@ pub fn apply_views(conn: &Connection) -> Result<()> {
 // No tables+views shortcut: the sole init path is `super::init_db`, which runs
 // run_migrations *between* tables and views. A tables-then-views shortcut would
 // skip the four unique indexes the migrations create — never reintroduce one.
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::storage::{db, migrations};
+
+    /// A DB predating `paper_meta_provider` (migration 02) and
+    /// `paper_roots_soft_delete` (migration 01) — the two migrations whose
+    /// columns `papers` / `deleted_papers` select. `apply_tables` cannot repair
+    /// these: their DDL is `CREATE TABLE IF NOT EXISTS`, so it sees the tables
+    /// and no-ops.
+    fn legacy_conn() -> rusqlite::Connection {
+        let conn = db::open_in_memory().unwrap();
+        conn.execute_batch(
+            "CREATE TABLE PAPER_ROOTS(
+                 SOURCE_FK  INTEGER PRIMARY KEY AUTOINCREMENT,
+                 SOURCE_ID  TEXT    NOT NULL UNIQUE,
+                 CREATED_AT TIMESTAMP NOT NULL DEFAULT (datetime('now')),
+                 UPDATED_AT TIMESTAMP NOT NULL DEFAULT (datetime('now'))
+             );
+             CREATE TABLE PAPER_META(
+                 PAPER_ID   INTEGER NOT NULL PRIMARY KEY,
+                 URL        TEXT,
+                 PUBLISHED  DATE,
+                 UPDATED    DATE,
+                 CATEGORIES LIST,
+                 DOI        TEXT,
+                 JOURNAL_REF TEXT,
+                 COMMENT    TEXT,
+                 SUMMARY    TEXT,
+                 PDF_PATH   TEXT,
+                 FULL_TEXT  TEXT,
+                 DOWNLOADED_SOURCE BOOL DEFAULT 0,
+                 AUTHORS    LIST,
+                 TAGS       LIST,
+                 CREATED_AT TIMESTAMP NOT NULL DEFAULT (datetime('now')),
+                 UPDATED_AT TIMESTAMP NOT NULL DEFAULT (datetime('now'))
+             );",
+        )
+        .unwrap();
+        conn
+    }
+
+    fn has_column(conn: &rusqlite::Connection, table: &str, col: &str) -> bool {
+        conn.prepare(&format!("PRAGMA table_info({table})"))
+            .unwrap()
+            .query_map([], |r| r.get::<_, String>(1))
+            .unwrap()
+            .collect::<rusqlite::Result<Vec<String>>>()
+            .unwrap()
+            .iter()
+            .any(|n| n.eq_ignore_ascii_case(col))
+    }
+
+    /// `apply_tables` runs table DDL and NOTHING else: every `.sql` file is
+    /// `CREATE TABLE IF NOT EXISTS`, so a table that already exists is left
+    /// exactly as-is — columns added to the base def since are NOT reconciled
+    /// onto it.
+    ///
+    /// This is the contract behind "any column added to a base `.sql` def needs a
+    /// companion guarded migration". If someone adds a column to PAPER_META.sql
+    /// and skips the migration, fresh installs get it and every existing user DB
+    /// silently doesn't — which is what the next test's failure mode looks like.
+    #[test]
+    fn apply_tables_does_not_reconcile_columns_onto_existing_tables() {
+        let conn = legacy_conn();
+        assert!(!has_column(&conn, "PAPER_META", "PROVIDER"));
+
+        apply_tables(&conn).unwrap();
+
+        assert!(
+            !has_column(&conn, "PAPER_META", "PROVIDER"),
+            "apply_tables must not be mistaken for a column reconciler"
+        );
+        assert!(!has_column(&conn, "PAPER_ROOTS", "STATUS"));
+        // It did still create the tables that were genuinely missing.
+        assert!(has_column(&conn, "PAPER", "SOURCE_FK"));
+    }
+
+    /// THE ORDERING INVARIANT: tables → migrations → views.
+    ///
+    /// The views select `PAPER_META.PROVIDER` and `PAPER_ROOTS.STATUS`, columns
+    /// only the migrations put on a legacy table. Running tables → views (the
+    /// "shortcut" the comment at the bottom of this file forbids) must fail;
+    /// slotting run_migrations in between must succeed.
+    ///
+    /// Reorder `init_db` to tables → views → migrations, or add a
+    /// tables-and-views convenience fn, and this test goes red.
+    #[test]
+    fn views_require_migrations_to_have_run_first() {
+        let conn = legacy_conn();
+        apply_tables(&conn).unwrap();
+
+        // SQLite resolves a view body lazily, so the failure can surface either at
+        // CREATE VIEW or at first SELECT — either way the phase order is wrong.
+        let skipped_migrations = apply_views(&conn).and_then(|()| {
+            Ok(conn.query_row("SELECT COUNT(*) FROM papers", [], |r| r.get::<_, i64>(0))?)
+        });
+        let err = skipped_migrations
+            .expect_err("views must not build against a DB the migrations haven't touched")
+            .to_string();
+        assert!(
+            err.contains("PROVIDER") || err.contains("STATUS"),
+            "expected a missing-migration-column error, got: {err}"
+        );
+
+        // Same DB, correct order: migrations first, then the views build and run.
+        migrations::run_migrations(&conn).unwrap();
+        apply_views(&conn).unwrap();
+        conn.query_row("SELECT COUNT(*) FROM papers", [], |r| r.get::<_, i64>(0))
+            .unwrap();
+        conn.query_row("SELECT COUNT(*) FROM deleted_papers", [], |r| {
+            r.get::<_, i64>(0)
+        })
+        .unwrap();
+    }
+
+    /// The other half of the ordering rule, at the front: `dedup_project_to_paper`
+    /// is `pub` precisely so `init_db` can call it OUTSIDE `run_migrations`,
+    /// BEFORE `apply_tables`. Once apply_tables has created PAPER_TO_READING with
+    /// its composite FK on (PROJECT_FK, SOURCE_FK), any DML on the still-unindexed
+    /// parent key is a hard "foreign key mismatch" — including the dedup DELETE
+    /// itself. Move the call into the migration list and a legacy DB with
+    /// duplicate memberships stops booting.
+    #[test]
+    fn dedup_project_to_paper_must_run_before_apply_tables() {
+        let conn = db::open_in_memory().unwrap();
+        conn.execute_batch(
+            "CREATE TABLE PROJECT_TO_PAPER(
+                 PROJECT_TO_PAPER_FK INTEGER NOT NULL PRIMARY KEY,
+                 PROJECT_FK  INTEGER NOT NULL,
+                 SOURCE_FK   INTEGER NOT NULL,
+                 CREATED_AT  TIMESTAMP NOT NULL DEFAULT (datetime('now')),
+                 UPDATED_AT  TIMESTAMP NOT NULL DEFAULT (datetime('now'))
+             );
+             INSERT INTO PROJECT_TO_PAPER (PROJECT_TO_PAPER_FK, PROJECT_FK, SOURCE_FK)
+                 VALUES (1, 7, 42), (2, 7, 42);",
+        )
+        .unwrap();
+
+        // Wrong order: tables first.
+        apply_tables(&conn).unwrap();
+        let err = migrations::dedup_project_to_paper(&conn)
+            .expect_err("dedup DML after apply_tables must not silently work")
+            .to_string();
+        assert!(
+            err.contains("foreign key mismatch"),
+            "expected the composite-FK mismatch that forces the pre-schema call, got: {err}"
+        );
+
+        // Right order (what init_db does) on the same legacy shape: boots clean.
+        let conn = db::open_in_memory().unwrap();
+        conn.execute_batch(
+            "CREATE TABLE PROJECT_TO_PAPER(
+                 PROJECT_TO_PAPER_FK INTEGER NOT NULL PRIMARY KEY,
+                 PROJECT_FK  INTEGER NOT NULL,
+                 SOURCE_FK   INTEGER NOT NULL,
+                 CREATED_AT  TIMESTAMP NOT NULL DEFAULT (datetime('now')),
+                 UPDATED_AT  TIMESTAMP NOT NULL DEFAULT (datetime('now'))
+             );
+             INSERT INTO PROJECT_TO_PAPER (PROJECT_TO_PAPER_FK, PROJECT_FK, SOURCE_FK)
+                 VALUES (1, 7, 42), (2, 7, 42);",
+        )
+        .unwrap();
+        crate::storage::init_db(&conn).unwrap();
+    }
+
+    /// Views are DROP-then-CREATE, so `apply_views` is safe to re-run on every
+    /// startup (it is: init_db runs unconditionally). A plain CREATE VIEW here
+    /// would fail the second call with "table papers already exists".
+    #[test]
+    fn apply_views_is_idempotent_and_creates_every_view() {
+        let conn = db::open_in_memory().unwrap();
+        crate::storage::init_db(&conn).unwrap();
+        apply_views(&conn).unwrap();
+
+        let mut views: Vec<String> = conn
+            .prepare("SELECT name FROM sqlite_master WHERE type = 'view'")
+            .unwrap()
+            .query_map([], |r| r.get(0))
+            .unwrap()
+            .collect::<rusqlite::Result<_>>()
+            .unwrap();
+        views.sort();
+        assert_eq!(
+            views,
+            vec![
+                "author_paper_counts",
+                "deleted_papers",
+                "latest_papers",
+                "papers"
+            ]
+        );
+    }
+}

--- a/src-tauri/crates/core/src/test_support.rs
+++ b/src-tauri/crates/core/src/test_support.rs
@@ -1,0 +1,44 @@
+//! Fixtures shared by the crate's in-module unit tests.
+//!
+//! `#[cfg(test)]`-only, so it can see private items — which is why the
+//! integration-test helper in `tests/common/` cannot be reused here (`tests/`
+//! is a separate compilation unit limited to the public API) and keeps its own
+//! four-line copy of [`db`].
+//!
+//! Only genuinely identical fixtures live here. Test modules that seed
+//! something of their own keep that seeding at the call site.
+
+use crate::models::PaperMetadata;
+use crate::storage::{db::open_in_memory, init_db};
+use chrono::NaiveDate;
+use rusqlite::Connection;
+
+/// A fresh in-memory DB with the schema applied.
+pub fn db() -> Connection {
+    let conn = open_in_memory().unwrap();
+    init_db(&conn).unwrap();
+    conn
+}
+
+/// A minimal arXiv `PaperMetadata` — everything optional left unset, so a test
+/// asserting on one field is not reading around a pile of unrelated fixture data.
+pub fn meta(source_id: &str, version: i64) -> PaperMetadata {
+    PaperMetadata {
+        source_id: source_id.into(),
+        version,
+        title: format!("Title of {source_id} v{version}"),
+        authors: vec!["Alice".into()],
+        published: NaiveDate::from_ymd_opt(2024, 1, 1).unwrap(),
+        updated: None,
+        summary: "s".into(),
+        category: Some("cs.LG".into()),
+        categories: Some(vec!["cs.LG".into()]),
+        doi: None,
+        journal_ref: None,
+        comment: None,
+        url: None,
+        tags: None,
+        source: Some("arxiv".into()),
+        author_orcids: None,
+    }
+}

--- a/src-tauri/crates/core/tests/common/mod.rs
+++ b/src-tauri/crates/core/tests/common/mod.rs
@@ -1,8 +1,11 @@
 //! Shared fixtures for `linxiv-core`'s integration tests.
 //!
-//! One schema-initialised in-memory DB, so a test does not hand-roll its own —
-//! roughly 20 in-module unit-test modules each define a private `mem()`/`db()`
-//! copy; migrating those is a separate pass, new tests start here.
+//! One schema-initialised in-memory DB, so a test does not hand-roll its own.
+//!
+//! Deliberately a copy of `src/test_support.rs`'s `db()`: that module is
+//! `#[cfg(test)]`, and `tests/` is a separate compilation unit that can only
+//! see `linxiv_core`'s public API. Four lines, so it stays duplicated rather
+//! than exposing a test-only module from the crate's public surface.
 
 use linxiv_core::storage;
 use rusqlite::Connection;

--- a/src-tauri/crates/core/tests/paper_source.rs
+++ b/src-tauri/crates/core/tests/paper_source.rs
@@ -143,7 +143,7 @@ async fn every_adapter_names_the_provider_its_records_carry() {
     // CONTEXT.md § Provider: PAPER_META.PROVIDER must equal the fetching module.
     assert_eq!(Arxiv::new(std::env::temp_dir()).name(), "arxiv");
     assert_eq!(OpenAlex::new("").name(), "openalex");
-    assert_eq!(CrossRef.name(), "crossref");
+    assert_eq!(CrossRef::new("").name(), "crossref");
 }
 
 #[tokio::test]
@@ -176,7 +176,7 @@ async fn real_adapters_refuse_bad_input_without_leaving_the_process() {
 
     // CrossRef no longer ignores `sort`: a key it cannot honour is refused
     // rather than silently dropped.
-    let err = CrossRef
+    let err = CrossRef::new("me@example.org")
         .search("attention", 5, "lastUpdated")
         .await
         .unwrap_err();

--- a/src-tauri/crates/share/src/lib.rs
+++ b/src-tauri/crates/share/src/lib.rs
@@ -379,14 +379,11 @@ pub fn import_shared_project(conn: &mut Connection, sp: &SharedProject) -> Resul
             }
             let title = truncate_text(&n.title);
             let content = truncate_text(&n.body);
-            if let Some(note_id) = e
-                .note_id
-                .filter(|_| e.title != title || e.content != content)
-            {
+            if e.title != title || e.content != content {
                 note_svc::update(
                     conn,
                     &NoteUpdateIn {
-                        note_id,
+                        note_id: e.note_id,
                         title: Some(title),
                         content: Some(content),
                     },

--- a/src/components/notes/NoteCard.tsx
+++ b/src/components/notes/NoteCard.tsx
@@ -24,26 +24,23 @@ export function NoteCard({ note, projects = [], onEdit, onDelete }: NoteCardProp
   const navigate = useNavigate();
   const cardRef = useRef<HTMLDivElement>(null);
   // Clicking the title/preview opens the full note on its own page so a long
-  // note can be read without dropping into the editor. id is effectively always
-  // set, but guard so a malformed note isn't a dead click.
-  const openNote = note.id != null ? () => navigate(`/notes/${note.id}`) : undefined;
+  // note can be read without dropping into the editor.
+  const openNote = () => navigate(`/notes/${note.id}`);
   // A drag-select that ends inside this region still fires click; don't navigate
   // away while the user is selecting preview text to copy. Only a selection
   // inside THIS card suppresses the click — a selection elsewhere shouldn't.
-  const handleCardClick = openNote
-    ? () => {
-        const sel = window.getSelection();
-        if (
-          sel &&
-          !sel.isCollapsed &&
-          sel.anchorNode &&
-          cardRef.current?.contains(sel.anchorNode)
-        ) {
-          return;
-        }
-        openNote();
-      }
-    : undefined;
+  const handleCardClick = () => {
+    const sel = window.getSelection();
+    if (
+      sel &&
+      !sel.isCollapsed &&
+      sel.anchorNode &&
+      cardRef.current?.contains(sel.anchorNode)
+    ) {
+      return;
+    }
+    openNote();
+  };
 
   const { date: stamp, edited: isEdited } = noteEdited(note);
   const scopeProject =
@@ -62,26 +59,17 @@ export function NoteCard({ note, projects = [], onEdit, onDelete }: NoteCardProp
       {/* Title + preview open the full-note page; actions row below stays separate. */}
       <div
         ref={cardRef}
-        role={openNote ? "button" : undefined}
-        tabIndex={openNote ? 0 : undefined}
-        aria-label={openNote ? `Open note: ${note.title || "Untitled note"}` : undefined}
+        role="button"
+        tabIndex={0}
+        aria-label={`Open note: ${note.title || "Untitled note"}`}
         onClick={handleCardClick}
-        onKeyDown={
-          openNote
-            ? (e) => {
-                if (e.key === "Enter" || e.key === " ") {
-                  e.preventDefault();
-                  openNote();
-                }
-              }
-            : undefined
-        }
-        className={
-          "flex flex-col gap-1.5" +
-          (openNote
-            ? " cursor-pointer rounded -m-1 p-1 transition-colors hover:bg-[var(--color-border)]"
-            : "")
-        }
+        onKeyDown={(e) => {
+          if (e.key === "Enter" || e.key === " ") {
+            e.preventDefault();
+            openNote();
+          }
+        }}
+        className="flex flex-col gap-1.5 cursor-pointer rounded -m-1 p-1 transition-colors hover:bg-[var(--color-border)]"
       >
         {/* Header: title + scope badge + date */}
         {/* Title on its own full-width row so it never competes with the scope

--- a/src/components/notes/NoteEditor.tsx
+++ b/src/components/notes/NoteEditor.tsx
@@ -71,10 +71,7 @@ export function NoteEditor({
     try {
       const trimmedTitle = title.trim();
       const trimmedContent = content.trim();
-      // NoteDetails.id is null only for a note that has not been inserted yet,
-      // which an editor loaded from the API never sees — update if we have one,
-      // otherwise fall through to create.
-      if (initialNote && initialNote.id !== null) {
+      if (initialNote) {
         await updateNote(initialNote.id, {
           title: trimmedTitle,
           content: trimmedContent,

--- a/src/components/papers/PaperCard.tsx
+++ b/src/components/papers/PaperCard.tsx
@@ -61,10 +61,7 @@ export const PaperCard = memo(function PaperCard({
       <button
         type="button"
         aria-label={`Open ${paper.title}`}
-        // PaperDetails.source_fk is optional in Rust (it doubles as a write
-        // shape); a row read back from the API always carries its root id.
-        disabled={paper.source_fk === null}
-        onClick={() => paper.source_fk !== null && onNavigate(paper.source_fk)}
+        onClick={() => onNavigate(paper.source_fk)}
         className="flex-1 text-left hover:brightness-110 cursor-pointer min-w-0"
       >
         {/* Meta row: category · arXiv id · venue/year · status badge */}

--- a/src/components/papers/PaperMetadataEditor.tsx
+++ b/src/components/papers/PaperMetadataEditor.tsx
@@ -47,13 +47,6 @@ export function PaperMetadataEditor({
       setError("At least one author is required.");
       return;
     }
-    // Repair is keyed by source_fk. PaperDetails leaves it optional in Rust
-    // (the struct doubles as a write shape), but every paper read back from
-    // the API has one — bail rather than PATCH a made-up id.
-    if (paper.source_fk === null) {
-      setError("This paper has no stable id to repair.");
-      return;
-    }
     setSubmitting(true);
     setError(null);
     try {

--- a/src/pages/GraphPage.tsx
+++ b/src/pages/GraphPage.tsx
@@ -318,12 +318,9 @@ export default function GraphPage() {
                   type="button"
                   key={project.id}
                   onClick={() =>
-                    project.id !== null &&
                     addToProjectMutation.mutate({ projectId: project.id, sourceIds: selectedSourceIds })
                   }
-                  // ProjectOut.id is optional in Rust (ProjectDetails doubles
-                  // as the write shape); a stored project always has one.
-                  disabled={addToProjectMutation.isPending || project.id === null}
+                  disabled={addToProjectMutation.isPending}
                   className="w-full text-left px-3 py-2 rounded-md border border-border hover:border-[var(--color-accent)] hover:text-[var(--color-accent)] text-text text-sm transition-colors disabled:opacity-50"
                 >
                   {project.name}

--- a/src/pages/LibraryPage.tsx
+++ b/src/pages/LibraryPage.tsx
@@ -504,10 +504,8 @@ export default function LibraryPage() {
                 <button
                   type="button"
                   key={project.id}
-                  onClick={() => project.id !== null && handleAddToProject(project.id)}
-                  // ProjectOut.id is optional in Rust (ProjectDetails doubles
-                  // as the write shape); a stored project always has one.
-                  disabled={addToProjectMutation.isPending || project.id === null}
+                  onClick={() => handleAddToProject(project.id)}
+                  disabled={addToProjectMutation.isPending}
                   className="w-full text-left px-3 py-2 rounded-md border border-border hover:border-[var(--color-accent)] hover:text-[var(--color-accent)] text-text text-sm transition-colors disabled:opacity-50"
                 >
                   {project.name}

--- a/src/pages/PaperDetailPage.tsx
+++ b/src/pages/PaperDetailPage.tsx
@@ -330,9 +330,7 @@ export default function PaperDetailPage() {
   }
 
   function handleDeleteNote(note: Note) {
-    // NoteDetails.id is optional in Rust (it doubles as the insert shape); a
-    // note listed from the API is already stored, so it always has one.
-    if (!deleteNoteMutation.isPending && note.id !== null) {
+    if (!deleteNoteMutation.isPending) {
       deleteNoteMutation.mutate(note.id);
     }
   }

--- a/src/types/generated.ts
+++ b/src/types/generated.ts
@@ -23,7 +23,11 @@ export type PaperDetails = {
   pdf_path: string | null,
   source: string | null,
   downloaded_source: boolean,
-  source_fk: number | null,
+  /**
+   * Never null: PAPER.SOURCE_FK is NOT NULL and every reader selects from
+   * the `papers` view.
+   */
+  source_fk: number,
 };
 
 export type SearchResultOut = {
@@ -47,7 +51,11 @@ export type SearchResultOut = {
 export type Status = "active" | "archived" | "deleted";
 
 export type ProjectOut = {
-  id: number | null,
+  /**
+   * Never null: `ProjectDetails.id` is optional only because that struct
+   * doubles as the pre-insert shape; `to_out` refuses a row without an id.
+   */
+  id: number,
   name: string,
   description: string,
   color_hex: string | null,
@@ -62,7 +70,10 @@ export type ProjectOut = {
 };
 
 export type NoteDetails = {
-  id: number | null,
+  /**
+   * NOTE_SK is the primary key; a read row always has one.
+   */
+  id: number,
   /**
    * Stable identity (uuid v4) surviving export/import + share.
    */


### PR DESCRIPTION
- **refactor: drop null from three read shapes**
- **test(core): add shared unit-test fixtures**
- **test(core): use shared db()/meta() fixtures**
- **feat(sources): wire CROSSREF_MAILTO to polite pool**
- **test(core): cover schema ordering + version_check**
- **fix(sources): sanitize polite UA to visible ASCII**
