### PR TITLE
fix: support Pacman in the in-app updater

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -154,6 +154,8 @@ jobs:
     name: Build (linux-x86_64-pacman)
     runs-on: ubuntu-22.04
     container: archlinux:base-devel
+    permissions:
+      contents: read
     steps:
       # The job container starts intentionally small. Install git/node before
       # checkout and the native libraries before the Tauri build.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,18 +41,7 @@ jobs:
       # over it. After v0.3.0-beta the next release is v0.3.1 — see docs/build.md.
       - name: Set app version from tag
         shell: bash
-        run: |
-          ver="${GITHUB_REF_NAME#v}"
-          jq --arg v "$ver" '.version = $v' src-tauri/tauri.conf.json > /tmp/tauri.conf.json
-          mv /tmp/tauri.conf.json src-tauri/tauri.conf.json
-          npm version "$ver" --no-git-tag-version --allow-same-version
-          # linxiv-p2p is a separate vendored submodule; its version is independent.
-          for f in src-tauri/Cargo.toml src-tauri/crates/*/Cargo.toml; do
-            [ "$f" = "src-tauri/crates/p2p/Cargo.toml" ] && continue
-            # -i.bak (suffix attached, no space) parses the same on GNU sed
-            # (Linux/Windows Git Bash) and BSD sed (macOS); bare `-i` doesn't.
-            sed -i.bak "s/^version = \".*\"/version = \"$ver\"/" "$f" && rm -f "$f.bak"
-          done
+        run: bash scripts/set_release_version.sh "$GITHUB_REF_NAME"
 
       - name: Refuse to release without real updater signing set up
         shell: bash
@@ -161,12 +150,51 @@ jobs:
           if-no-files-found: error
           retention-days: 1
 
+  build-arch:
+    name: Build (linux-x86_64-pacman)
+    runs-on: ubuntu-22.04
+    container: archlinux:base-devel
+    steps:
+      # The job container starts intentionally small. Install git/node before
+      # checkout and the native libraries before the Tauri build.
+      - name: Install Arch build dependencies
+        run: |
+          pacman -Syu --noconfirm --needed \
+            curl file git glib2 gtk3 libappindicator librsvg nodejs npm openssl \
+            patchelf rustup webkit2gtk-4.1 wget xdotool
+
+      - uses: actions/checkout@v7
+        with:
+          submodules: recursive
+
+      - name: Set app and package version from tag
+        run: bash scripts/set_release_version.sh "$GITHUB_REF_NAME"
+
+      # makepkg refuses to run as root, while GitHub job containers default to
+      # root. Build as an unprivileged account after dependency installation.
+      - name: Build native Arch package
+        run: |
+          useradd --create-home builder
+          chown -R builder:builder "$GITHUB_WORKSPACE"
+          runuser -u builder -- env HOME=/home/builder bash -c '
+            rustup default stable
+            npm ci
+            npm run build:arch
+          '
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: linxiv-arch-package
+          path: packaging/arch/*.pkg.tar.zst
+          if-no-files-found: error
+          retention-days: 1
+
   # Runs only once every build job has finished, which is what puts the raw
   # binaries at the BOTTOM of the release asset list rather than interleaved.
   # Keep this job last: anything uploaded after it lands below it too.
   upload-raw-binaries:
     name: Upload raw binaries
-    needs: build
+    needs: [build, build-arch]
     # fail-fast is off above so one broken platform still ships the others'
     # installers. Run on a partial matrix for the same reason: withholding
     # every binary because one runner died would be worse than the old
@@ -176,6 +204,20 @@ jobs:
     permissions:
       contents: write
     steps:
+      - name: Collect the native Arch package
+        if: ${{ needs.build-arch.result == 'success' }}
+        uses: actions/download-artifact@v4
+        with:
+          name: linxiv-arch-package
+          path: arch-package
+
+      - name: Upload the native Arch package
+        if: ${{ needs.build-arch.result == 'success' }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+        run: gh release upload "$GITHUB_REF_NAME" arch-package/*.pkg.tar.zst --clobber
+
       - name: Collect every platform's binaries
         uses: actions/download-artifact@v4
         with:

--- a/scripts/set_release_version.sh
+++ b/scripts/set_release_version.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# Keep every shipped package's version aligned with the release tag.
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+ver="${1#v}"
+if [[ ! "$ver" =~ ^[0-9]+\.[0-9]+\.[0-9]+([.-][0-9A-Za-z.-]+)?$ ]]; then
+  echo "invalid release version: $1" >&2
+  exit 1
+fi
+
+node -e '
+  const fs = require("node:fs");
+  const path = "src-tauri/tauri.conf.json";
+  const config = JSON.parse(fs.readFileSync(path, "utf8"));
+  config.version = process.argv[1];
+  fs.writeFileSync(path, `${JSON.stringify(config, null, 2)}\n`);
+' "$ver"
+
+npm version "$ver" --no-git-tag-version --allow-same-version
+
+# linxiv-p2p is a separate vendored submodule; its version is independent.
+for file in src-tauri/Cargo.toml src-tauri/crates/*/Cargo.toml; do
+  [[ "$file" == "src-tauri/crates/p2p/Cargo.toml" ]] && continue
+  sed -i.bak "s/^version = \".*\"/version = \"$ver\"/" "$file"
+  rm -f "$file.bak"
+done
+
+# PKGBUILD reserves hyphens as separators between pkgver, pkgrel and arch.
+arch_ver="${ver//-/_}"
+sed -i.bak "s/^pkgver=.*/pkgver=$arch_ver/" packaging/arch/PKGBUILD
+rm -f packaging/arch/PKGBUILD.bak

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -36,7 +36,7 @@ tauri-plugin-fs = "2"
 tauri-plugin-opener = "2"
 tauri-plugin-updater = "2"
 # relaunch() after an in-place update installs (AppImage via the updater plugin,
-# or deb/rpm via apply_linux_package_update below).
+# or deb/rpm/pacman via apply_linux_package_update below).
 tauri-plugin-process = "2"
 tauri-plugin-texbrain = { git = "https://github.com/linxiv-dev/tex-brain-linxiv-plugin", rev = "9499d4343033de0c3f1e52a2f2a06989fa4d2f13" }
 serde = { version = "1", features = ["derive"] }
@@ -73,7 +73,7 @@ keyring = { version = "3", features = [
 argon2 = "0.5"
 # Random DEK bytes on first run (same major as the lockfile's transitive copy).
 getrandom = "0.3"
-# deb/rpm self-update (apply_linux_package_update): downloads the release asset
+# Native-package self-update (apply_linux_package_update): downloads the release asset
 # directly, since the Tauri updater plugin only ever swaps AppImage/app.tar.gz/
 # NSIS-MSI in place. 0.12.x already pulled transitively (linxiv-core/tex-brain);
 # tauri-plugin-updater pulls its own, newer 0.13.x separately. json: parses the
@@ -81,10 +81,10 @@ getrandom = "0.3"
 # instead of trusting Content-Length.
 reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "json", "stream"] }
 # apply_linux_package_update: an O_EXCL-created unique path for the downloaded
-# deb/rpm, so a local process can't symlink-swap a predictable temp path
+# native packages, so a local process can't symlink-swap a predictable temp path
 # before pkexec reads it. (Also used by the share-dispatcher test below.)
 tempfile = "3"
-# apply_linux_package_update: verify the downloaded deb/rpm against the sha256
+# apply_linux_package_update: verify the downloaded native package against the sha256
 # GitHub's Releases API reports for the asset (fetched over api.github.com,
 # a separate channel from the objects.githubusercontent.com download).
 sha2 = "0.10"

--- a/src-tauri/src/integrations.rs
+++ b/src-tauri/src/integrations.rs
@@ -336,22 +336,23 @@ pub fn uninstall_cli() -> Result<(), String> {
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
-// In-place update: deb/rpm
+// In-place update: deb/rpm/pacman
 //
 // The Tauri updater plugin (main.rs) only ever swaps an AppImage, a macOS
 // app.tar.gz, or a Windows NSIS/MSI in place — it has no notion of a
-// dpkg/rpm-managed install. Rather than standing up an APT/YUM repository (a
-// separate hosting + package-signing project), a deb/rpm install self-updates
+// package-manager-owned install. Rather than standing up distro repositories
+// (a separate hosting + package-signing project), a native install self-updates
 // by downloading the matching asset straight off the GitHub release and
 // installing it with `pkexec`, the same one-time privilege prompt a user
 // would see running `dpkg -i`/`rpm -U` by hand.
 // ─────────────────────────────────────────────────────────────────────────────
 
-/// "deb", "rpm", or `None` (AppImage, dev build, or a non-Linux platform).
+/// "deb", "rpm", "pacman", or `None` (AppImage, dev build, or a non-Linux
+/// platform).
 ///
 /// Resolved by asking the system package database whether it owns the
 /// running executable — `is_cli_installed`'s approach of trusting a fixed
-/// path doesn't apply here, since deb/rpm both put the binary at
+/// path doesn't apply here, since native packages put the binary at
 /// `/usr/bin/linxiv` and only the package manager can say which one (if
 /// either) actually installed it.
 fn linux_package_kind() -> Option<&'static str> {
@@ -369,13 +370,17 @@ fn linux_package_kind() -> Option<&'static str> {
         Some("deb")
     } else if owned_by("rpm", &["-qf", &exe.to_string_lossy()]) {
         Some("rpm")
+    } else if owned_by("pacman", &["-Qo", &exe.to_string_lossy()]) {
+        // Pacman packages cannot be replaced by Tauri's AppImage updater;
+        // route them through the native package path as well.
+        Some("pacman")
     } else {
         None
     }
 }
 
 /// JS-facing: which package manager (if any) owns this install, so the UI can
-/// pick the update path (deb/rpm here vs. the Tauri updater plugin for
+/// pick the update path (native package here vs. the Tauri updater plugin for
 /// everything else). `dpkg -S`/`rpm -qf` read the whole package database, so
 /// this runs off the main thread like any other blocking probe.
 #[tauri::command]
@@ -412,7 +417,7 @@ fn is_allowed_asset_url(url: &str) -> bool {
             .is_some_and(|h| ALLOWED_ASSET_HOSTS.contains(&h))
 }
 
-/// Upper bound on a downloaded deb/rpm — generous for a desktop app package,
+/// Upper bound on a downloaded native package — generous for a desktop app,
 /// just enough to refuse an absurd/misconfigured response before install.
 const MAX_UPDATE_PACKAGE_BYTES: u64 = 300 * 1024 * 1024;
 
@@ -453,8 +458,16 @@ async fn resolve_release_asset(
     release
         .assets
         .into_iter()
-        .find(|a| a.name.ends_with(&format!(".{kind}")) && a.name.contains(arch))
-        .ok_or_else(|| format!("No {arch} .{kind} asset found on the latest release"))
+        .find(|a| package_asset_matches(&a.name, kind, arch))
+        .ok_or_else(|| format!("No {arch} {kind} asset found on the latest release"))
+}
+
+fn package_asset_matches(name: &str, kind: &str, arch: &str) -> bool {
+    let suffix = match kind {
+        "pacman" => ".pkg.tar.zst",
+        other => return name.ends_with(&format!(".{other}")) && name.contains(arch),
+    };
+    name.starts_with("linxiv-") && name.ends_with(suffix) && name.contains(arch)
 }
 
 /// release.yml's asset naming: rpm carries the raw Rust arch ("x86_64",
@@ -467,8 +480,8 @@ fn arch_token<'a>(rust_arch: &'a str, kind: &str) -> &'a str {
     }
 }
 
-/// `dpkg -i`/`rpm -U` don't check a signature on what they install, and
-/// deb/rpm assets aren't covered by `createUpdaterArtifacts`'s minisign
+/// `dpkg -i`/`rpm -U`/`pacman -U` don't check a signature on what they install,
+/// and native package assets aren't covered by `createUpdaterArtifacts`'s minisign
 /// signing (that only signs the AppImage/app.tar.gz/NSIS-MSI artifacts) — so
 /// unlike that path, this one has no real code-signing: the sha256 checked
 /// here comes from the same GitHub API response as the download URL, so it
@@ -494,7 +507,7 @@ pub async fn apply_linux_package_update() -> Result<(), String> {
     let kind = tokio::task::spawn_blocking(linux_package_kind)
         .await
         .map_err(|e| e.to_string())?
-        .ok_or("Not a deb/rpm install")?;
+        .ok_or("Not a supported native package install")?;
 
     let client = reqwest::Client::builder()
         .timeout(std::time::Duration::from_secs(600))
@@ -543,25 +556,35 @@ pub async fn apply_linux_package_update() -> Result<(), String> {
         // shared-dir path could be symlink-swapped by another local user
         // between write and pkexec's read; this one can't be pre-created or
         // guessed.
+        let suffix = if kind == "pacman" {
+            "pkg.tar.zst"
+        } else {
+            kind
+        };
         let mut tmp = tempfile::Builder::new()
             .prefix("linxiv-update-")
-            .suffix(&format!(".{kind}"))
+            .suffix(&format!(".{suffix}"))
             .tempfile()
             .map_err(|e| format!("Could not create temp file: {e}"))?;
         tmp.write_all(&bytes)
             .and_then(|_| tmp.flush())
             .map_err(|e| format!("Could not write update package: {e}"))?;
 
-        let (installer, install_args): (&str, &str) = match kind {
-            "deb" => ("dpkg", "-i"),
-            _ => ("rpm", "-U"),
+        let (installer, install_args): (&str, &[&str]) = match kind {
+            "deb" => ("dpkg", &["-i"]),
+            "rpm" => ("rpm", &["-U"]),
+            "pacman" => ("pacman", &["-U", "--noconfirm"]),
+            _ => return Err(format!("Unsupported package manager: {kind}")),
         };
         let path_str = tmp.path().to_string_lossy().to_string();
         eprintln!(
-            "[linxiv] apply_linux_package_update: pkexec {installer} {install_args} {path_str}"
+            "[linxiv] apply_linux_package_update: pkexec {installer} {} {path_str}",
+            install_args.join(" ")
         );
         let status = std::process::Command::new("pkexec")
-            .args([installer, install_args, &path_str])
+            .arg(installer)
+            .args(install_args)
+            .arg(&path_str)
             .status()
             .map_err(|e| format!("Could not launch pkexec: {e}"))?;
         // tmp stays in scope (not dropped/deleted) until here.
@@ -1459,9 +1482,34 @@ mod tests {
             ("x86_64", "rpm", "x86_64"),
             ("aarch64", "deb", "arm64"),
             ("aarch64", "rpm", "aarch64"),
+            ("x86_64", "pacman", "x86_64"),
         ];
         for (rust_arch, kind, expected) in cases {
             assert_eq!(arch_token(rust_arch, kind), *expected);
         }
+    }
+
+    #[test]
+    fn native_package_asset_matching() {
+        assert!(package_asset_matches(
+            "linxiv-0.4.1-1-x86_64.pkg.tar.zst",
+            "pacman",
+            "x86_64"
+        ));
+        assert!(!package_asset_matches(
+            "linxiv-0.4.1-1-aarch64.pkg.tar.zst",
+            "pacman",
+            "x86_64"
+        ));
+        assert!(package_asset_matches(
+            "linXiv_0.4.1_amd64.deb",
+            "deb",
+            "amd64"
+        ));
+        assert!(package_asset_matches(
+            "linXiv-0.4.1-1.x86_64.rpm",
+            "rpm",
+            "x86_64"
+        ));
     }
 }

--- a/src/api/updates.ts
+++ b/src/api/updates.ts
@@ -137,19 +137,19 @@ export async function openReleaseUrl(url: string): Promise<void> {
   }
 }
 
+export type LinuxPackageKind = "deb" | "rpm" | "pacman";
+
 /**
- * Which package manager (if any) owns this install: "deb" or "rpm" route the
- * update through `apply_linux_package_update` (pkexec dpkg/rpm — the Tauri
- * updater plugin only knows how to swap an AppImage), null routes through the
- * updater plugin (AppImage/macOS/Windows) or, outside Tauri, the browser
- * download fallback.
+ * Which package manager (if any) owns this install. Native packages route
+ * through the privileged package updater; null routes through the Tauri
+ * updater (AppImage/macOS/Windows) or the browser fallback outside Tauri.
  */
-export async function getLinuxPackageKind(): Promise<"deb" | "rpm" | null> {
+export async function getLinuxPackageKind(): Promise<LinuxPackageKind | null> {
   if (!isTauri) return null;
   try {
     const { invoke } = await import("@tauri-apps/api/core");
     const kind = await invoke<string | null>("get_linux_package_kind");
-    return kind === "deb" || kind === "rpm" ? kind : null;
+    return kind === "deb" || kind === "rpm" || kind === "pacman" ? kind : null;
   } catch {
     return null;
   }
@@ -159,12 +159,12 @@ export async function getLinuxPackageKind(): Promise<"deb" | "rpm" | null> {
  * Install the update and relaunch. Never called outside Tauri (the browser
  * build only ever offers the "Download" fallback).
  *
- * For deb/rpm, `apply_linux_package_update` resolves the asset itself from
+ * For native packages, `apply_linux_package_update` resolves the asset itself from
  * the pinned repo's latest release — it never takes a URL from here, since
  * that would let webview JS point a root-privileged install at an arbitrary
  * GitHub-hosted asset.
  */
-export async function installUpdate(packageKind: "deb" | "rpm" | null): Promise<void> {
+export async function installUpdate(packageKind: LinuxPackageKind | null): Promise<void> {
   if (!isTauri) throw new Error("Not running in Tauri");
 
   if (packageKind) {

--- a/src/components/settings/AboutSection.tsx
+++ b/src/components/settings/AboutSection.tsx
@@ -9,6 +9,7 @@ import {
   getLinuxPackageKind,
   installUpdate,
   openReleaseUrl,
+  type LinuxPackageKind,
   type UpdateResult,
 } from "../../api/updates";
 import {
@@ -102,7 +103,7 @@ function UpdateMessage({
   installError,
 }: {
   result: UpdateResult;
-  packageKind: "deb" | "rpm" | null;
+  packageKind: LinuxPackageKind | null;
   packageKindResolved: boolean;
   onInstall: () => void;
   installing: boolean;
@@ -173,9 +174,9 @@ export function AboutSection() {
   const { hash } = useLocation();
   const [version, setVersion] = useState<string | null>(null);
   const [versionResolved, setVersionResolved] = useState(false);
-  const [packageKind, setPackageKind] = useState<"deb" | "rpm" | null>(null);
+  const [packageKind, setPackageKind] = useState<LinuxPackageKind | null>(null);
   // A seeded result paints Install on the first render, before the IPC hop
-  // that says which install path applies; a deb/rpm click before then would
+  // that says which install path applies; a native-package click before then would
   // route through the AppImage updater.
   const [packageKindResolved, setPackageKindResolved] = useState(false);
   const [installing, setInstalling] = useState(false);


### PR DESCRIPTION
## Summary

- detect Pacman-owned installations instead of routing them through Tauri's AppImage updater
- download, checksum-verify, and install native Arch packages with `pkexec pacman -U`
- build and upload a `.pkg.tar.zst` from an Arch Linux release job
- stamp the app, Rust crates, npm package, and PKGBUILD from one release-version script

## Root cause

The Linux package probe only checked `dpkg` and `rpm`. On Arch and Manjaro, Pacman owns `/usr/bin/linxiv-app`, but the probe returned `None`, so the frontend treated the installation like an AppImage. Tauri's updater then attempted to replace a root-owned native package and the in-app update failed.

## Impact

Future releases include a native Arch artifact, and Pacman installations can update through the existing **Install and restart** flow while remaining registered with the system package manager.

## Validation

- `npm run build`
- `cargo fmt --all --check`
- `cargo test --lib native_package_asset_matching`
- `bash -n scripts/set_release_version.sh`
- exercised stable and prerelease version stamping
- built `linxiv-0.4.0-1-x86_64.pkg.tar.zst` on Manjaro
- installed the package with Pacman and verified `linxiv 0.4.0` plus `pacman -Qkk linxiv` (0 altered files)
