### PR TITLE
perf/rusty

### DIFF
--- a/src-tauri/crates/cli/src/cmd/paper.rs
+++ b/src-tauri/crates/cli/src/cmd/paper.rs
@@ -87,11 +87,8 @@ pub(super) fn resolve_paper_or_exit(
     svc_paper::get_required(&ctx.conn, source_id).unwrap_or_else(|e| fail(e))
 }
 
-fn paper(source_id: &str) -> svc_paper::Paper {
-    svc_paper::Paper {
-        source_id: Some(source_id.to_string()),
-        ..Default::default()
-    }
+fn paper(source_id: &str) -> svc_paper::PaperRef {
+    svc_paper::PaperRef::source(source_id.to_string())
 }
 
 pub async fn run(cmd: PaperCmd, ctx: &mut Ctx) -> anyhow::Result<()> {

--- a/src-tauri/crates/cli/src/cmd/pdf.rs
+++ b/src-tauri/crates/cli/src/cmd/pdf.rs
@@ -175,10 +175,7 @@ pub async fn run(cmd: PdfCmd, ctx: &mut Ctx) -> anyhow::Result<()> {
             let source_id = as_source_id(&ctx.conn, &source_id);
             let all = match svc_paper::get_all(
                 &ctx.conn,
-                &svc_paper::Paper {
-                    source_id: Some(source_id.clone()),
-                    ..Default::default()
-                },
+                &svc_paper::PaperRef::source(source_id.clone()),
             )? {
                 Some(all) => all,
                 None => fail(linxiv_core::error::CoreError::PaperNotFound(
@@ -251,10 +248,7 @@ pub async fn run(cmd: PdfCmd, ctx: &mut Ctx) -> anyhow::Result<()> {
 fn stored_versions(ctx: &Ctx, source_id: &str) -> Vec<i64> {
     svc_paper::get_all(
         &ctx.conn,
-        &svc_paper::Paper {
-            source_id: Some(source_id.to_string()),
-            ..Default::default()
-        },
+        &svc_paper::PaperRef::source(source_id.to_string()),
     )
     .ok()
     .flatten()

--- a/src-tauri/crates/cli/src/cmd/tag.rs
+++ b/src-tauri/crates/cli/src/cmd/tag.rs
@@ -4,7 +4,7 @@ use clap::Subcommand;
 use serde_json::json;
 
 use linxiv_core::models::TagIn;
-use linxiv_core::service::paper::{self as svc_paper, Paper};
+use linxiv_core::service::paper::{self as svc_paper, PaperRef};
 use linxiv_core::service::project as svc_project;
 use linxiv_core::service::tag::{self as svc_tag, Tag};
 
@@ -68,15 +68,9 @@ pub async fn run(cmd: TagCmd, ctx: &mut Ctx) -> anyhow::Result<()> {
         // cmd_tag_list: missing paper -> empty list (no error), matching get_paper_tags.
         TagCmd::List { source_id } => {
             let source_id = as_source_id(&ctx.conn, &source_id);
-            let tags = svc_paper::get(
-                &ctx.conn,
-                &Paper {
-                    source_id: Some(source_id.clone()),
-                    ..Default::default()
-                },
-            )?
-            .map(|d| d.tags)
-            .unwrap_or_default();
+            let tags = svc_paper::get(&ctx.conn, &PaperRef::source(source_id.clone()))?
+                .map(|d| d.tags)
+                .unwrap_or_default();
             output(&json!({ "source_id": source_id, "tags": tags }));
         }
         // cmd_tag_list_all

--- a/src-tauri/crates/cli/src/cmd/trash.rs
+++ b/src-tauri/crates/cli/src/cmd/trash.rs
@@ -2,7 +2,7 @@
 
 use clap::Subcommand;
 
-use linxiv_core::service::paper::{self as svc_paper, Paper};
+use linxiv_core::service::paper::{self as svc_paper, PaperRef};
 use linxiv_core::service::project::{self as svc_project, Project};
 
 use crate::ctx::Ctx;
@@ -32,13 +32,8 @@ pub async fn run(cmd: TrashCmd, ctx: &mut Ctx) -> anyhow::Result<()> {
         TrashCmd::Restore { source_id } => {
             let source_id = as_source_id(&ctx.conn, &source_id);
             svc_paper::require_trashed(&ctx.conn, &source_id).unwrap_or_else(|e| fail(e));
-            let (pdf_path, project_fks) = svc_paper::restore(
-                &mut ctx.conn,
-                &Paper {
-                    source_id: Some(source_id.clone()),
-                    ..Default::default()
-                },
-            )?;
+            let (pdf_path, project_fks) =
+                svc_paper::restore(&mut ctx.conn, &PaperRef::source(source_id.clone()))?;
             output(&linxiv_core::service::trash::RestoredPaper {
                 ok: true,
                 restored: source_id,
@@ -52,14 +47,8 @@ pub async fn run(cmd: TrashCmd, ctx: &mut Ctx) -> anyhow::Result<()> {
             svc_paper::require_trashed(&ctx.conn, &source_id).unwrap_or_else(|e| fail(e));
             // _do_paper_hard_delete: get_paper_root None -> not found; here unreachable
             // after the guard, but mirror the message off hard_delete's None return.
-            if svc_paper::hard_delete(
-                &mut ctx.conn,
-                &Paper {
-                    source_id: Some(source_id.clone()),
-                    ..Default::default()
-                },
-            )?
-            .is_none()
+            if svc_paper::hard_delete(&mut ctx.conn, &PaperRef::source(source_id.clone()))?
+                .is_none()
             {
                 fail(linxiv_core::error::CoreError::PaperNotFound(
                     source_id.clone(),

--- a/src-tauri/crates/core/src/service/export_import.rs
+++ b/src-tauri/crates/core/src/service/export_import.rs
@@ -3,8 +3,9 @@
 //! A `.lxproj` file is a zip archive: `manifest.json` (project + papers + notes,
 //! all keyed by source_id — no local DB ids) plus optional `pdfs/{source_id}_v{n}.pdf`
 //! entries. That archive PDF name (`{source_id}_v{version}.pdf`, WITH the `_v`
-//! separator) is DISTINCT from the on-disk managed name `{safe}v{version}.pdf`
-//! (`service::paper::pdf_on_disk_name`) — do NOT unify the two.
+//! separator) is owned by [`ArchivePdfName`] and is DISTINCT from the on-disk
+//! managed name `{safe}v{version}.pdf` (`service::paper::pdf_on_disk_name`) —
+//! the separate type/helper keep the two formats unmixable; do NOT unify them.
 //!
 //! DI seam: every DB-touching fn takes `conn` first; every FS-touching fn takes the
 //! resolved `pdf_dir: &Path` as a param. Nothing here reads config.
@@ -224,6 +225,42 @@ pub struct AnnotationEntry {
     pub uuid: Option<String>,
 }
 
+/// Archive PDF name: in-zip path `pdfs/{source_id}_v{version}.pdf` (WITH the
+/// `_v` separator). Owns both directions of the archive format. DISTINCT from
+/// the on-disk managed name `{safe}v{version}.pdf`
+/// (`service::paper::pdf_on_disk_name`) — the two types keep the formats
+/// unmixable; do NOT unify them.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ArchivePdfName {
+    pub source_id: String,
+    pub version: i64,
+}
+
+impl ArchivePdfName {
+    /// Decode an in-zip entry path. Returns `None` for entries the import
+    /// loop skips: non-`.pdf` names and stems without `_v`. (The `pdfs/`
+    /// prefix is filtered at the zip layer; here any directory prefix is
+    /// dropped via the basename.) Splits on the LAST `_v` — the encoded
+    /// `_v{version}` suffix is always the last one, so source_ids that
+    /// themselves contain `_v` round-trip. A non-numeric version falls back
+    /// to 1 (Python import parity).
+    pub fn parse_entry(archive_name: &str) -> Option<Self> {
+        let basename = archive_name.rsplit('/').next().unwrap_or(archive_name);
+        let stem = basename.strip_suffix(".pdf")?;
+        let sep = stem.rfind("_v")?;
+        Some(Self {
+            source_id: stem[..sep].to_string(),
+            version: stem[sep + 2..].parse().unwrap_or(1),
+        })
+    }
+}
+
+impl std::fmt::Display for ArchivePdfName {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "pdfs/{}_v{}.pdf", self.source_id, self.version)
+    }
+}
+
 /// A decoded archive PDF entry. `archive_name` is the in-zip path, e.g.
 /// `pdfs/2204.12985_v1.pdf`; the zip layer fills `bytes` from the archive.
 #[derive(Debug, Clone)]
@@ -323,7 +360,11 @@ pub fn build_manifest(
             let Some(stored) = &p.pdf_path else { continue };
             let local = pdf_dir.join(stored);
             if local.is_file() {
-                pdf_files.push((format!("pdfs/{}_v{}.pdf", p.source_id, p.version), local));
+                let name = ArchivePdfName {
+                    source_id: p.source_id.clone(),
+                    version: p.version,
+                };
+                pdf_files.push((name.to_string(), local));
             }
         }
     }
@@ -573,30 +614,25 @@ fn import_pdfs(
     std::fs::create_dir_all(pdf_dir).map_err(|e| CoreError::Internal(e.to_string()))?;
 
     for entry in pdfs {
+        let Some(name) = ArchivePdfName::parse_entry(&entry.archive_name) else {
+            continue;
+        };
+        if !source_ids.iter().any(|s| s == &name.source_id) {
+            continue;
+        }
+
+        // Dest keeps the archive basename VERBATIM (not re-encoded): a
+        // non-canonical stem like `a_v01.pdf` must land on disk unchanged.
         let basename = entry
             .archive_name
             .rsplit('/')
             .next()
             .unwrap_or(&entry.archive_name);
-        let Some(stem) = basename.strip_suffix(".pdf") else {
-            continue;
-        };
-        // Last "_v" splits source_id from version.
-        let Some(sep) = stem.rfind("_v") else {
-            continue;
-        };
-        let source_id = &stem[..sep];
-        let version_str = &stem[sep + 2..];
-        if !source_ids.iter().any(|s| s == source_id) {
-            continue;
-        }
-
         let dest = pdf_dir.join(basename);
         std::fs::write(&dest, &entry.bytes).map_err(|e| CoreError::Internal(e.to_string()))?;
-        let version: i64 = version_str.parse().unwrap_or(1);
         let dest_str = dest.to_string_lossy().to_string();
 
-        if let Err(e) = paper::mark_pdf_saved(conn, source_id, &dest_str, version) {
+        if let Err(e) = paper::mark_pdf_saved(conn, &name.source_id, &dest_str, name.version) {
             // Bundled PDF names a version that wasn't imported: drop the file, log, skip.
             let _ = std::fs::remove_file(&dest);
             tracing::warn!("import: skipping PDF {basename}: {e}");
@@ -727,6 +763,76 @@ mod tests {
     use crate::models::{AnnotationIn, Status};
     use crate::test_support::db;
     use chrono::NaiveDate;
+
+    // ── ArchivePdfName (pins the exact legacy import-loop behavior) ─────────
+
+    #[test]
+    fn archive_pdf_name_display() {
+        let n = ArchivePdfName {
+            source_id: "2204.12985".into(),
+            version: 1,
+        };
+        assert_eq!(n.to_string(), "pdfs/2204.12985_v1.pdf");
+    }
+
+    #[test]
+    fn archive_pdf_name_parse_skips_and_accepts_like_import_loop() {
+        // Skipped: non-.pdf suffix, stem without "_v".
+        assert_eq!(ArchivePdfName::parse_entry("pdfs/a_v1.txt"), None);
+        assert_eq!(ArchivePdfName::parse_entry("pdfs/av1.pdf"), None);
+        // Accepted regardless of directory prefix — only the basename is
+        // parsed (the `pdfs/` filter lives at the zip layer).
+        for path in [
+            "pdfs/a_v2.pdf",
+            "other/a_v2.pdf",
+            "a_v2.pdf",
+            "x/y/a_v2.pdf",
+        ] {
+            assert_eq!(
+                ArchivePdfName::parse_entry(path),
+                Some(ArchivePdfName {
+                    source_id: "a".into(),
+                    version: 2,
+                }),
+                "{path}"
+            );
+        }
+        // Non-numeric or empty version falls back to 1.
+        assert_eq!(
+            ArchivePdfName::parse_entry("pdfs/a_vX.pdf")
+                .unwrap()
+                .version,
+            1
+        );
+        assert_eq!(
+            ArchivePdfName::parse_entry("pdfs/a_v.pdf").unwrap().version,
+            1
+        );
+    }
+
+    #[test]
+    fn archive_pdf_name_round_trips() {
+        // Property-style: parse(display(n)) == n. Includes source_ids that
+        // themselves contain "_v" — rfind splits on the LAST "_v", which is
+        // always the encoded `_v{version}` suffix.
+        for sid in [
+            "2204.12985",
+            "arxiv:1",
+            "foo_v2_bar",
+            "a_v",
+            "_v",
+            "x_v5",
+            "",
+        ] {
+            for version in [0, 1, 7, 12, 130] {
+                let n = ArchivePdfName {
+                    source_id: sid.into(),
+                    version,
+                };
+                assert_eq!(ArchivePdfName::parse_entry(&n.to_string()), Some(n));
+            }
+        }
+    }
 
     fn meta(source_id: &str, version: i64, title: &str, tags: &[&str]) -> PaperMetadata {
         PaperMetadata {

--- a/src-tauri/crates/core/src/service/export_import.rs
+++ b/src-tauri/crates/core/src/service/export_import.rs
@@ -291,14 +291,7 @@ pub fn build_manifest(
             continue; // Python skips notes whose source_id no longer resolves.
         };
         let version = match n.paper_id_fk {
-            Some(pid) => paper::get(
-                conn,
-                &paper::Paper {
-                    paper_id: Some(pid),
-                    ..Default::default()
-                },
-            )?
-            .map(|p| p.version),
+            Some(pid) => paper::get(conn, &paper::PaperRef::Id(pid))?.map(|p| p.version),
             None => None,
         };
         note_entries.push(NoteEntry {
@@ -520,13 +513,7 @@ fn commit_body(
         match paperq::get_paper_root(conn, &source_id)? {
             Some(root) => {
                 if root.status == "deleted" {
-                    paper::restore(
-                        conn,
-                        &paper::Paper {
-                            source_id: Some(source_id.clone()),
-                            ..Default::default()
-                        },
-                    )?;
+                    paper::restore(conn, &paper::PaperRef::source(source_id.clone()))?;
                 }
                 if on_conflict == OnConflict::Overwrite {
                     // Storage-level: an archive replays already-stored metadata, so it
@@ -640,10 +627,9 @@ fn import_notes(
         let paper_id = match nd.paper_version {
             Some(v) if v != 0 => paper::get(
                 conn,
-                &paper::Paper {
-                    source_id: Some(paper_source_id.clone()),
+                &paper::PaperRef::Source {
+                    source_id: paper_source_id.clone(),
                     version: Some(v),
-                    ..Default::default()
                 },
             )?
             .map(|p| p.paper_id),
@@ -890,10 +876,9 @@ mod tests {
         // A note pinned to arxiv:1 v1.
         let pid_v1 = paper::get(
             &conn,
-            &paper::Paper {
-                source_id: Some("arxiv:1".into()),
+            &paper::PaperRef::Source {
+                source_id: "arxiv:1".into(),
                 version: Some(1),
-                ..Default::default()
             },
         )
         .unwrap()
@@ -998,15 +983,9 @@ mod tests {
         assert_eq!(got.source_fks.len(), 1, "paper linked to the new project");
 
         // Paper metadata saved.
-        let p = paper::get(
-            &conn,
-            &paper::Paper {
-                source_id: Some("arxiv:1".into()),
-                ..Default::default()
-            },
-        )
-        .unwrap()
-        .unwrap();
+        let p = paper::get(&conn, &paper::PaperRef::source("arxiv:1".into()))
+            .unwrap()
+            .unwrap();
         assert_eq!(p.title, "New Paper");
 
         // PDF written under the archive basename + recorded on the paper.
@@ -1049,15 +1028,9 @@ mod tests {
             let pid =
                 commit_from_manifest(&mut conn, &manifest, &[], OnConflict::Merge, tmp.path())
                     .unwrap();
-            let p = paper::get(
-                &conn,
-                &paper::Paper {
-                    source_id: Some("arxiv:1".into()),
-                    ..Default::default()
-                },
-            )
-            .unwrap()
-            .unwrap();
+            let p = paper::get(&conn, &paper::PaperRef::source("arxiv:1".into()))
+                .unwrap()
+                .unwrap();
             assert_eq!(p.title, "Stored Title", "merge does not overwrite metadata");
             assert_eq!(
                 project::get(
@@ -1080,15 +1053,9 @@ mod tests {
                 .unwrap();
             commit_from_manifest(&mut conn, &manifest, &[], OnConflict::Overwrite, tmp.path())
                 .unwrap();
-            let p = paper::get(
-                &conn,
-                &paper::Paper {
-                    source_id: Some("arxiv:1".into()),
-                    ..Default::default()
-                },
-            )
-            .unwrap()
-            .unwrap();
+            let p = paper::get(&conn, &paper::PaperRef::source("arxiv:1".into()))
+                .unwrap()
+                .unwrap();
             assert_eq!(
                 p.title, "Archive Title",
                 "overwrite repairs metadata from the archive"
@@ -1101,14 +1068,7 @@ mod tests {
         let mut conn = db();
         let tmp = tempfile::tempdir().unwrap();
         paper::save_paper_metadata(&mut conn, &meta("arxiv:1", 1, "T", &[]), None).unwrap();
-        paper::delete(
-            &mut conn,
-            &paper::Paper {
-                source_id: Some("arxiv:1".into()),
-                ..Default::default()
-            },
-        )
-        .unwrap();
+        paper::delete(&mut conn, &paper::PaperRef::source("arxiv:1".into())).unwrap();
         assert!(paper::is_paper_deleted(&conn, "arxiv:1").unwrap());
 
         let manifest = base_manifest("P", vec![paper_entry("arxiv:1", 1, "T", &[])], vec![]);
@@ -1220,10 +1180,9 @@ mod tests {
         .unwrap();
         let pv1 = paper::get(
             &conn,
-            &paper::Paper {
-                source_id: Some("arxiv:1".into()),
+            &paper::PaperRef::Source {
+                source_id: "arxiv:1".into(),
                 version: Some(1),
-                ..Default::default()
             },
         )
         .unwrap()
@@ -1272,15 +1231,9 @@ mod tests {
         assert_eq!(proj.name, "Round Trip");
         assert_eq!(proj.source_fks.len(), 1);
 
-        let p = paper::get(
-            &conn2,
-            &paper::Paper {
-                source_id: Some("arxiv:1".into()),
-                ..Default::default()
-            },
-        )
-        .unwrap()
-        .unwrap();
+        let p = paper::get(&conn2, &paper::PaperRef::source("arxiv:1".into()))
+            .unwrap()
+            .unwrap();
         assert_eq!(p.title, "Paper One");
         assert!(p.has_pdf);
 
@@ -1372,15 +1325,9 @@ mod tests {
         let manifest = base_manifest("P", vec![paper_entry("arxiv:1", 1, "T", &["B"])], vec![]);
         commit_from_manifest(&mut conn, &manifest, &[], OnConflict::Merge, tmp.path()).unwrap();
 
-        let p = paper::get(
-            &conn,
-            &paper::Paper {
-                source_id: Some("arxiv:1".into()),
-                ..Default::default()
-            },
-        )
-        .unwrap()
-        .unwrap();
+        let p = paper::get(&conn, &paper::PaperRef::source("arxiv:1".into()))
+            .unwrap()
+            .unwrap();
         let mut tags = p.tags.clone();
         tags.sort();
         assert_eq!(

--- a/src-tauri/crates/core/src/service/feed.rs
+++ b/src-tauri/crates/core/src/service/feed.rs
@@ -214,16 +214,14 @@ pub fn list_rules(conn: &Connection) -> Result<Vec<FilterRule>> {
     rss::list_rules(conn)
 }
 
-/// Create an auto-filter rule.
-pub fn create_rule(conn: &Connection, field: &str, keywords: &str, action: &str) -> Result<i64> {
-    if !matches!(field, "TITLE" | "SUMMARY" | "AUTHOR") {
-        return Err(CoreError::Validation(
-            "field must be TITLE, SUMMARY, or AUTHOR".into(),
-        ));
-    }
-    if !matches!(action, "DENY" | "ALLOW") {
-        return Err(CoreError::Validation("action must be DENY or ALLOW".into()));
-    }
+/// Create an auto-filter rule. Field/action validity is the type's job
+/// (deserialization rejects unknown variants); only keywords needs checking.
+pub fn create_rule(
+    conn: &Connection,
+    field: FilterField,
+    keywords: &str,
+    action: FilterAction,
+) -> Result<i64> {
     if keywords.trim().is_empty() {
         return Err(CoreError::Validation("keywords is required".into()));
     }
@@ -309,22 +307,30 @@ mod tests {
     }
 
     #[test]
-    fn create_rule_validates_field_action_keywords() {
+    fn create_rule_requires_keywords() {
         let c = conn();
         assert!(matches!(
-            create_rule(&c, "BODY", "x", "DENY"),
+            create_rule(&c, FilterField::Title, "  ", FilterAction::Deny),
             Err(CoreError::Validation(_))
         ));
-        assert!(matches!(
-            create_rule(&c, "TITLE", "x", "MAYBE"),
-            Err(CoreError::Validation(_))
-        ));
-        assert!(matches!(
-            create_rule(&c, "TITLE", "  ", "DENY"),
-            Err(CoreError::Validation(_))
-        ));
-        let id = create_rule(&c, "TITLE", "llm", "DENY").unwrap();
+        let id = create_rule(&c, FilterField::Title, "llm", FilterAction::Deny).unwrap();
         delete_rule(&c, id).unwrap();
         assert!(matches!(delete_rule(&c, id), Err(CoreError::NotFound(_))));
+    }
+
+    /// Invalid field/action strings die at deserialization now, not in the
+    /// service -- pin that "BODY"/"MAYBE" are rejected on the wire.
+    #[test]
+    fn invalid_field_action_fail_deserialization() {
+        assert!(serde_json::from_str::<FilterField>(r#""BODY""#).is_err());
+        assert!(serde_json::from_str::<FilterAction>(r#""MAYBE""#).is_err());
+        assert_eq!(
+            serde_json::from_str::<FilterField>(r#""TITLE""#).unwrap(),
+            FilterField::Title
+        );
+        assert_eq!(
+            serde_json::from_str::<FilterAction>(r#""ALLOW""#).unwrap(),
+            FilterAction::Allow
+        );
     }
 }

--- a/src-tauri/crates/core/src/service/paper.rs
+++ b/src-tauri/crates/core/src/service/paper.rs
@@ -34,14 +34,29 @@ pub use store::DoiVersionCandidate;
 
 // ── lookup query objects (defined in service/paper.py, not models.py) ────────
 
-/// Identifies a single paper — supply one of the three keys. `version` is only
-/// meaningful alongside `source_id` (ignored when paper_id/source_fk drive).
-#[derive(Debug, Default, Clone)]
-pub struct Paper {
-    pub source_fk: Option<i64>,
-    pub paper_id: Option<i64>,
-    pub source_id: Option<String>,
-    pub version: Option<i64>,
+/// Identifies a single paper. Version pinning only exists for source_id
+/// lookups; `Id` and `SourceFk` carry no version by construction.
+#[derive(Debug, Clone)]
+pub enum PaperRef {
+    /// Exact PAPER row by PK (selects that exact version).
+    Id(i64),
+    /// Latest version for a root.
+    SourceFk(i64),
+    /// By source_id; `version` pins one stored version, `None` → latest.
+    Source {
+        source_id: String,
+        version: Option<i64>,
+    },
+}
+
+impl PaperRef {
+    /// `Source` with no version pin — the overwhelmingly common lookup.
+    pub fn source(source_id: String) -> Self {
+        PaperRef::Source {
+            source_id,
+            version: None,
+        }
+    }
 }
 
 /// Filter criteria for listing multiple papers.
@@ -109,39 +124,30 @@ fn paper_by_source_fk(conn: &Connection, source_fk: i64) -> Result<Option<PaperD
 
 // ── lookup seam ──────────────────────────────────────────────────────────────
 
-/// Fetch a single paper version. Resolution order:
-/// `paper_id` → `source_fk` → `source_id` (`version` only applies to source_id).
-pub fn get(conn: &Connection, paper: &Paper) -> Result<Option<PaperDetails>> {
-    if let Some(pid) = paper.paper_id {
-        return paper_by_id(conn, pid); // version (if any) ignored
+/// Fetch a single paper version. `Id` is PK-exact; `SourceFk` and an unpinned
+/// `Source` resolve to the latest version.
+pub fn get(conn: &Connection, paper: &PaperRef) -> Result<Option<PaperDetails>> {
+    match paper {
+        PaperRef::Id(pid) => paper_by_id(conn, *pid),
+        PaperRef::SourceFk(sfk) => paper_by_source_fk(conn, *sfk),
+        PaperRef::Source { source_id, version } => {
+            store::get_paper(conn, &canonical_source_id(conn, source_id), *version)
+        }
     }
-    if let Some(sfk) = paper.source_fk {
-        return paper_by_source_fk(conn, sfk); // version ignored
-    }
-    if let Some(sid) = paper.source_id.as_deref() {
-        return store::get_paper(conn, &canonical_source_id(conn, sid), paper.version);
-    }
-    Ok(None)
 }
 
 /// `get` by source_id where absence is an error: the one place the paper not-found
 /// contract comes from (`CoreError::PaperNotFound` — route 404, CLI exit 1, MCP tool
 /// error all word it identically). Mirrors `project::get_required`.
 pub fn get_required(conn: &Connection, source_id: &str) -> Result<PaperDetails> {
-    get(
-        conn,
-        &Paper {
-            source_id: Some(source_id.to_string()),
-            ..Default::default()
-        },
-    )?
-    .ok_or_else(|| CoreError::PaperNotFound(source_id.to_string()))
+    get(conn, &PaperRef::source(source_id.to_string()))?
+        .ok_or_else(|| CoreError::PaperNotFound(source_id.to_string()))
 }
 
 /// Fetch every stored version, display fields from the latest. Key resolution
 /// shares [`resolve_source_id`] with delete/restore/hard-delete. (`get` stays
-/// paper_id-first: its paper_id key selects an exact version row by PK.)
-pub fn get_all(conn: &Connection, paper: &Paper) -> Result<Option<PaperDetailsAll>> {
+/// PK-exact for `Id`: that key selects one version row.)
+pub fn get_all(conn: &Connection, paper: &PaperRef) -> Result<Option<PaperDetailsAll>> {
     let Some(source_id) = resolve_source_id(conn, paper)? else {
         return Ok(None);
     };
@@ -344,13 +350,7 @@ pub fn search_library(conn: &Connection, query: &str, limit: i64) -> Result<Vec<
     let mut papers = search_store::search_full_text(conn, query, limit).unwrap_or_default();
     let mut seen: HashSet<String> = papers.iter().map(|p| p.source_id.clone()).collect();
     for sfk in note_store::search_notes_source_fks(conn, query, limit)? {
-        if let Some(p) = get(
-            conn,
-            &Paper {
-                source_fk: Some(sfk),
-                ..Default::default()
-            },
-        )? {
+        if let Some(p) = get(conn, &PaperRef::SourceFk(sfk))? {
             if seen.insert(p.source_id.clone()) {
                 papers.push(p);
             }
@@ -362,22 +362,17 @@ pub fn search_library(conn: &Connection, query: &str, limit: i64) -> Result<Vec<
 
 // ── soft / hard delete ───────────────────────────────────────────────────────
 
-/// Resolve a `Paper` to its text source_id. Order: source_id → source_fk → paper_id.
-fn resolve_source_id(conn: &Connection, paper: &Paper) -> Result<Option<String>> {
-    if let Some(sid) = paper.source_id.as_deref() {
-        return Ok(Some(canonical_source_id(conn, sid)));
+/// Resolve a `PaperRef` to its text source_id (any variant → the root's id).
+fn resolve_source_id(conn: &Connection, paper: &PaperRef) -> Result<Option<String>> {
+    match paper {
+        PaperRef::Source { source_id, .. } => Ok(Some(canonical_source_id(conn, source_id))),
+        PaperRef::SourceFk(sfk) => store::get_source_id(conn, *sfk),
+        PaperRef::Id(pid) => Ok(paper_by_id(conn, *pid)?.map(|p| p.source_id)),
     }
-    if let Some(sfk) = paper.source_fk {
-        return store::get_source_id(conn, sfk);
-    }
-    if let Some(pid) = paper.paper_id {
-        return Ok(paper_by_id(conn, pid)?.map(|p| p.source_id));
-    }
-    Ok(None)
 }
 
 /// Soft-delete a paper. Returns its stored PDF_PATH (for the caller to unlink).
-pub fn delete(conn: &mut Connection, paper: &Paper) -> Result<Option<String>> {
+pub fn delete(conn: &mut Connection, paper: &PaperRef) -> Result<Option<String>> {
     match resolve_source_id(conn, paper)? {
         Some(sid) => store::soft_delete_paper(conn, &sid),
         None => Ok(None),
@@ -386,7 +381,7 @@ pub fn delete(conn: &mut Connection, paper: &Paper) -> Result<Option<String>> {
 
 /// Restore a soft-deleted paper. Returns (pdf_path, project_fks). The root's
 /// SOURCE_FK is read before the restore write — it's an immutable PK, no TOCTOU.
-pub fn restore(conn: &mut Connection, paper: &Paper) -> Result<(Option<String>, Vec<i64>)> {
+pub fn restore(conn: &mut Connection, paper: &PaperRef) -> Result<(Option<String>, Vec<i64>)> {
     let Some(source_id) = resolve_source_id(conn, paper)? else {
         return Ok((None, Vec::new()));
     };
@@ -413,7 +408,7 @@ pub fn require_trashed(conn: &Connection, source_id: &str) -> Result<()> {
 }
 
 /// Permanently remove a paper (children cascade off the FK).
-pub fn hard_delete(conn: &mut Connection, paper: &Paper) -> Result<Option<String>> {
+pub fn hard_delete(conn: &mut Connection, paper: &PaperRef) -> Result<Option<String>> {
     match resolve_source_id(conn, paper)? {
         Some(sid) => store::hard_delete_paper(conn, &sid),
         None => Ok(None),
@@ -834,69 +829,43 @@ mod tests {
         let fk = ensure_paper_root(conn, "arxiv:A").unwrap();
         let v1 = get(
             conn,
-            &Paper {
-                source_id: Some("arxiv:A".into()),
+            &PaperRef::Source {
+                source_id: "arxiv:A".into(),
                 version: Some(1),
-                ..Default::default()
             },
         )
         .unwrap()
         .unwrap()
         .paper_id;
-        let v2 = get(
-            conn,
-            &Paper {
-                source_id: Some("arxiv:A".into()),
-                ..Default::default()
-            },
-        )
-        .unwrap()
-        .unwrap()
-        .paper_id;
+        let v2 = get(conn, &PaperRef::source("arxiv:A".into()))
+            .unwrap()
+            .unwrap()
+            .paper_id;
         (fk, v1, v2)
     }
 
     #[test]
-    fn get_dispatch_priority_and_version_handling() {
+    fn get_dispatch_and_version_handling() {
         let mut conn = db();
-        let (fk, v1, v2) = seed_two_versions(&mut conn);
+        let (fk, v1, _v2) = seed_two_versions(&mut conn);
 
         // source_fk -> latest version.
         assert_eq!(
-            get(
-                &conn,
-                &Paper {
-                    source_fk: Some(fk),
-                    ..Default::default()
-                }
-            )
-            .unwrap()
-            .unwrap()
-            .version,
+            get(&conn, &PaperRef::SourceFk(fk))
+                .unwrap()
+                .unwrap()
+                .version,
             2
         );
         // paper_id -> that exact version.
-        assert_eq!(
-            get(
-                &conn,
-                &Paper {
-                    paper_id: Some(v1),
-                    ..Default::default()
-                }
-            )
-            .unwrap()
-            .unwrap()
-            .version,
-            1
-        );
+        assert_eq!(get(&conn, &PaperRef::Id(v1)).unwrap().unwrap().version, 1);
         // source_id + version -> pinned; source_id alone -> latest.
         assert_eq!(
             get(
                 &conn,
-                &Paper {
-                    source_id: Some("arxiv:A".into()),
-                    version: Some(1),
-                    ..Default::default()
+                &PaperRef::Source {
+                    source_id: "arxiv:A".into(),
+                    version: Some(1)
                 }
             )
             .unwrap()
@@ -905,47 +874,12 @@ mod tests {
             1
         );
         assert_eq!(
-            get(
-                &conn,
-                &Paper {
-                    source_id: Some("arxiv:A".into()),
-                    ..Default::default()
-                }
-            )
-            .unwrap()
-            .unwrap()
-            .version,
+            get(&conn, &PaperRef::source("arxiv:A".into()))
+                .unwrap()
+                .unwrap()
+                .version,
             2
         );
-
-        // Priority paper_id > source_fk > source_id; version ignored for paper_id.
-        let p = get(
-            &conn,
-            &Paper {
-                paper_id: Some(v2),
-                source_fk: Some(999),
-                source_id: Some("nope".into()),
-                version: Some(1),
-            },
-        )
-        .unwrap()
-        .unwrap();
-        assert_eq!(p.version, 2);
-        // source_fk beats source_id.
-        let p = get(
-            &conn,
-            &Paper {
-                source_fk: Some(fk),
-                source_id: Some("nope".into()),
-                ..Default::default()
-            },
-        )
-        .unwrap()
-        .unwrap();
-        assert_eq!(p.version, 2);
-
-        assert!(get(&conn, &Paper::default()).unwrap().is_none());
-        let _ = v1;
     }
 
     #[test]
@@ -954,18 +888,9 @@ mod tests {
         let (fk, v1, _v2) = seed_two_versions(&mut conn);
 
         for key in [
-            Paper {
-                source_id: Some("arxiv:A".into()),
-                ..Default::default()
-            },
-            Paper {
-                paper_id: Some(v1),
-                ..Default::default()
-            },
-            Paper {
-                source_fk: Some(fk),
-                ..Default::default()
-            },
+            PaperRef::source("arxiv:A".into()),
+            PaperRef::Id(v1),
+            PaperRef::SourceFk(fk),
         ] {
             let all = get_all(&conn, &key).unwrap().unwrap();
             assert_eq!(all.source_id, "arxiv:A");
@@ -979,16 +904,7 @@ mod tests {
             assert_eq!(all.published, NaiveDate::from_ymd_opt(2024, 1, 1));
         }
 
-        assert!(get_all(
-            &conn,
-            &Paper {
-                paper_id: Some(424242),
-                ..Default::default()
-            }
-        )
-        .unwrap()
-        .is_none());
-        assert!(get_all(&conn, &Paper::default()).unwrap().is_none());
+        assert!(get_all(&conn, &PaperRef::Id(424242)).unwrap().is_none());
     }
 
     #[test]
@@ -997,16 +913,10 @@ mod tests {
         save_paper_metadata(&mut conn, &meta("arxiv:A", 1, "cs.LG", &["ml"]), None).unwrap();
         save_paper_metadata(&mut conn, &meta("arxiv:B", 1, "math.CO", &["theory"]), None).unwrap();
         let fk_a = ensure_paper_root(&mut conn, "arxiv:A").unwrap();
-        let pid_b = get(
-            &conn,
-            &Paper {
-                source_id: Some("arxiv:B".into()),
-                ..Default::default()
-            },
-        )
-        .unwrap()
-        .unwrap()
-        .paper_id;
+        let pid_b = get(&conn, &PaperRef::source("arxiv:B".into()))
+            .unwrap()
+            .unwrap()
+            .paper_id;
 
         // No filters -> both latest papers.
         assert_eq!(get_many(&conn, &Papers::default()).unwrap().len(), 2);
@@ -1090,15 +1000,9 @@ mod tests {
         let (sid, ver) = upsert(&mut conn, &p, Some(&["shared".into()])).unwrap();
         assert_eq!((sid.as_str(), ver), ("local:abc", 1)); // version None/0 -> 1
 
-        let got = get(
-            &conn,
-            &Paper {
-                source_id: Some("local:abc".into()),
-                ..Default::default()
-            },
-        )
-        .unwrap()
-        .unwrap();
+        let got = get(&conn, &PaperRef::source("local:abc".into()))
+            .unwrap()
+            .unwrap();
         assert_eq!(got.title, "Manual");
         assert_eq!(got.authors, vec!["Carol".to_string()]);
         // upsert tags + extra tags merged.
@@ -1148,14 +1052,7 @@ mod tests {
                 .http_status(),
             404
         );
-        delete(
-            &mut conn,
-            &Paper {
-                source_fk: Some(fk),
-                ..Default::default()
-            },
-        )
-        .unwrap();
+        delete(&mut conn, &PaperRef::SourceFk(fk)).unwrap();
         require_trashed(&conn, "arxiv:A").unwrap();
     }
 
@@ -1173,14 +1070,7 @@ mod tests {
         proj_store::add_papers(&conn, proj, &[fk]).unwrap();
 
         // Soft-delete resolved via paper_id.
-        delete(
-            &mut conn,
-            &Paper {
-                paper_id: Some(v1),
-                ..Default::default()
-            },
-        )
-        .unwrap();
+        delete(&mut conn, &PaperRef::Id(v1)).unwrap();
         assert!(is_paper_deleted(&conn, "arxiv:A").unwrap());
         let deleted = list_deleted(&conn).unwrap();
         assert_eq!(deleted.len(), 1);
@@ -1188,38 +1078,15 @@ mod tests {
         assert_eq!(deleted[0].project_fks, vec![proj]); // enriched
 
         // Restore resolved via source_fk -> returns project_fks.
-        let (_pdf, fks) = restore(
-            &mut conn,
-            &Paper {
-                source_fk: Some(fk),
-                ..Default::default()
-            },
-        )
-        .unwrap();
+        let (_pdf, fks) = restore(&mut conn, &PaperRef::SourceFk(fk)).unwrap();
         assert_eq!(fks, vec![proj]);
         assert!(!is_paper_deleted(&conn, "arxiv:A").unwrap());
 
         // Hard-delete resolved via source_id.
-        hard_delete(
-            &mut conn,
-            &Paper {
-                source_id: Some("arxiv:A".into()),
-                ..Default::default()
-            },
-        )
-        .unwrap();
-        assert!(get(
-            &conn,
-            &Paper {
-                source_id: Some("arxiv:A".into()),
-                ..Default::default()
-            }
-        )
-        .unwrap()
-        .is_none());
-
-        // No-key ops are no-ops.
-        assert!(delete(&mut conn, &Paper::default()).unwrap().is_none());
+        hard_delete(&mut conn, &PaperRef::source("arxiv:A".into())).unwrap();
+        assert!(get(&conn, &PaperRef::source("arxiv:A".into()))
+            .unwrap()
+            .is_none());
     }
 
     #[test]
@@ -1231,10 +1098,9 @@ mod tests {
         assert!(
             get(
                 &conn,
-                &Paper {
-                    source_id: Some("arxiv:p".into()),
-                    version: Some(1),
-                    ..Default::default()
+                &PaperRef::Source {
+                    source_id: "arxiv:p".into(),
+                    version: Some(1)
                 }
             )
             .unwrap()
@@ -1246,10 +1112,9 @@ mod tests {
         mark_pdf_saved(&mut conn, "arxiv:p", "/tmp/b.pdf", 1).unwrap();
         let got = get(
             &conn,
-            &Paper {
-                source_id: Some("arxiv:p".into()),
+            &PaperRef::Source {
+                source_id: "arxiv:p".into(),
                 version: Some(1),
-                ..Default::default()
             },
         )
         .unwrap()
@@ -1260,10 +1125,9 @@ mod tests {
         set_full_text(&mut conn, "arxiv:p", 1, "the full tex body").unwrap();
         let got = get(
             &conn,
-            &Paper {
-                source_id: Some("arxiv:p".into()),
+            &PaperRef::Source {
+                source_id: "arxiv:p".into(),
                 version: Some(1),
-                ..Default::default()
             },
         )
         .unwrap()
@@ -1302,10 +1166,7 @@ mod tests {
         // …and the rebuild after a delete has to find that older body too. It
         // would be unrecoverable otherwise: a forced re-fetch of v2 extracts
         // empty again and so stores nothing to rebuild from.
-        let key = Paper {
-            source_id: Some("arxiv:ft".into()),
-            ..Default::default()
-        };
+        let key = PaperRef::source("arxiv:ft".into());
         delete(&mut conn, &key).unwrap();
         assert!(search_full_text(&conn, "zephyranthes", 10)
             .unwrap()
@@ -1323,10 +1184,7 @@ mod tests {
     fn should_store_full_text_refuses_to_clobber_with_empty() {
         let mut conn = db();
         save_paper_metadata(&mut conn, &meta("arxiv:clob", 1, "cs.LG", &[]), None).unwrap();
-        let key = Paper {
-            source_id: Some("arxiv:clob".into()),
-            ..Default::default()
-        };
+        let key = PaperRef::source("arxiv:clob".into());
 
         // Nothing stored yet: an empty extract is written, marking it attempted.
         let fresh = get(&conn, &key).unwrap().unwrap();
@@ -1390,10 +1248,7 @@ mod tests {
         save_paper_metadata(&mut conn, &abs_url_only, None).unwrap();
 
         for sid in ["openalex:x", "arxiv:noPdfLink"] {
-            let key = Paper {
-                source_id: Some(sid.into()),
-                ..Default::default()
-            };
+            let key = PaperRef::source(sid.into());
             let paper = get(&conn, &key).unwrap().unwrap();
             assert!(source_fetch_url(&paper).is_err());
         }
@@ -1440,10 +1295,7 @@ mod tests {
             full_text_backfill_count(&conn).unwrap()
         );
         for (m, fetchable) in &cases {
-            let key = Paper {
-                source_id: Some(m.source_id.clone()),
-                ..Default::default()
-            };
+            let key = PaperRef::source(m.source_id.clone());
             let paper = get(&conn, &key).unwrap().unwrap();
             assert_eq!(
                 source_fetch_url(&paper).is_ok(),
@@ -1464,15 +1316,7 @@ mod tests {
     fn source_fetch_url_takes_arxiv_pdf_links_only() {
         let mut conn = db();
         let fetch_url_of = |conn: &Connection, sid: &str| {
-            let p = get(
-                conn,
-                &Paper {
-                    source_id: Some(sid.into()),
-                    ..Default::default()
-                },
-            )
-            .unwrap()
-            .unwrap();
+            let p = get(conn, &PaperRef::source(sid.into())).unwrap().unwrap();
             source_fetch_url(&p).map(str::to_string)
         };
 
@@ -1617,15 +1461,7 @@ mod tests {
             ..meta("arxiv:R", 1, "cs.LG", &[])
         };
         repair_paper(&mut conn, fk, &dupes).unwrap();
-        let got = get(
-            &conn,
-            &Paper {
-                source_fk: Some(fk),
-                ..Default::default()
-            },
-        )
-        .unwrap()
-        .unwrap();
+        let got = get(&conn, &PaperRef::SourceFk(fk)).unwrap().unwrap();
         assert_eq!(got.title, "Fixed");
         assert_eq!(got.authors, vec!["Ada".to_string(), "Bo".to_string()]);
 

--- a/src-tauri/crates/core/src/service/paper.rs
+++ b/src-tauri/crates/core/src/service/paper.rs
@@ -11,9 +11,8 @@
 //! (export/import contract). PaperDetails (one version) / PaperDetailsAll (all
 //! versions) / SearchResultOut stay distinct serializers (D16).
 //!
-//! Several Python `storage.db` reads have no dedicated Rust storage fn yet
-//! (`get_paper_by_id`, `get_paper_by_source_fk`, `get_categories`,
-//! `get_papers_by_json_tag`); they are composed here from existing storage fns
+//! One Python `storage.db` read has no dedicated Rust storage fn yet
+//! (`get_paper_by_source_fk`); it is composed here from existing storage fns
 //! rather than adding raw SQL to the service.
 
 use crate::error::{CoreError, Result};
@@ -105,12 +104,9 @@ pub fn pdf_on_disk_name(source_id: &str, version: i64) -> String {
 
 // ── composed reads (no dedicated storage fn exists yet) ──────────────────────
 
-/// `db.get_paper_by_id` — exact PAPER version by PK. Composed by scanning the
-/// all-versions list (same `papers` view the Python query hits).
+/// `db.get_paper_by_id` — exact PAPER version by PK.
 fn paper_by_id(conn: &Connection, paper_id: i64) -> Result<Option<PaperDetails>> {
-    Ok(store::list_papers(conn, false, None, 0, None)?
-        .into_iter()
-        .find(|p| p.paper_id == paper_id))
+    store::get_paper_by_id(conn, paper_id)
 }
 
 /// `db.get_paper_by_source_fk` — latest version for a root. Composed:
@@ -475,27 +471,14 @@ pub fn list_papers_sorted(
 
 /// Sorted distinct primary categories across latest papers (`db.get_categories`).
 pub fn get_categories(conn: &Connection) -> Result<Vec<String>> {
-    let set: std::collections::BTreeSet<String> = store::list_papers(conn, true, None, 0, None)?
-        .into_iter()
-        .filter_map(|p| p.category)
-        .collect();
-    Ok(set.into_iter().collect())
+    store::get_categories(conn)
 }
 
 /// Latest papers whose JSON tags include `label`, case-insensitively
-/// (`db.get_papers_by_json_tag`). Order: published DESC, then paper_id DESC so
-/// same-published-date papers are deterministic (matches the SQL secondary sort).
+/// (`db.get_papers_by_json_tag`). Order: published DESC (undated last), then
+/// paper_id DESC so same-published-date papers are deterministic.
 pub fn get_papers_by_tag(conn: &Connection, label: &str) -> Result<Vec<PaperDetails>> {
-    let mut out: Vec<PaperDetails> = store::list_papers(conn, true, None, 0, None)?
-        .into_iter()
-        .filter(|p| p.tags.iter().any(|t| t.eq_ignore_ascii_case(label)))
-        .collect();
-    out.sort_by(|a, b| {
-        b.published
-            .cmp(&a.published)
-            .then(b.paper_id.cmp(&a.paper_id))
-    });
-    Ok(out)
+    store::get_papers_by_json_tag(conn, label)
 }
 
 // ── root / id helpers ────────────────────────────────────────────────────────
@@ -1019,6 +1002,98 @@ mod tests {
         assert_eq!(hits.len(), 1);
         assert_eq!(hits[0].source_id, "local:abc");
         assert!(get_papers_by_tag(&conn, "nope").unwrap().is_empty());
+    }
+
+    /// Pins the paper_id lookup's exact semantics: the one version row that PK
+    /// names, with FULL_TEXT blanked like every list read (the source_id path
+    /// via `get_paper` does return the body — the difference is load-bearing).
+    #[test]
+    fn paper_by_id_returns_exact_version_with_full_text_blanked() {
+        let mut conn = db();
+        let (_fk, v1, _v2) = seed_two_versions(&mut conn);
+        set_full_text(&mut conn, "arxiv:A", 1, "tex body").unwrap();
+
+        let p = get(&conn, &PaperRef::Id(v1)).unwrap().unwrap();
+        assert_eq!(p.paper_id, v1);
+        assert_eq!(p.version, 1);
+        assert_eq!(p.title, "T1");
+        assert!(p.downloaded_source);
+        assert_eq!(p.full_text, None);
+        assert!(get(&conn, &PaperRef::Id(424242)).unwrap().is_none());
+    }
+
+    /// Pins get_categories: distinct, NULLs excluded, byte-order ascending
+    /// (BTreeSet<String> order == SQL BINARY collation), latest versions only.
+    #[test]
+    fn get_categories_distinct_sorted_null_free_latest_only() {
+        let mut conn = db();
+        save_paper_metadata(&mut conn, &meta("arxiv:1", 1, "cs.LG", &[]), None).unwrap();
+        save_paper_metadata(&mut conn, &meta("arxiv:2", 1, "cs.LG", &[]), None).unwrap(); // dup
+        save_paper_metadata(&mut conn, &meta("arxiv:3", 1, "CS.AI", &[]), None).unwrap(); // 'C' < 'c'
+                                                                                          // A superseded version's category must not surface.
+        save_paper_metadata(&mut conn, &meta("arxiv:4", 1, "old.CAT", &[]), None).unwrap();
+        save_paper_metadata(&mut conn, &meta("arxiv:4", 2, "math.CO", &[]), None).unwrap();
+        let no_cat = PaperMetadata {
+            category: None,
+            categories: None,
+            ..meta("arxiv:5", 1, "unused", &[])
+        };
+        save_paper_metadata(&mut conn, &no_cat, None).unwrap();
+
+        assert_eq!(
+            get_categories(&conn).unwrap(),
+            vec![
+                "CS.AI".to_string(),
+                "cs.LG".to_string(),
+                "math.CO".to_string()
+            ]
+        );
+    }
+
+    /// Pins get_papers_by_tag: ASCII-case-insensitive whole-tag match on the
+    /// JSON list, published DESC with NULL-published papers last, and papers
+    /// with NULL TAGS skipped rather than erroring.
+    #[test]
+    fn get_papers_by_tag_matches_case_insensitively_and_sinks_null_published() {
+        let mut conn = db();
+        // Dated papers whose tag differs only in case (published day 1 vs 2).
+        save_paper_metadata(&mut conn, &meta("arxiv:old", 1, "cs.LG", &["SHARED"]), None).unwrap();
+        save_paper_metadata(&mut conn, &meta("arxiv:new", 2, "cs.LG", &["shared"]), None).unwrap();
+        let untagged = PaperMetadata {
+            tags: None,
+            ..meta("arxiv:untagged", 1, "cs.LG", &[])
+        };
+        save_paper_metadata(&mut conn, &untagged, None).unwrap();
+        // NULL published is unreachable through save_paper_metadata; raw rows.
+        conn.execute(
+            "INSERT INTO PAPER_ROOTS (SOURCE_ID) VALUES ('arxiv:undated')",
+            [],
+        )
+        .unwrap();
+        let fk = conn.last_insert_rowid();
+        conn.execute(
+            "INSERT INTO PAPER (SOURCE_ID, VERSION, TITLE, SOURCE_FK) \
+             VALUES ('arxiv:undated', 1, 'U', ?)",
+            [fk],
+        )
+        .unwrap();
+        let pid = conn.last_insert_rowid();
+        conn.execute(
+            "INSERT INTO PAPER_META (PAPER_ID, TAGS) VALUES (?, '[\"Shared\"]')",
+            [pid],
+        )
+        .unwrap();
+
+        let hits = get_papers_by_tag(&conn, "sHaRed").unwrap();
+        assert_eq!(
+            hits.iter()
+                .map(|p| p.source_id.as_str())
+                .collect::<Vec<_>>(),
+            // published DESC first, then the NULL-published paper last.
+            ["arxiv:new", "arxiv:old", "arxiv:undated"]
+        );
+        // Whole-tag equality only — no substring matching.
+        assert!(get_papers_by_tag(&conn, "share").unwrap().is_empty());
     }
 
     #[test]

--- a/src-tauri/crates/core/src/service/paper.rs
+++ b/src-tauri/crates/core/src/service/paper.rs
@@ -97,7 +97,9 @@ pub fn pdf_filename_safe(source_id: &str) -> String {
 
 /// On-disk name for a directly-imported PDF: `{safe}v{version}.pdf` (NO
 /// underscore before `v`). Distinct from the `.lxproj` archive format
-/// `{source_id}_v{version}.pdf` — do not unify.
+/// `{source_id}_v{version}.pdf`, which is owned by
+/// `service::export_import::ArchivePdfName` — the separate type keeps the two
+/// formats unmixable; do not unify.
 pub fn pdf_on_disk_name(source_id: &str, version: i64) -> String {
     format!("{}v{}.pdf", pdf_filename_safe(source_id), version)
 }

--- a/src-tauri/crates/core/src/service/paper_import.rs
+++ b/src-tauri/crates/core/src/service/paper_import.rs
@@ -530,10 +530,9 @@ mod tests {
 
         let p = paper::get(
             &conn,
-            &paper::Paper {
-                source_id: Some("local:abc".into()),
+            &paper::PaperRef::Source {
+                source_id: "local:abc".into(),
                 version: Some(1),
-                ..Default::default()
             },
         )
         .unwrap()
@@ -736,15 +735,11 @@ mod tests {
         assert!(matches!(err, CoreError::Internal(_)));
 
         // Brand-new root with NULL pdf_path → hard-deleted: paper + root gone.
-        assert!(paper::get(
-            &conn,
-            &paper::Paper {
-                source_id: Some("local:new".into()),
-                ..Default::default()
-            }
-        )
-        .unwrap()
-        .is_none());
+        assert!(
+            paper::get(&conn, &paper::PaperRef::source("local:new".into()))
+                .unwrap()
+                .is_none()
+        );
         assert!(store::get_paper_root(&conn, "local:new").unwrap().is_none());
         // Temp upload cleaned up.
         let uploads = fs::read_dir(dir.path()).unwrap().filter(|e| {
@@ -803,15 +798,9 @@ mod tests {
         .await
         .unwrap();
         assert!(res.source_id.starts_with("local:"));
-        let p = paper::get(
-            &conn,
-            &paper::Paper {
-                source_id: Some(res.source_id.clone()),
-                ..Default::default()
-            },
-        )
-        .unwrap()
-        .unwrap();
+        let p = paper::get(&conn, &paper::PaperRef::source(res.source_id.clone()))
+            .unwrap()
+            .unwrap();
         assert!(p.has_pdf);
     }
 

--- a/src-tauri/crates/core/src/storage/queries/paper.rs
+++ b/src-tauri/crates/core/src/storage/queries/paper.rs
@@ -79,6 +79,21 @@ pub fn get_paper(
     }
 }
 
+/// `storage/db.py::get_paper_by_id` — one exact PAPER version by PK. Reads the
+/// list column set (FULL_TEXT blanked): paper_id callers never saw the body
+/// when this was composed from `list_papers`, and keeping it out means the
+/// lookup never hauls a full TeX corpus row into memory.
+pub fn get_paper_by_id(conn: &Connection, paper_id: i64) -> Result<Option<PaperDetails>> {
+    let mut stmt = conn.prepare(&format!(
+        "SELECT {PAPER_COLUMNS_NO_TEXT} FROM papers WHERE paper_id = ?"
+    ))?;
+    let mut rows = stmt.query([paper_id])?;
+    match rows.next()? {
+        Some(row) => Ok(Some(row_to_paper(row)?)),
+        None => Ok(None),
+    }
+}
+
 /// The `papers`/`latest_papers` column list with FULL_TEXT blanked out — every
 /// column `row_to_paper` reads, in the view's order. `PaperDetails` callers see
 /// no difference; the CLI's raw-row `linxiv library list`, which dumps whatever
@@ -223,6 +238,42 @@ pub fn list_papers_sorted(
     let (sql, params) = list_papers_sql(latest_only, limit, offset, category, sort, desc);
     let mut stmt = conn.prepare(&sql)?;
     let mut rows = stmt.query(params_from_iter(&params))?;
+    let mut out = Vec::new();
+    while let Some(row) = rows.next()? {
+        out.push(row_to_paper(row)?);
+    }
+    Ok(out)
+}
+
+/// `storage/db.py::get_categories` — distinct primary categories across latest
+/// active papers, NULLs excluded, ascending. BINARY collation (the default) is
+/// byte order — the same ordering the service's old BTreeSet<String> produced.
+pub fn get_categories(conn: &Connection) -> Result<Vec<String>> {
+    let mut stmt = conn.prepare(
+        "SELECT DISTINCT category FROM latest_papers \
+         WHERE category IS NOT NULL ORDER BY category",
+    )?;
+    let rows = stmt.query_map([], |r| r.get::<_, String>(0))?;
+    Ok(rows.collect::<rusqlite::Result<_>>()?)
+}
+
+/// `storage/db.py::get_papers_by_json_tag` — latest papers whose JSON TAGS list
+/// holds `label`, matched whole and case-insensitively (NOCASE folds ASCII
+/// only, same rule as the service's old `eq_ignore_ascii_case` filter).
+///
+/// Matches the JSON column, not PAPER_TO_TAG: the relational half is
+/// code-synced (no triggers), skips empty labels, and folds label case into a
+/// shared TAG row — the JSON list is what the old in-Rust filter read.
+/// `published DESC` puts NULL dates last, exactly where `Option<NaiveDate>`
+/// descending put them; `paper_id DESC` breaks same-date ties.
+pub fn get_papers_by_json_tag(conn: &Connection, label: &str) -> Result<Vec<PaperDetails>> {
+    let mut stmt = conn.prepare(&format!(
+        "SELECT {PAPER_COLUMNS_NO_TEXT} FROM latest_papers WHERE tags IS NOT NULL \
+         AND EXISTS (SELECT 1 FROM json_each(latest_papers.tags) \
+                     WHERE json_each.value = ? COLLATE NOCASE) \
+         ORDER BY published DESC, paper_id DESC"
+    ))?;
+    let mut rows = stmt.query([label])?;
     let mut out = Vec::new();
     while let Some(row) = rows.next()? {
         out.push(row_to_paper(row)?);

--- a/src-tauri/crates/core/src/storage/queries/rss.rs
+++ b/src-tauri/crates/core/src/storage/queries/rss.rs
@@ -5,7 +5,7 @@ use std::collections::HashSet;
 
 use chrono::NaiveDateTime;
 use rusqlite::{params, Connection};
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use ts_rs::TS;
 
@@ -222,12 +222,29 @@ pub fn prune_cache_entries(
 /// keeps `FilterRule` codegen-able (a bare `String` would flatten the
 /// frontend's hand-written `"TITLE"|"SUMMARY"|"AUTHOR"` union to `string`).
 /// `rename_all` pins the wire strings to the on-disk `TEXT` values.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, TS)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, TS)]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
 pub enum FilterField {
     Title,
     Summary,
     Author,
+}
+
+impl FilterField {
+    /// The canonical on-disk `TEXT` value (matches the wire string).
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            FilterField::Title => "TITLE",
+            FilterField::Summary => "SUMMARY",
+            FilterField::Author => "AUTHOR",
+        }
+    }
+}
+
+impl rusqlite::types::ToSql for FilterField {
+    fn to_sql(&self) -> rusqlite::Result<rusqlite::types::ToSqlOutput<'_>> {
+        Ok(self.as_str().into())
+    }
 }
 
 impl rusqlite::types::FromSql for FilterField {
@@ -242,11 +259,27 @@ impl rusqlite::types::FromSql for FilterField {
 }
 
 /// `RSS_FILTER_RULE.ACTION` -- see `FilterField` for why this is an enum.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, TS)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, TS)]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
 pub enum FilterAction {
     Deny,
     Allow,
+}
+
+impl FilterAction {
+    /// The canonical on-disk `TEXT` value (matches the wire string).
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            FilterAction::Deny => "DENY",
+            FilterAction::Allow => "ALLOW",
+        }
+    }
+}
+
+impl rusqlite::types::ToSql for FilterAction {
+    fn to_sql(&self) -> rusqlite::Result<rusqlite::types::ToSqlOutput<'_>> {
+        Ok(self.as_str().into())
+    }
 }
 
 impl rusqlite::types::FromSql for FilterAction {
@@ -286,7 +319,12 @@ pub fn list_rules(conn: &Connection) -> Result<Vec<FilterRule>> {
     Ok(rows.collect::<rusqlite::Result<_>>()?)
 }
 
-pub fn create_rule(conn: &Connection, field: &str, keywords: &str, action: &str) -> Result<i64> {
+pub fn create_rule(
+    conn: &Connection,
+    field: FilterField,
+    keywords: &str,
+    action: FilterAction,
+) -> Result<i64> {
     conn.execute(
         "INSERT INTO RSS_FILTER_RULE (FIELD, KEYWORDS, ACTION) VALUES (?1, ?2, ?3)",
         params![field, keywords, action],
@@ -580,11 +618,24 @@ mod tests {
     #[test]
     fn rule_crud_round_trips() {
         let c = conn();
-        let id = create_rule(&c, "TITLE", "quantum", "DENY").unwrap();
+        let id = create_rule(&c, FilterField::Title, "quantum", FilterAction::Deny).unwrap();
         let rules = list_rules(&c).unwrap();
         assert_eq!(rules.len(), 1);
         assert_eq!(rules[0].rule_id, id);
+        assert_eq!(rules[0].field, FilterField::Title);
+        assert_eq!(rules[0].keywords, "quantum");
+        assert_eq!(rules[0].action, FilterAction::Deny);
         assert!(rules[0].enabled);
+
+        // ToSql must write the exact canonical TEXT values, not Debug names.
+        let (f, a): (String, String) = c
+            .query_row(
+                "SELECT FIELD, ACTION FROM RSS_FILTER_RULE WHERE RULE_ID = ?1",
+                [id],
+                |r| Ok((r.get(0)?, r.get(1)?)),
+            )
+            .unwrap();
+        assert_eq!((f.as_str(), a.as_str()), ("TITLE", "DENY"));
 
         assert!(delete_rule(&c, id).unwrap());
         assert!(list_rules(&c).unwrap().is_empty());

--- a/src-tauri/crates/core/tests/paper_source.rs
+++ b/src-tauri/crates/core/tests/paper_source.rs
@@ -99,15 +99,9 @@ async fn an_adapter_fetch_stores_through_the_service_save_path() {
     let stored = fetch_and_save(&fake(), &mut conn, "fake:1").await.unwrap();
     assert_eq!(stored, "fake:1");
 
-    let got = svc_paper::get(
-        &conn,
-        &svc_paper::Paper {
-            source_id: Some("fake:1".to_string()),
-            ..Default::default()
-        },
-    )
-    .unwrap()
-    .expect("saved paper is readable");
+    let got = svc_paper::get(&conn, &svc_paper::PaperRef::source("fake:1".to_string()))
+        .unwrap()
+        .expect("saved paper is readable");
     assert_eq!(got.title, "Attention Is All You Need");
     assert_eq!(got.source.as_deref(), Some("fake"));
 }

--- a/src-tauri/crates/mcp/src/notes_pdf_trash.rs
+++ b/src-tauri/crates/mcp/src/notes_pdf_trash.rs
@@ -264,10 +264,9 @@ impl Server {
         self.with_conn(|conn| {
             let paper = svc_paper::get(
                 conn,
-                &svc_paper::Paper {
-                    source_id: Some(p.paper_id.clone()),
+                &svc_paper::PaperRef::Source {
+                    source_id: p.paper_id.clone(),
                     version: p.version,
-                    ..Default::default()
                 },
             )
             .map_err(core_err)?
@@ -295,10 +294,9 @@ impl Server {
         let (source_id, ver) = self.with_conn(|conn| {
             svc_paper::get(
                 conn,
-                &svc_paper::Paper {
-                    source_id: Some(p.paper_id.clone()),
+                &svc_paper::PaperRef::Source {
+                    source_id: p.paper_id.clone(),
                     version: p.version,
-                    ..Default::default()
                 },
             )
             .map_err(core_err)?
@@ -373,15 +371,11 @@ impl Server {
     ) -> Result<String, ErrorData> {
         let pdf_dir = self.pdf_dir.clone();
         self.with_conn(|conn| {
-            let all = svc_paper::get_all(
-                conn,
-                &svc_paper::Paper {
-                    source_id: Some(p.paper_id.clone()),
-                    ..Default::default()
-                },
-            )
-            .map_err(core_err)?
-            .ok_or_else(|| crate::util::guard_err(CoreError::PaperNotFound(p.paper_id.clone())))?;
+            let all = svc_paper::get_all(conn, &svc_paper::PaperRef::source(p.paper_id.clone()))
+                .map_err(core_err)?
+                .ok_or_else(|| {
+                    crate::util::guard_err(CoreError::PaperNotFound(p.paper_id.clone()))
+                })?;
             for ver in &all.versions {
                 let path = svc_files::pdf_path(
                     &pdf_dir,
@@ -434,14 +428,8 @@ impl Server {
             // require_trashed passing implies the root exists (STATUS='deleted' row),
             // so no separate existence check — same reasoning as cli/cmd/trash.rs.
             svc_paper::require_trashed(conn, &p.paper_id).map_err(guard_err)?;
-            svc_paper::hard_delete(
-                conn,
-                &svc_paper::Paper {
-                    source_id: Some(p.paper_id.clone()),
-                    ..Default::default()
-                },
-            )
-            .map_err(core_err)?;
+            svc_paper::hard_delete(conn, &svc_paper::PaperRef::source(p.paper_id.clone()))
+                .map_err(core_err)?;
             json_ok(&linxiv_core::service::trash::HardDeletedPaper {
                 ok: true,
                 hard_deleted: p.paper_id.clone(),

--- a/src-tauri/crates/mcp/src/papers.rs
+++ b/src-tauri/crates/mcp/src/papers.rs
@@ -26,11 +26,8 @@ use crate::Server;
 use crate::util::{core_err, invalid, json_ok};
 
 /// `Paper(source_id=paper_id)` lookup key, as the Python tools build it.
-fn paper_key(paper_id: &str) -> svc_paper::Paper {
-    svc_paper::Paper {
-        source_id: Some(paper_id.to_string()),
-        ..Default::default()
-    }
+fn paper_key(paper_id: &str) -> svc_paper::PaperRef {
+    svc_paper::PaperRef::source(paper_id.to_string())
 }
 
 fn default_source() -> String {

--- a/src-tauri/crates/mcp/src/projects_tags.rs
+++ b/src-tauri/crates/mcp/src/projects_tags.rs
@@ -15,7 +15,7 @@ use serde_json::json;
 
 use linxiv_core::error::CoreError;
 use linxiv_core::models::{ProjectDetails, ProjectIn, ProjectUpdateIn, Status, TagIn};
-use linxiv_core::service::paper::{self, Paper};
+use linxiv_core::service::paper::{self, PaperRef};
 use linxiv_core::service::project::{self, Project, Projects};
 use linxiv_core::service::tag::{self, Tag};
 
@@ -448,16 +448,10 @@ impl Server {
         let paper_id = _params.0.paper_id;
         self.with_conn(|conn| {
             // Python `get_paper_tags` returns [] for an absent paper (no error).
-            let tags = paper::get(
-                conn,
-                &Paper {
-                    source_id: Some(paper_id.clone()),
-                    ..Default::default()
-                },
-            )
-            .map_err(core_err)?
-            .map(|p| p.tags)
-            .unwrap_or_default();
+            let tags = paper::get(conn, &PaperRef::source(paper_id.clone()))
+                .map_err(core_err)?
+                .map(|p| p.tags)
+                .unwrap_or_default();
             jval(json!({ "paper_id": paper_id, "tags": tags }))
         })
     }

--- a/src-tauri/crates/share/src/lib.rs
+++ b/src-tauri/crates/share/src/lib.rs
@@ -339,14 +339,8 @@ pub fn import_shared_project(conn: &mut Connection, sp: &SharedProject) -> Resul
         if paper_svc::is_paper_deleted(conn, &p.source_id)? {
             continue;
         }
-        let known = paper_svc::get(
-            conn,
-            &paper_svc::Paper {
-                source_id: Some(p.source_id.clone()),
-                ..Default::default()
-            },
-        )?
-        .is_some();
+        let known =
+            paper_svc::get(conn, &paper_svc::PaperRef::source(p.source_id.clone()))?.is_some();
         if !known {
             // Metadata writes apply only to papers not already in the DB.
             paper_svc::save_paper_metadata(conn, &paper_meta(p), None)?;

--- a/src-tauri/src/protocol.rs
+++ b/src-tauri/src/protocol.rs
@@ -19,7 +19,7 @@ use tauri::http::{header, Request, Response, StatusCode};
 use tauri::{AppHandle, Manager, Runtime, UriSchemeContext, UriSchemeResponder};
 
 use linxiv_core::error::CoreError;
-use linxiv_core::service::paper::{self as svc_paper, Paper};
+use linxiv_core::service::paper::{self as svc_paper, PaperRef};
 use linxiv_core::sources::http as core_http;
 
 use crate::route::{pct_decode, pdfs::resolve_local_pdf, split_segments};
@@ -90,10 +90,9 @@ fn serve_local_pdf<R: Runtime>(app: &AppHandle<R>, query: &str) -> Response<Cow<
     let found = state.with_conn(|conn| {
         svc_paper::get(
             conn,
-            &Paper {
-                source_id: Some(source_id.clone()),
+            &PaperRef::Source {
+                source_id: source_id.clone(),
                 version,
-                ..Default::default()
             },
         )
         .ok()

--- a/src-tauri/src/route/feed.rs
+++ b/src-tauri/src/route/feed.rs
@@ -12,6 +12,7 @@ use serde_json::{json, Value};
 
 use linxiv_core::config::UserSettings;
 use linxiv_core::service::feed as svc_feed;
+use linxiv_core::service::feed::{FilterAction, FilterField};
 
 use crate::route::{ApiError, ReqCtx};
 use crate::state::AppState;
@@ -119,17 +120,17 @@ fn list_rules(state: &AppState) -> Result<Value, ApiError> {
 fn create_rule(state: &AppState, ctx: &ReqCtx<'_>) -> Result<Value, ApiError> {
     #[derive(Deserialize)]
     struct Body {
-        field: String,
+        field: FilterField,
         keywords: String,
         #[serde(default = "default_action")]
-        action: String,
+        action: FilterAction,
     }
-    fn default_action() -> String {
-        "DENY".to_string()
+    fn default_action() -> FilterAction {
+        FilterAction::Deny
     }
     let b: Body = ctx.parse_body()?;
     let rule_id =
-        state.with_conn(|conn| svc_feed::create_rule(conn, &b.field, &b.keywords, &b.action))?;
+        state.with_conn(|conn| svc_feed::create_rule(conn, b.field, &b.keywords, b.action))?;
     Ok(json!({ "rule_id": rule_id }))
 }
 
@@ -172,6 +173,69 @@ mod tests {
             },
         )
         .await
+    }
+
+    async fn post(
+        state: &AppState,
+        path: &str,
+        body: serde_json::Value,
+    ) -> Result<serde_json::Value, crate::route::ApiError> {
+        route(
+            state,
+            ApiRequest {
+                method: "POST".into(),
+                path: path.into(),
+                body: Some(body),
+            },
+        )
+        .await
+    }
+
+    /// Invalid field/action values die at body deserialization: 422 (same
+    /// status the old service-side validation returned) with a detail naming
+    /// the offending value and the valid variants.
+    #[tokio::test]
+    async fn create_rule_invalid_field_or_action_is_422_naming_the_value() {
+        let st = state();
+        let err = post(
+            &st,
+            "/api/feed/rules",
+            serde_json::json!({ "field": "BODY", "keywords": "x" }),
+        )
+        .await
+        .unwrap_err();
+        assert_eq!(err.status, 422);
+        assert!(err.detail.contains("BODY"), "got: {}", err.detail);
+        assert!(err.detail.contains("TITLE"), "got: {}", err.detail);
+
+        let err = post(
+            &st,
+            "/api/feed/rules",
+            serde_json::json!({ "field": "TITLE", "keywords": "x", "action": "MAYBE" }),
+        )
+        .await
+        .unwrap_err();
+        assert_eq!(err.status, 422);
+        assert!(err.detail.contains("MAYBE"), "got: {}", err.detail);
+        assert!(err.detail.contains("DENY"), "got: {}", err.detail);
+    }
+
+    /// Omitted action still defaults to DENY with typed bodies.
+    #[tokio::test]
+    async fn create_rule_defaults_action_to_deny() {
+        let st = state();
+        let res = post(
+            &st,
+            "/api/feed/rules",
+            serde_json::json!({ "field": "TITLE", "keywords": "llm" }),
+        )
+        .await
+        .unwrap();
+        assert!(res["rule_id"].as_i64().is_some());
+        let rules = st
+            .with_conn(|conn| linxiv_core::service::feed::list_rules(conn))
+            .unwrap();
+        assert_eq!(rules[0].action, super::FilterAction::Deny);
     }
 
     #[tokio::test]

--- a/src-tauri/src/route/papers.rs
+++ b/src-tauri/src/route/papers.rs
@@ -12,7 +12,7 @@ use serde_json::{json, Value};
 use linxiv_core::config;
 use linxiv_core::error::CoreError;
 use linxiv_core::models::PaperMetadata;
-use linxiv_core::service::paper::{self as svc_paper, Paper};
+use linxiv_core::service::paper::{self as svc_paper, PaperRef};
 use linxiv_core::service::project as svc_project;
 
 use crate::route::{path_i64, ApiError, ReqCtx};
@@ -106,10 +106,9 @@ fn by_sfk(state: &AppState, fk: &str, ctx: &ReqCtx<'_>) -> Result<Value, ApiErro
             // version branch: resolve source_id first, then the pinned version.
             let source_id = svc_paper::get_source_id(conn, source_fk)?
                 .ok_or_else(|| CoreError::PaperNotFound(source_fk.to_string()))?;
-            let key = Paper {
-                source_id: Some(source_id),
+            let key = PaperRef::Source {
+                source_id: source_id,
                 version: Some(version),
-                ..Default::default()
             };
             svc_paper::get(conn, &key)?
                 .ok_or_else(|| ApiError::new(404, format!("Version {version} not stored")))?
@@ -257,18 +256,12 @@ struct RepairBody {
     tags: Option<Vec<String>>,
 }
 
-fn sfk_key(source_fk: i64) -> Paper {
-    Paper {
-        source_fk: Some(source_fk),
-        ..Default::default()
-    }
+fn sfk_key(source_fk: i64) -> PaperRef {
+    PaperRef::SourceFk(source_fk)
 }
 
-pub(crate) fn sid_key(source_id: &str) -> Paper {
-    Paper {
-        source_id: Some(source_id.to_string()),
-        ..Default::default()
-    }
+pub(crate) fn sid_key(source_id: &str) -> PaperRef {
+    PaperRef::source(source_id.to_string())
 }
 
 use super::to_value;

--- a/src-tauri/src/route/pdfs.rs
+++ b/src-tauri/src/route/pdfs.rs
@@ -9,7 +9,7 @@ use serde_json::{json, Value};
 
 use linxiv_core::error::CoreError;
 use linxiv_core::service::files;
-use linxiv_core::service::paper::{self as svc_paper, pdf_on_disk_name, Paper};
+use linxiv_core::service::paper::{self as svc_paper, pdf_on_disk_name, PaperRef};
 
 use crate::route::{ApiError, ReqCtx};
 use crate::state::AppState;
@@ -72,14 +72,8 @@ fn list_saved(state: &AppState) -> Result<Value, ApiError> {
 fn delete_saved(state: &AppState, source_id: &str) -> Result<Value, ApiError> {
     let pdf_dir = state.pdf_dir.clone();
     state.with_conn(|conn| -> Result<(), ApiError> {
-        let all = svc_paper::get_all(
-            conn,
-            &Paper {
-                source_id: Some(source_id.to_string()),
-                ..Default::default()
-            },
-        )?
-        .ok_or_else(|| CoreError::PaperNotFound(source_id.to_string()))?;
+        let all = svc_paper::get_all(conn, &PaperRef::source(source_id.to_string()))?
+            .ok_or_else(|| CoreError::PaperNotFound(source_id.to_string()))?;
         for ver in &all.versions {
             let path = resolve_local_pdf(&pdf_dir, ver.pdf_path.as_deref(), source_id, ver.version);
             if let Some(p) = &path {
@@ -106,10 +100,9 @@ fn pdf_path(state: &AppState, source_id: &str, ctx: &ReqCtx<'_>) -> Result<Value
     state.with_conn(|conn| {
         let paper = svc_paper::get(
             conn,
-            &Paper {
-                source_id: Some(source_id.to_string()),
+            &PaperRef::Source {
+                source_id: source_id.to_string(),
                 version,
-                ..Default::default()
             },
         )?
         .ok_or_else(|| CoreError::PaperNotFound(source_id.to_string()))?;

--- a/src-tauri/src/route/share.rs
+++ b/src-tauri/src/route/share.rs
@@ -1303,10 +1303,9 @@ async fn shared_pdf(
         .with_conn(|c| {
             paper_svc::get(
                 c,
-                &paper_svc::Paper {
-                    source_id: Some(source_id.clone()),
+                &paper_svc::PaperRef::Source {
+                    source_id: source_id.clone(),
                     version: Some(version),
-                    ..Default::default()
                 },
             )
         })?
@@ -1612,15 +1611,9 @@ mod tests {
             assert_eq!(p.project_tags, vec!["RL".to_string()]);
             assert_eq!(p.source_fks.len(), 1, "paper linked to project");
 
-            let paper = paper_svc::get(
-                c,
-                &paper_svc::Paper {
-                    source_id: Some("arxiv:9".into()),
-                    ..Default::default()
-                },
-            )
-            .unwrap()
-            .expect("paper row created");
+            let paper = paper_svc::get(c, &paper_svc::PaperRef::source("arxiv:9".into()))
+                .unwrap()
+                .expect("paper row created");
             assert_eq!(paper.title, "Remote Paper");
             assert_eq!(paper.tags, vec!["remote-tag".to_string()]);
 

--- a/src-tauri/src/route/trash.rs
+++ b/src-tauri/src/route/trash.rs
@@ -12,7 +12,7 @@
 
 use serde_json::Value;
 
-use linxiv_core::service::paper::{self as svc_paper, Paper};
+use linxiv_core::service::paper::{self as svc_paper, PaperRef};
 use linxiv_core::service::project as svc_project;
 use linxiv_core::service::trash as svc_trash;
 
@@ -52,10 +52,7 @@ fn restore(state: &AppState, source_id: &str) -> Result<Value, ApiError> {
             svc_paper::require_trashed(conn, source_id)?;
             Ok(svc_paper::restore(
                 conn,
-                &Paper {
-                    source_id: Some(source_id.to_string()),
-                    ..Default::default()
-                },
+                &PaperRef::source(source_id.to_string()),
             )?)
         })?;
     crate::route::to_value(&svc_trash::RestoredPaper {
@@ -71,13 +68,7 @@ fn restore(state: &AppState, source_id: &str) -> Result<Value, ApiError> {
 fn hard_delete(state: &AppState, source_id: &str) -> Result<Value, ApiError> {
     state.with_conn(|conn| -> Result<(), ApiError> {
         svc_paper::require_trashed(conn, source_id)?;
-        svc_paper::hard_delete(
-            conn,
-            &Paper {
-                source_id: Some(source_id.to_string()),
-                ..Default::default()
-            },
-        )?;
+        svc_paper::hard_delete(conn, &PaperRef::source(source_id.to_string()))?;
         Ok(())
     })?;
     crate::route::to_value(&svc_trash::HardDeletedPaper {

--- a/src-tauri/src/share_sync.rs
+++ b/src-tauri/src/share_sync.rs
@@ -136,10 +136,9 @@ pub(crate) async fn populate_pdf_blobs(
         let custom = match state.with_conn(|c| {
             paper_svc::get(
                 c,
-                &paper_svc::Paper {
-                    source_id: Some(p.source_id.clone()),
+                &paper_svc::PaperRef::Source {
+                    source_id: p.source_id.clone(),
                     version: Some(p.version),
-                    ..Default::default()
                 },
             )
         }) {


### PR DESCRIPTION
- **refactor(core): make paper lookup key an enum**
- **perf(core): push composed paper reads into SQL**
- **refactor(core): type the .lxproj archive PDF name**
- **refactor(feed): typed FilterField/FilterAction in create_rule**
