### PR TITLE
fix(desktop): set app category and description for Linux desktop entries

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -32,6 +32,8 @@
     "active": true,
     "targets": "all",
     "createUpdaterArtifacts": true,
+    "category": "Education",
+    "shortDescription": "Discover, manage, and visualize academic papers",
     "icon": [
       "icons/32x32.png",
       "icons/128x128.png",


### PR DESCRIPTION
deb/rpm/AppImage .desktop files were generated with an empty Categories
and a generic Comment since tauri.conf.json never set them. Closes #200.
