### PR TITLE
feat(core): merge duplicate paper roots (dedupe)

### DIFF
--- a/goldens/cli/paper_help.txt
+++ b/goldens/cli/paper_help.txt
@@ -1,8 +1,8 @@
 usage: linxiv paper [-h]
-                    {get,delete,versions,repair,restore,hard-delete,search,remove-from-all-projects,doi-candidates,fetch-source,index-sources} ...
+                    {get,delete,versions,repair,restore,hard-delete,search,remove-from-all-projects,doi-candidates,merge,fetch-source,index-sources} ...
 
 positional arguments:
-  {get,delete,versions,repair,restore,hard-delete,search,remove-from-all-projects,doi-candidates,fetch-source,index-sources}
+  {get,delete,versions,repair,restore,hard-delete,search,remove-from-all-projects,doi-candidates,merge,fetch-source,index-sources}
     get                 Get full details for a paper
     delete              Soft-delete a paper
     versions            List all stored versions of a paper
@@ -13,6 +13,8 @@ positional arguments:
     remove-from-all-projects
                         Remove a paper from every project
     doi-candidates      List other paper roots sharing this paper's DOI
+    merge               Merge a duplicate paper into this one (the duplicate is
+                        deleted)
     fetch-source        Fetch a paper's arXiv TeX source and index it for
                         full-text search
     index-sources       Backfill full-text search over stored arXiv papers with

--- a/src-tauri/crates/cli/src/cmd/paper.rs
+++ b/src-tauri/crates/cli/src/cmd/paper.rs
@@ -8,7 +8,7 @@ use crate::output::{as_source_id, fail, output};
 
 use linxiv_core::config;
 use linxiv_core::models::PaperMetadata;
-use linxiv_core::service::{paper as svc_paper, project as svc_project};
+use linxiv_core::service::{paper as svc_paper, paper_merge as svc_merge, project as svc_project};
 
 #[derive(Subcommand)]
 pub enum PaperCmd {
@@ -53,6 +53,13 @@ pub enum PaperCmd {
     RemoveFromAllProjects { source_id: String },
     /// List other paper roots sharing this paper's DOI
     DoiCandidates { source_id: String },
+    /// Merge a duplicate paper into this one (the duplicate is deleted)
+    Merge {
+        /// The paper that survives; its metadata stays canonical
+        winner_source_id: String,
+        /// The duplicate to merge away
+        loser_source_id: String,
+    },
     /// Fetch a paper's arXiv TeX source and index it for full-text search
     FetchSource {
         source_id: String,
@@ -211,6 +218,31 @@ pub async fn run(cmd: PaperCmd, ctx: &mut Ctx) -> anyhow::Result<()> {
                 None => fail(linxiv_core::error::CoreError::PaperNotFound(
                     source_id.clone(),
                 )),
+            }
+        }
+
+        // POST /api/papers/sfk/{fk}/merge: winner's metadata is canonical; the
+        // duplicate's notes/annotations/memberships/tags/versions/PDFs move over.
+        // Guard failures (self-merge, trashed, share-linked) exit like the route's
+        // 409; unknown papers like its 404.
+        PaperCmd::Merge {
+            winner_source_id,
+            loser_source_id,
+        } => {
+            let winner = as_source_id(&ctx.conn, &winner_source_id);
+            let loser = as_source_id(&ctx.conn, &loser_source_id);
+            match svc_merge::merge_papers(
+                &mut ctx.conn,
+                &ctx.pdf_dir,
+                &paper(&winner),
+                &paper(&loser),
+            ) {
+                Ok(receipt) => output(&receipt),
+                Err(
+                    e @ (linxiv_core::error::CoreError::Conflict(_)
+                    | linxiv_core::error::CoreError::PaperNotFound(_)),
+                ) => fail(e),
+                Err(e) => return Err(e.into()),
             }
         }
 

--- a/src-tauri/crates/core/src/service/mod.rs
+++ b/src-tauri/crates/core/src/service/mod.rs
@@ -10,6 +10,7 @@ pub mod note;
 pub mod orcid_backfill;
 pub mod paper;
 pub mod paper_import;
+pub mod paper_merge;
 pub mod project;
 pub mod reading_list;
 pub mod search_state;

--- a/src-tauri/crates/core/src/service/paper.rs
+++ b/src-tauri/crates/core/src/service/paper.rs
@@ -373,7 +373,7 @@ pub fn search_library(conn: &Connection, query: &str, limit: i64) -> Result<Vec<
 // ── soft / hard delete ───────────────────────────────────────────────────────
 
 /// Resolve a `PaperRef` to its text source_id (any variant → the root's id).
-fn resolve_source_id(conn: &Connection, paper: &PaperRef) -> Result<Option<String>> {
+pub(crate) fn resolve_source_id(conn: &Connection, paper: &PaperRef) -> Result<Option<String>> {
     match paper {
         PaperRef::Source { source_id, .. } => Ok(Some(canonical_source_id(conn, source_id))),
         PaperRef::SourceFk(sfk) => store::get_source_id(conn, *sfk),

--- a/src-tauri/crates/core/src/service/paper_import.rs
+++ b/src-tauri/crates/core/src/service/paper_import.rs
@@ -33,7 +33,7 @@ use std::sync::Mutex;
 /// Serializes the pre-existence check + insert in `import_pdf` so two concurrent
 /// imports of the same upstream paper can't race on check-then-upsert. Mirrors
 /// Python's `threading.Lock`.
-static IMPORT_ROOT_LOCK: Mutex<()> = Mutex::new(());
+pub(crate) static IMPORT_ROOT_LOCK: Mutex<()> = Mutex::new(());
 
 /// Result of a successful `import_pdf` (Python `PaperImportResult`, defined in
 /// `service/paper.py` — a service result, not a storage model).
@@ -327,10 +327,11 @@ fn import_body(
     external: Option<(String, i64)>,
     st: &mut ImportState,
 ) -> Result<String> {
+    // Held for the whole write section (not just check-then-upsert): a merge
+    // holds this same lock end-to-end, and releasing it between the row insert
+    // and mark_pdf_saved would let a merge collapse the half-written root.
+    let _guard = IMPORT_ROOT_LOCK.lock().unwrap_or_else(|p| p.into_inner());
     let (sid, ver, pre_existing_pdf) = {
-        // Serialize check-then-upsert against concurrent imports of the same paper.
-        let _guard = IMPORT_ROOT_LOCK.lock().unwrap_or_else(|p| p.into_inner());
-
         // If enrichment resolved an upstream identity (arXiv/DOI), key on it as
         // this paper's Paper Root, not the content hash.
         if let Some((ext_id, ext_version)) = external {

--- a/src-tauri/crates/core/src/service/paper_merge.rs
+++ b/src-tauri/crates/core/src/service/paper_merge.rs
@@ -1,0 +1,696 @@
+//! paper_merge service — the paper/PDF dedupe workflow's front door.
+//!
+//! Orchestrates [`storage::queries::paper::merge_plan`] /
+//! [`merge_paper_roots`] around the filesystem work, in the same shape as
+//! `paper_import`'s rollback philosophy:
+//!
+//! 1. Plan (read-only DB classification of the loser's versions).
+//! 2. FS phase: rename loser PDFs to the winner's on-disk names — reversible.
+//! 3. DB transaction: every dependent row re-pointed, loser root deleted.
+//!    On failure the renames are undone (best-effort) and the error surfaces.
+//! 4. Post-commit only: unlink duplicate loser PDFs — the one irreversible
+//!    filesystem step goes last, and a failure there can no longer corrupt
+//!    state (worst case: an orphan file in the PDF dir).
+//!
+//! Serialized under `paper_import::IMPORT_ROOT_LOCK`: a concurrent PDF import
+//! resolving to the loser's identity must not race the root's deletion.
+//!
+//! Accepted crash window (same class as `paper_import`'s rename-then-commit):
+//! a process kill between the FS renames and the DB commit leaves loser rows
+//! pointing at moved files. Nothing is lost — the files sit under the winner's
+//! on-disk names, and readers fall back from the stored path to the recomputed
+//! managed name — but a re-run is needed to reconcile the pointers.
+
+use crate::error::{CoreError, Result};
+use crate::service::paper::{pdf_on_disk_name, resolve_source_id, PaperRef};
+use crate::service::paper_import::IMPORT_ROOT_LOCK;
+use crate::storage::queries::paper as store;
+use crate::storage::queries::paper::{MergeStats, VersionAction};
+use rusqlite::Connection;
+use serde::Serialize;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+/// What a completed merge did — the receipt all three surfaces emit.
+#[derive(Debug, Clone, Serialize, ts_rs::TS)]
+pub struct MergeReceipt {
+    pub winner_source_fk: i64,
+    pub winner_source_id: String,
+    /// The id that no longer exists after the merge.
+    pub merged_source_id: String,
+    pub notes_moved: usize,
+    pub annotations_moved: usize,
+    pub memberships_moved: usize,
+    /// Loser memberships dropped because the winner was already in the project.
+    pub memberships_collapsed: usize,
+    pub reading_statuses_moved: usize,
+    /// Loser versions the winner lacked, re-keyed under the winner (same
+    /// version numbers).
+    pub versions_transplanted: usize,
+    /// Loser versions collapsed into the winner's same-numbered versions.
+    pub versions_collapsed: usize,
+    /// Tags the loser carried that the winner didn't (now unioned in).
+    pub tags_added: Vec<String>,
+    /// Loser PDFs renamed to winner on-disk names in the managed dir.
+    pub pdfs_renamed: usize,
+    /// Loser PDFs that filled a PDF-less winner version — renamed in, or
+    /// pointed at in place when stored outside the managed dir.
+    pub pdfs_adopted: usize,
+    /// Duplicate loser PDFs unlinked after commit.
+    pub pdfs_deleted: usize,
+    /// Duplicate loser PDFs left on disk because they live outside the
+    /// managed PDF dir (never deleted there).
+    pub pdfs_kept_external: usize,
+    /// Loser versions whose stored PDF path had no file behind it
+    /// (transplants/adoptions found gone pre-rename, duplicates found gone
+    /// post-commit).
+    pub pdfs_missing: usize,
+}
+
+/// Resolve a ref to its root's SOURCE_FK (trashed roots included — the plan
+/// wants to reject those with a 409, not a 404).
+fn resolve_source_fk(conn: &Connection, paper: &PaperRef) -> Result<i64> {
+    match paper {
+        PaperRef::SourceFk(sfk) => Ok(*sfk),
+        _ => {
+            let sid = resolve_source_id(conn, paper)?.ok_or_else(|| {
+                // Plain id in the message, matching every other surface.
+                CoreError::PaperNotFound(match paper {
+                    PaperRef::Id(pid) => pid.to_string(),
+                    PaperRef::SourceFk(sfk) => sfk.to_string(),
+                    PaperRef::Source { source_id, .. } => source_id.clone(),
+                })
+            })?;
+            crate::service::paper::resolve_source_fk(conn, &sid)
+        }
+    }
+}
+
+/// One executed (reversible) rename, kept so a failed DB phase can undo it.
+struct DoneRename {
+    from: PathBuf,
+    to: PathBuf,
+}
+
+/// Merge the `loser` paper root into the `winner`: winner's metadata is
+/// canonical; the loser's notes, annotations, project memberships, reading
+/// statuses, tags, missing versions, and PDFs move over; the loser root is
+/// deleted. See the storage module for the exact row-level contract.
+pub fn merge_papers(
+    conn: &mut Connection,
+    pdf_dir: &Path,
+    winner: &PaperRef,
+    loser: &PaperRef,
+) -> Result<MergeReceipt> {
+    let _guard = IMPORT_ROOT_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+
+    let winner_fk = resolve_source_fk(conn, winner)?;
+    let loser_fk = resolve_source_fk(conn, loser)?;
+    // "Winner has a PDF" is judged by a real file, not the stored string.
+    let plan = store::merge_plan(conn, winner_fk, loser_fk, |p: &str| Path::new(p).is_file())?;
+
+    // ── FS phase: reversible renames only ───────────────────────────────────
+    let mut renames: Vec<(i64, String)> = Vec::new();
+    let mut done: Vec<DoneRename> = Vec::new();
+    let mut pdfs_adopted = 0usize;
+    let mut pdfs_missing = 0usize;
+
+    // Never move a file that lives outside the managed PDF dir (a hand-linked
+    // or legacy path): keep it where it is and let the DB keep pointing at it.
+    let managed = fs::canonicalize(pdf_dir).ok();
+    let mut rename_for = |version: i64,
+                          from_str: &str,
+                          adopt: bool,
+                          done: &mut Vec<DoneRename>,
+                          renames: &mut Vec<(i64, String)>|
+     -> Result<()> {
+        let from = Path::new(from_str);
+        let to = pdf_dir.join(pdf_on_disk_name(&plan.winner_id, version));
+        if !from.is_file() {
+            pdfs_missing += 1;
+            return Ok(()); // absent from `renames` → DB clears the pointer
+        }
+        let inside_managed = managed.as_deref().is_some_and(|m| {
+            from.parent()
+                .and_then(|p| fs::canonicalize(p).ok())
+                .is_some_and(|p| p == m)
+        });
+        // Keep the file where it is (DB points at it) when it must not be
+        // moved: it lives outside the managed dir, or an unrelated file (e.g.
+        // an orphan from a crashed import) already occupies the destination —
+        // rename() would silently destroy that file's bytes.
+        if !inside_managed || (from != to.as_path() && to.exists()) {
+            renames.push((version, from_str.to_owned()));
+            if adopt {
+                pdfs_adopted += 1;
+            }
+            return Ok(());
+        }
+        if from != to.as_path() {
+            fs::rename(from, &to).map_err(|e| {
+                CoreError::Internal(format!(
+                    "merge_papers: renaming PDF {from:?} -> {to:?} failed: {e}"
+                ))
+            })?;
+            done.push(DoneRename {
+                from: from.to_path_buf(),
+                to: to.clone(),
+            });
+        }
+        renames.push((version, to.to_string_lossy().into_owned()));
+        if adopt {
+            pdfs_adopted += 1;
+        }
+        Ok(())
+    };
+
+    let mut fs_result: Result<()> = Ok(());
+    for action in &plan.actions {
+        let r = match action {
+            VersionAction::Transplant {
+                version,
+                loser_pdf_path: Some(p),
+            } => rename_for(*version, p, false, &mut done, &mut renames),
+            VersionAction::AdoptPdf {
+                version,
+                loser_pdf_path,
+            } => rename_for(*version, loser_pdf_path, true, &mut done, &mut renames),
+            _ => Ok(()),
+        };
+        if let Err(e) = r {
+            fs_result = Err(e);
+            break;
+        }
+    }
+    if let Err(e) = fs_result {
+        return Err(fold_undo_failures(e, undo_renames(&done)));
+    }
+
+    // ── DB phase ────────────────────────────────────────────────────────────
+    let stats: MergeStats = match store::merge_paper_roots(conn, &plan, &renames) {
+        Ok(s) => s,
+        Err(e) => {
+            return Err(fold_undo_failures(e, undo_renames(&done)));
+        }
+    };
+
+    // ── Post-commit: irreversible deletions last, best-effort ───────────────
+    let mut pdfs_deleted = 0usize;
+    let mut pdfs_kept_external = 0usize;
+    for action in &plan.actions {
+        if let VersionAction::Collapse {
+            version,
+            duplicate_pdf_path: Some(p),
+        } = action
+        {
+            // Delete only while the winner's copy verifiably exists as a
+            // DIFFERENT file — the plan-time snapshot may have gone stale, and
+            // both rows can point at one shared file. Skipping leaves at worst
+            // an orphan in the PDF dir; deleting wrongly loses the last copy.
+            let winner_path = store::pdf_path_for_version(conn, plan.winner_fk, *version)?;
+            let winner_has_other_copy = winner_path
+                .as_deref()
+                .is_some_and(|wp| wp != p.as_str() && Path::new(wp).is_file());
+            if !Path::new(p).is_file() {
+                pdfs_missing += 1;
+            } else if winner_has_other_copy {
+                if crate::service::files::delete_pdf(pdf_dir, p) {
+                    pdfs_deleted += 1;
+                } else {
+                    // Outside the managed dir: never deleted, reported instead.
+                    pdfs_kept_external += 1;
+                }
+            }
+        }
+    }
+
+    Ok(MergeReceipt {
+        winner_source_fk: plan.winner_fk,
+        winner_source_id: plan.winner_id,
+        merged_source_id: plan.loser_id,
+        notes_moved: stats.notes_moved,
+        annotations_moved: stats.annotations_moved,
+        memberships_moved: stats.memberships_moved,
+        memberships_collapsed: stats.memberships_collapsed,
+        reading_statuses_moved: stats.reading_statuses_moved,
+        versions_transplanted: stats.versions_transplanted,
+        versions_collapsed: stats.versions_collapsed,
+        tags_added: stats.tags_added,
+        pdfs_renamed: done.len(),
+        pdfs_adopted,
+        pdfs_deleted,
+        pdfs_kept_external,
+        pdfs_missing,
+    })
+}
+
+/// Reverse the FS phase, reporting what could NOT be restored (the caller
+/// folds failures into its error instead of silently losing them).
+fn undo_renames(done: &[DoneRename]) -> Vec<String> {
+    let mut failed = Vec::new();
+    for r in done.iter().rev() {
+        if let Err(e) = fs::rename(&r.to, &r.from) {
+            failed.push(format!("{:?} -> {:?}: {e}", r.to, r.from));
+        }
+    }
+    failed
+}
+
+/// A failed undo leaves files under winner names with the DB unchanged — an
+/// inconsistency the caller must hear about, upgraded to Internal so nobody
+/// blindly retries against the skewed filesystem.
+fn fold_undo_failures(e: CoreError, failed: Vec<String>) -> CoreError {
+    if failed.is_empty() {
+        e
+    } else {
+        CoreError::Internal(format!(
+            "{e}; additionally {} PDF rename(s) could not be undone: {}",
+            failed.len(),
+            failed.join(", ")
+        ))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_support::db;
+    use rusqlite::params;
+    use tempfile::tempdir;
+
+    fn root(conn: &Connection, sid: &str) -> i64 {
+        conn.execute("INSERT INTO PAPER_ROOTS (SOURCE_ID) VALUES (?)", [sid])
+            .unwrap();
+        conn.last_insert_rowid()
+    }
+
+    fn version(conn: &Connection, fk: i64, sid: &str, v: i64, pdf: Option<&str>) {
+        conn.execute(
+            "INSERT INTO PAPER (SOURCE_ID, VERSION, TITLE, HAS_PDF, SOURCE_FK) \
+             VALUES (?1, ?2, 'T', ?3, ?4)",
+            params![sid, v, pdf.is_some(), fk],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO PAPER_META (PAPER_ID, PDF_PATH, AUTHORS) VALUES (?1, ?2, '[\"A\"]')",
+            params![conn.last_insert_rowid(), pdf],
+        )
+        .unwrap();
+    }
+
+    /// Winner arxiv:W v1 (own PDF) + v2 (no PDF); loser local:L v1 (duplicate
+    /// PDF), v2 (adoptable PDF), v3 (transplantable PDF). Files really exist.
+    fn seeded(pdf_dir: &Path) -> (Connection, i64, i64) {
+        let conn = db();
+        let w = root(&conn, "arxiv:W");
+        let l = root(&conn, "local:L");
+        let path = |name: &str| pdf_dir.join(name).to_string_lossy().into_owned();
+        for (name, content) in [
+            ("arxiv_Wv1.pdf", "winner-v1"),
+            ("local_Lv1.pdf", "dup"),
+            ("local_Lv2.pdf", "adopt-me"),
+            ("local_Lv3.pdf", "transplant-me"),
+        ] {
+            fs::write(pdf_dir.join(name), content).unwrap();
+        }
+        version(&conn, w, "arxiv:W", 1, Some(&path("arxiv_Wv1.pdf")));
+        version(&conn, w, "arxiv:W", 2, None);
+        version(&conn, l, "local:L", 1, Some(&path("local_Lv1.pdf")));
+        version(&conn, l, "local:L", 2, Some(&path("local_Lv2.pdf")));
+        version(&conn, l, "local:L", 3, Some(&path("local_Lv3.pdf")));
+        (conn, w, l)
+    }
+
+    #[test]
+    fn merge_end_to_end_renames_adopts_and_deletes_files() {
+        let dir = tempdir().unwrap();
+        let (mut conn, w, _l) = seeded(dir.path());
+
+        let r = merge_papers(
+            &mut conn,
+            dir.path(),
+            &PaperRef::SourceFk(w),
+            &PaperRef::source("local:L".into()),
+        )
+        .unwrap();
+
+        assert_eq!(r.winner_source_id, "arxiv:W");
+        assert_eq!(r.merged_source_id, "local:L");
+        assert_eq!(r.versions_transplanted, 1);
+        assert_eq!(r.versions_collapsed, 2);
+        assert_eq!(r.pdfs_renamed, 2); // adopt v2 + transplant v3
+        assert_eq!(r.pdfs_adopted, 1);
+        assert_eq!(r.pdfs_deleted, 1); // duplicate v1
+        assert_eq!(r.pdfs_missing, 0);
+
+        // Filesystem: winner names exist with the loser's bytes; loser names gone.
+        let read = |n: &str| fs::read_to_string(dir.path().join(n)).unwrap();
+        assert_eq!(read("arxiv_Wv1.pdf"), "winner-v1");
+        assert_eq!(read("arxiv_Wv2.pdf"), "adopt-me");
+        assert_eq!(read("arxiv_Wv3.pdf"), "transplant-me");
+        for gone in ["local_Lv1.pdf", "local_Lv2.pdf", "local_Lv3.pdf"] {
+            assert!(!dir.path().join(gone).exists(), "{gone} should be gone");
+        }
+
+        // DB pointers follow the renames.
+        let row = |v: i64| -> (Option<String>, bool) {
+            conn.query_row(
+                "SELECT m.PDF_PATH, p.HAS_PDF FROM PAPER p \
+                 JOIN PAPER_META m ON m.PAPER_ID = p.PAPER_ID \
+                 WHERE p.SOURCE_FK = ?1 AND p.VERSION = ?2",
+                params![w, v],
+                |r| Ok((r.get(0)?, r.get(1)?)),
+            )
+            .unwrap()
+        };
+        let expect = |n: &str| Some(dir.path().join(n).to_string_lossy().into_owned());
+        assert_eq!(row(1), (expect("arxiv_Wv1.pdf"), true));
+        assert_eq!(row(2), (expect("arxiv_Wv2.pdf"), true));
+        assert_eq!(row(3), (expect("arxiv_Wv3.pdf"), true));
+    }
+
+    #[test]
+    fn merge_counts_missing_files_and_skips_their_pointers() {
+        let dir = tempdir().unwrap();
+        let conn = db();
+        let w = root(&conn, "arxiv:W");
+        let l = root(&conn, "local:L");
+        version(&conn, w, "arxiv:W", 1, None);
+        // Both loser versions claim PDFs that don't exist on disk.
+        version(&conn, l, "local:L", 1, Some("/nonexistent/lv1.pdf")); // adopt attempt
+        version(&conn, l, "local:L", 2, Some("/nonexistent/lv2.pdf")); // transplant
+
+        let mut conn = conn;
+        let r = merge_papers(
+            &mut conn,
+            dir.path(),
+            &PaperRef::SourceFk(w),
+            &PaperRef::SourceFk(l),
+        )
+        .unwrap();
+        assert_eq!(r.pdfs_missing, 2);
+        assert_eq!(r.pdfs_renamed, 0);
+        assert_eq!(r.pdfs_adopted, 0);
+
+        // Adoption skipped: winner v1 still has no PDF. Transplanted v2's stale
+        // pointer cleared.
+        let row = |v: i64| -> (Option<String>, bool) {
+            conn.query_row(
+                "SELECT m.PDF_PATH, p.HAS_PDF FROM PAPER p \
+                 JOIN PAPER_META m ON m.PAPER_ID = p.PAPER_ID \
+                 WHERE p.SOURCE_FK = ?1 AND p.VERSION = ?2",
+                params![w, v],
+                |r| Ok((r.get(0)?, r.get(1)?)),
+            )
+            .unwrap()
+        };
+        assert_eq!(row(1), (None, false));
+        assert_eq!(row(2), (None, false));
+    }
+
+    #[test]
+    fn merge_restores_renamed_files_when_the_db_phase_fails() {
+        let dir = tempdir().unwrap();
+        let (mut conn, w, l) = seeded(dir.path());
+        // Fault injection: the merge transaction reads SEARCH_STATE; dropping
+        // the table makes the DB phase fail AFTER the FS phase renamed files.
+        conn.execute_batch("DROP TABLE SEARCH_STATE").unwrap();
+
+        let err = merge_papers(
+            &mut conn,
+            dir.path(),
+            &PaperRef::SourceFk(w),
+            &PaperRef::SourceFk(l),
+        )
+        .unwrap_err();
+        assert!(
+            err.to_string().to_lowercase().contains("search_state"),
+            "{err}"
+        );
+
+        // Every file is back under its original name, no winner-name leftovers.
+        for (name, content) in [
+            ("arxiv_Wv1.pdf", "winner-v1"),
+            ("local_Lv1.pdf", "dup"),
+            ("local_Lv2.pdf", "adopt-me"),
+            ("local_Lv3.pdf", "transplant-me"),
+        ] {
+            assert_eq!(
+                fs::read_to_string(dir.path().join(name)).unwrap(),
+                content,
+                "{name} not restored"
+            );
+        }
+        for leftover in ["arxiv_Wv2.pdf", "arxiv_Wv3.pdf"] {
+            assert!(
+                !dir.path().join(leftover).exists(),
+                "{leftover} left behind"
+            );
+        }
+        // And the DB rows are untouched.
+        let loser_rows: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM PAPER WHERE SOURCE_ID = 'local:L'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(loser_rows, 3);
+    }
+
+    /// Winner claims a PDF whose file is gone; the loser holds the only real
+    /// copy — it must be adopted, never deleted as a duplicate.
+    #[test]
+    fn merge_rescues_the_loser_pdf_when_the_winner_pointer_is_a_ghost() {
+        let dir = tempdir().unwrap();
+        let conn = db();
+        let w = root(&conn, "arxiv:W");
+        let l = root(&conn, "local:L");
+        let ghost = dir.path().join("arxiv_Wv1.pdf"); // stored, never written
+        let real = dir.path().join("local_Lv1.pdf");
+        fs::write(&real, "the-only-real-copy").unwrap();
+        version(&conn, w, "arxiv:W", 1, Some(&ghost.to_string_lossy()));
+        version(&conn, l, "local:L", 1, Some(&real.to_string_lossy()));
+
+        let mut conn = conn;
+        let r = merge_papers(
+            &mut conn,
+            dir.path(),
+            &PaperRef::SourceFk(w),
+            &PaperRef::SourceFk(l),
+        )
+        .unwrap();
+        assert_eq!(r.pdfs_adopted, 1);
+        assert_eq!(r.pdfs_deleted, 0, "the only real PDF must not be deleted");
+
+        let path: Option<String> = conn
+            .query_row(
+                "SELECT m.PDF_PATH FROM PAPER p JOIN PAPER_META m ON m.PAPER_ID = p.PAPER_ID \
+                 WHERE p.SOURCE_FK = ?1 AND p.VERSION = 1",
+                params![w],
+                |r| r.get(0),
+            )
+            .unwrap();
+        let expected = dir.path().join("arxiv_Wv1.pdf");
+        assert_eq!(path.as_deref(), Some(&*expected.to_string_lossy()));
+        assert_eq!(fs::read_to_string(&expected).unwrap(), "the-only-real-copy");
+    }
+
+    /// An unrelated file already at the destination name (orphan of a crashed
+    /// import) must never be overwritten: the loser file stays put and the DB
+    /// points at it in place.
+    #[test]
+    fn merge_never_overwrites_an_orphan_at_the_destination_name() {
+        let dir = tempdir().unwrap();
+        let conn = db();
+        let w = root(&conn, "arxiv:W");
+        let l = root(&conn, "local:L");
+        let orphan = dir.path().join("arxiv_Wv2.pdf");
+        let loser_file = dir.path().join("local_Lv2.pdf");
+        fs::write(&orphan, "orphan-bytes").unwrap();
+        fs::write(&loser_file, "loser-bytes").unwrap();
+        version(&conn, w, "arxiv:W", 1, None);
+        version(&conn, l, "local:L", 2, Some(&loser_file.to_string_lossy()));
+
+        let mut conn = conn;
+        merge_papers(
+            &mut conn,
+            dir.path(),
+            &PaperRef::SourceFk(w),
+            &PaperRef::SourceFk(l),
+        )
+        .unwrap();
+
+        assert_eq!(fs::read_to_string(&orphan).unwrap(), "orphan-bytes");
+        assert_eq!(fs::read_to_string(&loser_file).unwrap(), "loser-bytes");
+        let path: Option<String> = conn
+            .query_row(
+                "SELECT m.PDF_PATH FROM PAPER p JOIN PAPER_META m ON m.PAPER_ID = p.PAPER_ID \
+                 WHERE p.SOURCE_FK = ?1 AND p.VERSION = 2",
+                params![w],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(path.as_deref(), Some(&*loser_file.to_string_lossy()));
+    }
+
+    /// Undo failures are reported, and a caller folding them keeps both the
+    /// original failure and the un-restored files in one message.
+    #[test]
+    fn undo_failures_are_reported_and_folded_into_the_error() {
+        let dir = tempdir().unwrap();
+        let a = dir.path().join("a.pdf");
+        fs::write(&a, "x").unwrap();
+        let restorable = DoneRename {
+            from: dir.path().join("orig.pdf"),
+            to: a.clone(),
+        };
+        let gone = DoneRename {
+            from: dir.path().join("orig2.pdf"),
+            to: dir.path().join("never-existed.pdf"),
+        };
+        let failed = undo_renames(&[restorable, gone]);
+        assert_eq!(failed.len(), 1);
+        assert!(dir.path().join("orig.pdf").is_file());
+
+        let e = fold_undo_failures(CoreError::Conflict("boom".into()), failed);
+        let msg = e.to_string();
+        assert!(matches!(e, CoreError::Internal(_)));
+        assert!(
+            msg.contains("boom") && msg.contains("could not be undone"),
+            "{msg}"
+        );
+        // No failures -> the original error passes through untouched.
+        assert!(matches!(
+            fold_undo_failures(CoreError::Conflict("boom".into()), Vec::new()),
+            CoreError::Conflict(_)
+        ));
+    }
+
+    /// An external duplicate is never deleted (delete_pdf is dir-gated) and
+    /// the receipt says so instead of staying silent.
+    #[test]
+    fn merge_reports_external_duplicates_it_leaves_on_disk() {
+        let pdf_dir = tempdir().unwrap();
+        let elsewhere = tempdir().unwrap();
+        let w_pdf = pdf_dir.path().join("arxiv_Wv1.pdf");
+        let ext_dup = elsewhere.path().join("copy.pdf");
+        fs::write(&w_pdf, "winner").unwrap();
+        fs::write(&ext_dup, "dup").unwrap();
+
+        let conn = db();
+        let w = root(&conn, "arxiv:W");
+        let l = root(&conn, "local:L");
+        version(&conn, w, "arxiv:W", 1, Some(&w_pdf.to_string_lossy()));
+        version(&conn, l, "local:L", 1, Some(&ext_dup.to_string_lossy()));
+
+        let mut conn = conn;
+        let r = merge_papers(
+            &mut conn,
+            pdf_dir.path(),
+            &PaperRef::SourceFk(w),
+            &PaperRef::SourceFk(l),
+        )
+        .unwrap();
+        assert_eq!(r.pdfs_deleted, 0);
+        assert_eq!(r.pdfs_kept_external, 1);
+        assert!(ext_dup.is_file());
+    }
+
+    /// Winner and loser rows can point at ONE shared file; the post-commit
+    /// duplicate delete must recognize that and leave it alone.
+    #[test]
+    fn merge_never_deletes_a_file_the_winner_also_points_at() {
+        let dir = tempdir().unwrap();
+        let conn = db();
+        let w = root(&conn, "arxiv:W");
+        let l = root(&conn, "local:L");
+        let shared = dir.path().join("shared.pdf");
+        fs::write(&shared, "one-copy").unwrap();
+        version(&conn, w, "arxiv:W", 1, Some(&shared.to_string_lossy()));
+        version(&conn, l, "local:L", 1, Some(&shared.to_string_lossy()));
+
+        let mut conn = conn;
+        let r = merge_papers(
+            &mut conn,
+            dir.path(),
+            &PaperRef::SourceFk(w),
+            &PaperRef::SourceFk(l),
+        )
+        .unwrap();
+        assert_eq!(r.pdfs_deleted, 0, "the shared file is not a duplicate");
+        assert_eq!(fs::read_to_string(&shared).unwrap(), "one-copy");
+    }
+
+    /// A PDF stored OUTSIDE the managed dir (hand-linked / legacy path) is
+    /// never moved: the winner's row simply points at it where it lives.
+    #[test]
+    fn merge_leaves_external_pdfs_in_place() {
+        let pdf_dir = tempdir().unwrap();
+        let elsewhere = tempdir().unwrap();
+        let external = elsewhere.path().join("my-copy.pdf");
+        fs::write(&external, "external").unwrap();
+
+        let conn = db();
+        let w = root(&conn, "arxiv:W");
+        let l = root(&conn, "local:L");
+        version(&conn, w, "arxiv:W", 1, None); // adoption target
+        version(&conn, l, "local:L", 1, Some(&external.to_string_lossy()));
+
+        let mut conn = conn;
+        let r = merge_papers(
+            &mut conn,
+            pdf_dir.path(),
+            &PaperRef::SourceFk(w),
+            &PaperRef::SourceFk(l),
+        )
+        .unwrap();
+        assert_eq!(r.pdfs_adopted, 1);
+        assert_eq!(r.pdfs_renamed, 0, "external files must not be moved");
+        assert!(external.is_file(), "external file must stay where it was");
+
+        let (path, has): (Option<String>, bool) = conn
+            .query_row(
+                "SELECT m.PDF_PATH, p.HAS_PDF FROM PAPER p \
+                 JOIN PAPER_META m ON m.PAPER_ID = p.PAPER_ID \
+                 WHERE p.SOURCE_FK = ?1 AND p.VERSION = 1",
+                params![w],
+                |r| Ok((r.get(0)?, r.get(1)?)),
+            )
+            .unwrap();
+        assert_eq!(path.as_deref(), Some(&*external.to_string_lossy()));
+        assert!(has);
+    }
+
+    #[test]
+    fn merge_rejects_two_refs_to_the_same_root() {
+        let dir = tempdir().unwrap();
+        let mut conn = db();
+        let w = root(&conn, "arxiv:W");
+        version(&conn, w, "arxiv:W", 1, None);
+        let err = merge_papers(
+            &mut conn,
+            dir.path(),
+            &PaperRef::SourceFk(w),
+            &PaperRef::source("arxiv:W".into()),
+        )
+        .unwrap_err();
+        assert!(matches!(err, CoreError::Conflict(_)), "{err}");
+    }
+
+    #[test]
+    fn merge_surfaces_not_found_for_unknown_refs() {
+        let dir = tempdir().unwrap();
+        let mut conn = db();
+        let w = root(&conn, "arxiv:W");
+        version(&conn, w, "arxiv:W", 1, None);
+        let err = merge_papers(
+            &mut conn,
+            dir.path(),
+            &PaperRef::SourceFk(w),
+            &PaperRef::source("arxiv:nope".into()),
+        )
+        .unwrap_err();
+        assert!(matches!(err, CoreError::PaperNotFound(_)), "{err}");
+    }
+}

--- a/src-tauri/crates/core/src/storage/queries/paper/merge.rs
+++ b/src-tauri/crates/core/src/storage/queries/paper/merge.rs
@@ -1,0 +1,1324 @@
+//! Merge one paper root into another — the DB half of the paper/PDF dedupe.
+//!
+//! [`merge_plan`] classifies the loser's versions read-only; the service does
+//! the (reversible) PDF renames; [`merge_paper_roots`] is the one transaction
+//! that re-points every dependent row and deletes the loser root. Duplicate
+//! files are unlinked by the service only after commit.
+//!
+//! The winner's metadata is canonical — never field-merged. Children, tags,
+//! missing versions and PDFs move; use Paper Repair afterwards for metadata.
+
+use rusqlite::{params, Connection, OptionalExtension};
+use serde::Serialize;
+
+use crate::error::{CoreError, Result};
+use crate::storage::db::{list_from_sql, list_to_sql, transaction};
+
+use super::fts::refresh_fts;
+use super::write::sync_paper_tags;
+
+/// What happens to one loser version, decided by [`merge_plan`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum VersionAction {
+    /// Winner has no row with this VERSION: the loser PAPER row is re-keyed to
+    /// the winner (same VERSION), and its PDF file (if any) renamed with it.
+    Transplant {
+        version: i64,
+        loser_pdf_path: Option<String>,
+    },
+    /// Winner's same-numbered version exists but has no PDF while the loser's
+    /// does: the winner row adopts the loser's file; the loser row collapses.
+    AdoptPdf {
+        version: i64,
+        loser_pdf_path: String,
+    },
+    /// Winner's same-numbered version wins outright; the loser row collapses
+    /// and its PDF (if any) is a duplicate to delete post-commit.
+    Collapse {
+        version: i64,
+        duplicate_pdf_path: Option<String>,
+    },
+}
+
+/// Read-only merge plan: identities plus the per-version classification the
+/// service turns into filesystem renames.
+#[derive(Debug, Clone)]
+pub struct MergePlan {
+    pub winner_fk: i64,
+    pub winner_id: String,
+    pub loser_fk: i64,
+    pub loser_id: String,
+    pub actions: Vec<VersionAction>,
+    /// Both roots' (VERSION, stored PDF_PATH) at plan time (ascending);
+    /// re-checked in the transaction so post-plan drift — a version appearing
+    /// or a PDF attached concurrently — becomes a Conflict, not a surprise.
+    pub winner_snapshot: Vec<(i64, Option<String>)>,
+    pub loser_snapshot: Vec<(i64, Option<String>)>,
+}
+
+/// Row counts of what the merge transaction actually moved — the DB half of
+/// the receipt (the service adds the file-op counts).
+#[derive(Debug, Clone, Default, Serialize)]
+pub struct MergeStats {
+    pub notes_moved: usize,
+    pub annotations_moved: usize,
+    pub memberships_moved: usize,
+    pub memberships_collapsed: usize,
+    pub reading_statuses_moved: usize,
+    pub versions_transplanted: usize,
+    pub versions_collapsed: usize,
+    pub tags_added: Vec<String>,
+}
+
+/// A root's (fk, id, status), or a typed miss.
+fn require_root(conn: &Connection, source_fk: i64) -> Result<(String, String)> {
+    conn.query_row(
+        "SELECT SOURCE_ID, STATUS FROM PAPER_ROOTS WHERE SOURCE_FK = ?",
+        [source_fk],
+        |r| Ok((r.get(0)?, r.get(1)?)),
+    )
+    .optional()?
+    .ok_or_else(|| CoreError::PaperNotFound(source_fk.to_string()))
+}
+
+/// Non-empty stored PDF path for a version, if any. Treats NULL and `''` alike:
+/// both mean "no PDF" everywhere else in the schema.
+fn stored_pdf(path: Option<String>) -> Option<String> {
+    path.filter(|p| !p.is_empty())
+}
+
+/// Share docs key papers by source_id (CRDT), so a merged-away id in a peer's
+/// doc would resurrect via the next sync import — refuse instead. Runs at plan
+/// time and again in the transaction (the import lock is in-process only).
+fn ensure_loser_not_shared(conn: &Connection, loser_fk: i64, loser_id: &str) -> Result<()> {
+    // Any status: a trashed project keeps its SHARE_ID and can be restored,
+    // so its peers' docs still carry the member list.
+    let loser_shared: bool = conn.query_row(
+        "SELECT EXISTS(SELECT 1 FROM PROJECT_TO_PAPER ptp \
+         JOIN PROJECT pr ON pr.PROJECT_FK = ptp.PROJECT_FK \
+         WHERE ptp.SOURCE_FK = ? AND pr.SHARE_ID IS NOT NULL AND pr.SHARE_ID != '')",
+        [loser_fk],
+        |r| r.get(0),
+    )?;
+    if loser_shared {
+        return Err(CoreError::Conflict(format!(
+            "Cannot merge {loser_id:?} away: it belongs to a shared project, and peers' \
+             sync docs would re-create it. Remove it from the shared project first."
+        )));
+    }
+    Ok(())
+}
+
+/// A root's (VERSION, PDF_PATH) rows, ascending — the drift check's unit.
+fn version_snapshot(conn: &Connection, source_fk: i64) -> Result<Vec<(i64, Option<String>)>> {
+    let mut stmt = conn.prepare(
+        "SELECT p.VERSION, m.PDF_PATH FROM PAPER p \
+         LEFT JOIN PAPER_META m ON m.PAPER_ID = p.PAPER_ID \
+         WHERE p.SOURCE_FK = ? ORDER BY p.VERSION ASC",
+    )?;
+    let rows = stmt.query_map([source_fk], |r| Ok((r.get(0)?, r.get(1)?)))?;
+    Ok(rows.collect::<rusqlite::Result<_>>()?)
+}
+
+/// Classify every loser version against the winner's version set. Read-only.
+///
+/// Guards: both roots must exist and be `active`, and be distinct. A trashed
+/// root can't be merged in either direction — restore it first; merging is a
+/// deliberate act on live papers, not a trash operation.
+///
+/// `pdf_exists` is an injected file check (storage stays FS-free): whether the
+/// winner "has a PDF" must be judged by a real file, not the PDF_PATH string —
+/// a ghost pointer must lose to a real loser file, not delete it as a dup.
+pub fn merge_plan(
+    conn: &Connection,
+    winner_fk: i64,
+    loser_fk: i64,
+    pdf_exists: impl Fn(&str) -> bool,
+) -> Result<MergePlan> {
+    if winner_fk == loser_fk {
+        return Err(CoreError::Conflict(
+            "Cannot merge a paper into itself.".into(),
+        ));
+    }
+    let (winner_id, w_status) = require_root(conn, winner_fk)?;
+    let (loser_id, l_status) = require_root(conn, loser_fk)?;
+    for (label, status) in [("winner", w_status.as_str()), ("loser", l_status.as_str())] {
+        if status != "active" {
+            return Err(CoreError::Conflict(format!(
+                "Cannot merge: the {label} paper is in the trash (status {status:?}); restore it first."
+            )));
+        }
+    }
+
+    ensure_loser_not_shared(conn, loser_fk, &loser_id)?;
+
+    // (version -> pdf_path) for both roots; classifies collisions and is the
+    // drift baseline the transaction re-checks.
+    let winner_versions = version_snapshot(conn, winner_fk)?;
+    let loser_versions = version_snapshot(conn, loser_fk)?;
+
+    let actions = loser_versions
+        .clone()
+        .into_iter()
+        .map(|(version, l_path)| {
+            let l_path = stored_pdf(l_path);
+            match winner_versions.iter().find(|(wv, _)| *wv == version) {
+                None => VersionAction::Transplant {
+                    version,
+                    loser_pdf_path: l_path,
+                },
+                Some((_, w_path)) => {
+                    // File-backed, not string-backed (see fn docs).
+                    let winner_pdf = stored_pdf(w_path.clone()).filter(|p| pdf_exists(p.as_str()));
+                    match (winner_pdf, l_path) {
+                        (None, Some(p)) => VersionAction::AdoptPdf {
+                            version,
+                            loser_pdf_path: p,
+                        },
+                        (_, l) => VersionAction::Collapse {
+                            version,
+                            duplicate_pdf_path: l,
+                        },
+                    }
+                }
+            }
+        })
+        .collect();
+
+    Ok(MergePlan {
+        winner_fk,
+        winner_id,
+        loser_fk,
+        loser_id,
+        actions,
+        winner_snapshot: winner_versions,
+        loser_snapshot: loser_versions,
+    })
+}
+
+/// The merge transaction. `version_pdf_paths` carries, per version the service
+/// renamed a file for (transplants and adoptions), the NEW absolute path; a
+/// version absent from the slice means its file was missing on disk, so the
+/// row's PDF columns are cleared instead of pointing at a ghost.
+///
+/// Everything below runs in ONE deferred-FK transaction, ordered so parent-key
+/// moves land before the commit-time check (same technique as `repair_paper`):
+///
+/// 1. Version-pinned notes on collapsing loser rows → the winner's
+///    same-numbered PAPER_ID (beats `ON DELETE SET NULL` unpinning).
+/// 2. NOTE / ANNOTATION root re-point.
+/// 3. Reading status: statuses in overlap projects move only where the winner
+///    has none (winner's wins); leftovers die with the loser membership row.
+/// 4. Memberships: overlap rows deleted (cascade may only reach loser-keyed
+///    status rows, all handled in 3), disjoint rows re-keyed — child status
+///    rows first, then the parent membership (composite FK, deferred).
+/// 5. Transplants: PAPER re-keyed to the winner (SOURCE_ID + SOURCE_FK, same
+///    VERSION), PDF columns set from the rename outcome.
+/// 6. Adoptions: winner rows take the renamed file (PDF_PATH + HAS_PDF).
+/// 7. Tags: union of both roots' latest tag lists written across every
+///    surviving version (JSON half), then relational rows re-synced per
+///    version — transplanted rows pick up the winner SOURCE_ID here.
+/// 8. FTS: loser row dropped, winner rebuilt (now includes transplanted text).
+/// 9. Loser root deleted — collapsing PAPER rows and their PAPER_META /
+///    PAPER_TO_AUTHOR / PAPER_TO_TAG go by cascade.
+pub fn merge_paper_roots(
+    conn: &mut Connection,
+    plan: &MergePlan,
+    version_pdf_paths: &[(i64, String)],
+) -> Result<MergeStats> {
+    let new_path = |version: i64| -> Option<&str> {
+        version_pdf_paths
+            .iter()
+            .find(|(v, _)| *v == version)
+            .map(|(_, p)| p.as_str())
+    };
+    transaction(conn, |tx| {
+        tx.execute_batch("PRAGMA defer_foreign_keys = ON")?;
+        let mut stats = MergeStats::default();
+        let (w, l) = (plan.winner_fk, plan.loser_fk);
+
+        // Re-check every plan-time premise: the plan ran outside this
+        // transaction, and the import lock doesn't cover other processes.
+        for (fk, id) in [(w, &plan.winner_id), (l, &plan.loser_id)] {
+            let (cur_id, status) = require_root(tx, fk)?;
+            if cur_id != *id || status != "active" {
+                return Err(CoreError::Conflict(format!(
+                    "Paper {cur_id:?} changed while the merge was being prepared; retry."
+                )));
+            }
+        }
+        ensure_loser_not_shared(tx, l, &plan.loser_id)?;
+        if version_snapshot(tx, l)? != plan.loser_snapshot
+            || version_snapshot(tx, w)? != plan.winner_snapshot
+        {
+            return Err(CoreError::Conflict(format!(
+                "Paper {:?} or {:?} gained or lost versions (or a PDF was attached) while \
+                 the merge was being prepared; retry.",
+                plan.winner_id, plan.loser_id
+            )));
+        }
+
+        // 1. Re-pin notes pinned to collapsing loser versions.
+        for action in &plan.actions {
+            let (VersionAction::AdoptPdf { version, .. } | VersionAction::Collapse { version, .. }) =
+                action
+            else {
+                continue;
+            };
+            let ids: Option<(i64, i64)> = tx
+                .query_row(
+                    "SELECT lp.PAPER_ID, wp.PAPER_ID FROM PAPER lp, PAPER wp \
+                     WHERE lp.SOURCE_FK = ?1 AND wp.SOURCE_FK = ?2 \
+                       AND lp.VERSION = ?3 AND wp.VERSION = ?3",
+                    params![l, w, version],
+                    |r| Ok((r.get(0)?, r.get(1)?)),
+                )
+                .optional()?;
+            if let Some((loser_pid, winner_pid)) = ids {
+                tx.execute(
+                    "UPDATE NOTE SET PAPER_ID_FK = ? WHERE PAPER_ID_FK = ?",
+                    params![winner_pid, loser_pid],
+                )?;
+            }
+        }
+
+        // 2. Root-level children.
+        stats.notes_moved =
+            tx.execute("UPDATE NOTE SET SOURCE_FK = ? WHERE SOURCE_FK = ?", [w, l])?;
+        stats.annotations_moved = tx.execute(
+            "UPDATE ANNOTATION SET SOURCE_FK = ? WHERE SOURCE_FK = ?",
+            [w, l],
+        )?;
+
+        // 3 + 4. Memberships and reading status.
+        stats.reading_statuses_moved = tx.execute(
+            // Re-key only; the status is unchanged, so UPDATED_AT stays.
+            "UPDATE PAPER_TO_READING SET SOURCE_FK = ?1 \
+             WHERE SOURCE_FK = ?2 \
+               AND PROJECT_FK IN (SELECT PROJECT_FK FROM PROJECT_TO_PAPER WHERE SOURCE_FK = ?1) \
+               AND PROJECT_FK NOT IN (SELECT PROJECT_FK FROM PAPER_TO_READING WHERE SOURCE_FK = ?1)",
+            [w, l],
+        )?;
+        stats.memberships_collapsed = tx.execute(
+            "DELETE FROM PROJECT_TO_PAPER WHERE SOURCE_FK = ?2 \
+             AND PROJECT_FK IN (SELECT PROJECT_FK FROM PROJECT_TO_PAPER WHERE SOURCE_FK = ?1)",
+            [w, l],
+        )?;
+        // Disjoint projects: status child first, then the membership parent.
+        stats.reading_statuses_moved += tx.execute(
+            "UPDATE PAPER_TO_READING SET SOURCE_FK = ?1 WHERE SOURCE_FK = ?2",
+            [w, l],
+        )?;
+        stats.memberships_moved = tx.execute(
+            "UPDATE PROJECT_TO_PAPER SET SOURCE_FK = ?1, UPDATED_AT = datetime('now') \
+             WHERE SOURCE_FK = ?2",
+            [w, l],
+        )?;
+
+        // Tag lists must be read BEFORE the loser loses its rows.
+        let read_tags = |fk: i64| -> Result<Vec<String>> {
+            let json: Option<Option<String>> = tx
+                .query_row(
+                    "SELECT m.TAGS FROM PAPER p JOIN PAPER_META m ON m.PAPER_ID = p.PAPER_ID \
+                     WHERE p.SOURCE_FK = ? ORDER BY p.VERSION DESC LIMIT 1",
+                    [fk],
+                    |r| r.get(0),
+                )
+                .optional()?;
+            match json.flatten() {
+                Some(s) => list_from_sql(&s),
+                None => Ok(Vec::new()),
+            }
+        };
+        // Case-insensitive dedup: TAG.TAG is COLLATE NOCASE, so "ML" and "ml"
+        // resolve to one TAG_FK — treating them as distinct would write
+        // duplicate PAPER_TO_TAG rows for the same logical tag.
+        let mut merged_tags = read_tags(w)?;
+        for t in read_tags(l)? {
+            if !merged_tags.iter().any(|m| m.eq_ignore_ascii_case(&t)) {
+                stats.tags_added.push(t.clone());
+                merged_tags.push(t);
+            }
+        }
+
+        // 5. Transplants.
+        for action in &plan.actions {
+            let VersionAction::Transplant { version, .. } = action else {
+                continue;
+            };
+            tx.execute(
+                "UPDATE PAPER SET SOURCE_ID = ?1, SOURCE_FK = ?2, UPDATED_AT = datetime('now') \
+                 WHERE SOURCE_FK = ?3 AND VERSION = ?4",
+                params![plan.winner_id, w, l, version],
+            )?;
+            match new_path(*version) {
+                Some(p) => tx.execute(
+                    "UPDATE PAPER_META SET PDF_PATH = ?1 WHERE PAPER_ID IN \
+                     (SELECT PAPER_ID FROM PAPER WHERE SOURCE_FK = ?2 AND VERSION = ?3)",
+                    params![p, w, version],
+                )?,
+                // File was missing on disk: clear the stale pointer.
+                None => {
+                    tx.execute(
+                        "UPDATE PAPER_META SET PDF_PATH = NULL WHERE PAPER_ID IN \
+                         (SELECT PAPER_ID FROM PAPER WHERE SOURCE_FK = ?1 AND VERSION = ?2)",
+                        params![w, version],
+                    )?;
+                    tx.execute(
+                        "UPDATE PAPER SET HAS_PDF = 0 WHERE SOURCE_FK = ?1 AND VERSION = ?2",
+                        params![w, version],
+                    )?
+                }
+            };
+            stats.versions_transplanted += 1;
+        }
+
+        // 6. Adoptions. No rename for this version means the loser's file was
+        // gone too — clear the winner's (ghost or NULL) pointer, mirroring the
+        // Transplant branch, instead of leaving a stale path behind.
+        for action in &plan.actions {
+            let VersionAction::AdoptPdf { version, .. } = action else {
+                continue;
+            };
+            match new_path(*version) {
+                Some(p) => {
+                    tx.execute(
+                        "UPDATE PAPER_META SET PDF_PATH = ?1 WHERE PAPER_ID IN \
+                         (SELECT PAPER_ID FROM PAPER WHERE SOURCE_FK = ?2 AND VERSION = ?3)",
+                        params![p, w, version],
+                    )?;
+                    tx.execute(
+                        "UPDATE PAPER SET HAS_PDF = 1, UPDATED_AT = datetime('now') \
+                         WHERE SOURCE_FK = ?1 AND VERSION = ?2",
+                        params![w, version],
+                    )?;
+                }
+                None => {
+                    tx.execute(
+                        "UPDATE PAPER_META SET PDF_PATH = NULL WHERE PAPER_ID IN \
+                         (SELECT PAPER_ID FROM PAPER WHERE SOURCE_FK = ?1 AND VERSION = ?2)",
+                        params![w, version],
+                    )?;
+                    tx.execute(
+                        "UPDATE PAPER SET HAS_PDF = 0 WHERE SOURCE_FK = ?1 AND VERSION = ?2",
+                        params![w, version],
+                    )?;
+                }
+            }
+        }
+        stats.versions_collapsed = plan
+            .actions
+            .iter()
+            .filter(|a| !matches!(a, VersionAction::Transplant { .. }))
+            .count();
+
+        // 7. Tag union across every surviving version (both halves of dual
+        // tag storage; transplanted rows get the winner SOURCE_ID re-synced).
+        tx.execute(
+            "UPDATE PAPER_META SET TAGS = ?1 WHERE PAPER_ID IN \
+             (SELECT PAPER_ID FROM PAPER WHERE SOURCE_FK = ?2)",
+            params![list_to_sql(&merged_tags), w],
+        )?;
+        let winner_rows: Vec<(i64, i64)> = {
+            let mut stmt = tx.prepare("SELECT PAPER_ID, VERSION FROM PAPER WHERE SOURCE_FK = ?")?;
+            let rows = stmt.query_map([w], |r| Ok((r.get(0)?, r.get(1)?)))?;
+            rows.collect::<rusqlite::Result<_>>()?
+        };
+        for (pid, ver) in winner_rows {
+            sync_paper_tags(tx, pid, &plan.winner_id, ver, Some(&merged_tags))?;
+        }
+
+        // VERSION_CHECK: the loser's row dies with its root (cascade), but the
+        // winner's NEW_VERSION was computed against a version series the
+        // transplants may just have changed — drop it and let the next check
+        // re-derive rather than surface a stale "new version" pill.
+        tx.execute("DELETE FROM VERSION_CHECK WHERE SOURCE_FK = ?", [w])?;
+
+        // SEARCH_STATE saved-ids (the Search page's "already saved" checkmarks)
+        // durably hold source_id strings with no FK: rewrite the loser's id to
+        // the winner's so the mark survives the merge instead of dangling.
+        let saved: Option<String> = tx
+            .query_row(
+                "SELECT SAVED_IDS_JSON FROM SEARCH_STATE WHERE ID = 1",
+                [],
+                |r| r.get(0),
+            )
+            .optional()?;
+        if let Some(json) = saved {
+            if let Ok(serde_json::Value::Array(ids)) = serde_json::from_str(&json) {
+                let mut out: Vec<serde_json::Value> = Vec::with_capacity(ids.len());
+                for v in ids {
+                    let mapped = match v.as_str() {
+                        Some(s) if s == plan.loser_id => {
+                            serde_json::Value::String(plan.winner_id.clone())
+                        }
+                        _ => v,
+                    };
+                    if !out.contains(&mapped) {
+                        out.push(mapped);
+                    }
+                }
+                tx.execute(
+                    "UPDATE SEARCH_STATE SET SAVED_IDS_JSON = ? WHERE ID = 1",
+                    [serde_json::Value::Array(out).to_string()],
+                )?;
+            }
+        }
+
+        // 8 + 9. FTS, then the loser root (cascade collapses its leftover rows).
+        tx.execute(
+            "DELETE FROM papers_fts WHERE paper_id = ?",
+            [&plan.loser_id],
+        )?;
+        tx.execute("DELETE FROM PAPER_ROOTS WHERE SOURCE_FK = ?", [l])?;
+        refresh_fts(tx, &plan.winner_id)?;
+        tx.execute(
+            "UPDATE PAPER_ROOTS SET UPDATED_AT = datetime('now') WHERE SOURCE_FK = ?",
+            [w],
+        )?;
+        Ok(stats)
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::storage::{db::open_in_memory, init_db};
+    use rusqlite::params;
+
+    fn db() -> Connection {
+        let conn = open_in_memory().unwrap();
+        init_db(&conn).unwrap();
+        conn
+    }
+
+    fn root(conn: &Connection, sid: &str) -> i64 {
+        conn.execute("INSERT INTO PAPER_ROOTS (SOURCE_ID) VALUES (?)", [sid])
+            .unwrap();
+        conn.last_insert_rowid()
+    }
+
+    /// A PAPER + PAPER_META pair; `pdf` sets both PDF_PATH and HAS_PDF.
+    fn version(conn: &Connection, fk: i64, sid: &str, v: i64, pdf: Option<&str>) -> i64 {
+        conn.execute(
+            "INSERT INTO PAPER (SOURCE_ID, VERSION, TITLE, HAS_PDF, SOURCE_FK) \
+             VALUES (?1, ?2, ?3, ?4, ?5)",
+            params![sid, v, format!("{sid} v{v}"), pdf.is_some(), fk],
+        )
+        .unwrap();
+        let pid = conn.last_insert_rowid();
+        conn.execute(
+            "INSERT INTO PAPER_META (PAPER_ID, PDF_PATH, AUTHORS, TAGS) \
+             VALUES (?1, ?2, '[\"Alice\"]', NULL)",
+            params![pid, pdf],
+        )
+        .unwrap();
+        pid
+    }
+
+    fn project(conn: &Connection, name: &str, share_id: Option<&str>) -> i64 {
+        conn.execute(
+            "INSERT INTO PROJECT (NAME, SHARE_ID) VALUES (?1, ?2)",
+            params![name, share_id],
+        )
+        .unwrap();
+        conn.last_insert_rowid()
+    }
+
+    fn member(conn: &Connection, proj: i64, fk: i64) {
+        conn.execute(
+            "INSERT INTO PROJECT_TO_PAPER (PROJECT_FK, SOURCE_FK) VALUES (?1, ?2)",
+            params![proj, fk],
+        )
+        .unwrap();
+    }
+
+    fn reading(conn: &Connection, proj: i64, fk: i64, status: &str) {
+        conn.execute(
+            "INSERT INTO PAPER_TO_READING (PROJECT_FK, SOURCE_FK, STATUS) VALUES (?1, ?2, ?3)",
+            params![proj, fk, status],
+        )
+        .unwrap();
+    }
+
+    fn note(conn: &Connection, fk: i64, pinned: Option<i64>) -> i64 {
+        conn.execute(
+            "INSERT INTO NOTE (SOURCE_FK, PAPER_ID_FK, TITLE, NOTE) VALUES (?1, ?2, 't', 'b')",
+            params![fk, pinned],
+        )
+        .unwrap();
+        conn.last_insert_rowid()
+    }
+
+    fn count(conn: &Connection, sql: &str, p: impl rusqlite::Params) -> i64 {
+        conn.query_row(sql, p, |r| r.get(0)).unwrap()
+    }
+
+    // ── plan classification ─────────────────────────────────────────────────
+
+    #[test]
+    fn plan_classifies_transplant_adopt_and_collapse() {
+        let conn = db();
+        let w = root(&conn, "arxiv:W");
+        let l = root(&conn, "local:L");
+        version(&conn, w, "arxiv:W", 1, Some("/p/wv1.pdf"));
+        version(&conn, w, "arxiv:W", 2, None);
+        version(&conn, l, "local:L", 1, Some("/p/lv1.pdf")); // collides, W has PDF → dup
+        version(&conn, l, "local:L", 2, Some("/p/lv2.pdf")); // collides, W lacks PDF → adopt
+        version(&conn, l, "local:L", 3, Some("/p/lv3.pdf")); // W lacks v3 → transplant
+        version(&conn, l, "local:L", 4, None); // transplant, no file
+
+        let plan = merge_plan(&conn, w, l, |_| true).unwrap();
+        assert_eq!(plan.winner_id, "arxiv:W");
+        assert_eq!(plan.loser_id, "local:L");
+        assert_eq!(
+            plan.actions,
+            vec![
+                VersionAction::Collapse {
+                    version: 1,
+                    duplicate_pdf_path: Some("/p/lv1.pdf".into())
+                },
+                VersionAction::AdoptPdf {
+                    version: 2,
+                    loser_pdf_path: "/p/lv2.pdf".into()
+                },
+                VersionAction::Transplant {
+                    version: 3,
+                    loser_pdf_path: Some("/p/lv3.pdf".into())
+                },
+                VersionAction::Transplant {
+                    version: 4,
+                    loser_pdf_path: None
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn plan_treats_empty_pdf_path_as_no_pdf() {
+        let conn = db();
+        let w = root(&conn, "arxiv:W");
+        let l = root(&conn, "local:L");
+        version(&conn, w, "arxiv:W", 1, Some("")); // '' == no PDF
+        version(&conn, l, "local:L", 1, Some("/p/l.pdf"));
+        let plan = merge_plan(&conn, w, l, |_| true).unwrap();
+        assert_eq!(
+            plan.actions,
+            vec![VersionAction::AdoptPdf {
+                version: 1,
+                loser_pdf_path: "/p/l.pdf".into()
+            }]
+        );
+    }
+
+    /// A ghost winner pointer (stored path, file gone) must classify as
+    /// AdoptPdf, not mark the loser's real file a deletable duplicate.
+    #[test]
+    fn plan_ghost_winner_pdf_loses_to_a_real_loser_file() {
+        let conn = db();
+        let w = root(&conn, "arxiv:W");
+        let l = root(&conn, "local:L");
+        version(&conn, w, "arxiv:W", 1, Some("/p/ghost.pdf"));
+        version(&conn, l, "local:L", 1, Some("/p/real.pdf"));
+
+        // The injected check says the winner's file is gone, the loser's real.
+        let plan = merge_plan(&conn, w, l, |p| p == "/p/real.pdf").unwrap();
+        assert_eq!(
+            plan.actions,
+            vec![VersionAction::AdoptPdf {
+                version: 1,
+                loser_pdf_path: "/p/real.pdf".into()
+            }]
+        );
+    }
+
+    // ── plan guards ─────────────────────────────────────────────────────────
+
+    #[test]
+    fn plan_rejects_self_merge_missing_roots_and_trashed_roots() {
+        let conn = db();
+        let w = root(&conn, "arxiv:W");
+        let l = root(&conn, "local:L");
+
+        assert!(matches!(
+            merge_plan(&conn, w, w, |_| true),
+            Err(CoreError::Conflict(_))
+        ));
+        assert!(matches!(
+            merge_plan(&conn, 999, l, |_| true),
+            Err(CoreError::PaperNotFound(_))
+        ));
+        assert!(matches!(
+            merge_plan(&conn, w, 999, |_| true),
+            Err(CoreError::PaperNotFound(_))
+        ));
+
+        conn.execute(
+            "UPDATE PAPER_ROOTS SET STATUS = 'deleted' WHERE SOURCE_FK = ?",
+            [l],
+        )
+        .unwrap();
+        let err = merge_plan(&conn, w, l, |_| true).unwrap_err();
+        assert!(err.to_string().contains("loser"), "{err}");
+        conn.execute(
+            "UPDATE PAPER_ROOTS SET STATUS = 'active' WHERE SOURCE_FK = ?",
+            [l],
+        )
+        .unwrap();
+        conn.execute(
+            "UPDATE PAPER_ROOTS SET STATUS = 'deleted' WHERE SOURCE_FK = ?",
+            [w],
+        )
+        .unwrap();
+        let err = merge_plan(&conn, w, l, |_| true).unwrap_err();
+        assert!(err.to_string().contains("winner"), "{err}");
+    }
+
+    #[test]
+    fn plan_rejects_loser_in_shared_project_but_not_winner() {
+        let conn = db();
+        let w = root(&conn, "arxiv:W");
+        let l = root(&conn, "local:L");
+        version(&conn, w, "arxiv:W", 1, None);
+        version(&conn, l, "local:L", 1, None);
+        let shared = project(&conn, "shared", Some("share-uuid"));
+        member(&conn, shared, w);
+        // Winner in a shared project is fine — its id survives.
+        assert!(merge_plan(&conn, w, l, |_| true).is_ok());
+
+        member(&conn, shared, l);
+        let err = merge_plan(&conn, w, l, |_| true).unwrap_err();
+        assert!(
+            err.to_string().contains("shared project"),
+            "expected the share guard, got: {err}"
+        );
+
+        // A trashed shared project still blocks: it keeps its SHARE_ID and
+        // can be restored, so peers' docs still list the member.
+        conn.execute(
+            "UPDATE PROJECT SET STATUS = 'deleted' WHERE PROJECT_FK = ?",
+            [shared],
+        )
+        .unwrap();
+        assert!(merge_plan(&conn, w, l, |_| true).is_err());
+
+        // Clearing the SHARE_ID genuinely un-shares and unblocks.
+        conn.execute(
+            "UPDATE PROJECT SET SHARE_ID = NULL WHERE PROJECT_FK = ?",
+            [shared],
+        )
+        .unwrap();
+        assert!(merge_plan(&conn, w, l, |_| true).is_ok());
+    }
+
+    // ── the transaction ─────────────────────────────────────────────────────
+
+    /// One fully-loaded fixture: overlapping + disjoint projects, reading
+    /// statuses in every configuration, pinned + unpinned notes, annotations,
+    /// tags on both sides, full text on a transplanted version.
+    fn loaded_fixture(conn: &Connection) -> (i64, i64) {
+        let w = root(conn, "arxiv:W");
+        let l = root(conn, "local:L");
+        version(conn, w, "arxiv:W", 1, Some("/p/wv1.pdf"));
+        version(conn, l, "local:L", 1, Some("/p/lv1.pdf")); // collapse (dup)
+        version(conn, l, "local:L", 2, None); // transplant
+        conn.execute(
+            "UPDATE PAPER_META SET TAGS = '[\"ml\",\"shared\"]' WHERE PAPER_ID IN \
+             (SELECT PAPER_ID FROM PAPER WHERE SOURCE_FK = ?)",
+            [w],
+        )
+        .unwrap();
+        conn.execute(
+            "UPDATE PAPER_META SET TAGS = '[\"shared\",\"vision\"]' WHERE PAPER_ID IN \
+             (SELECT PAPER_ID FROM PAPER WHERE SOURCE_FK = ?)",
+            [l],
+        )
+        .unwrap();
+        (w, l)
+    }
+
+    #[test]
+    fn merge_moves_notes_and_repins_version_pinned_notes() {
+        let conn = db();
+        let (w, l) = loaded_fixture(&conn);
+        let w_v1: i64 = count(
+            &conn,
+            "SELECT PAPER_ID FROM PAPER WHERE SOURCE_FK = ? AND VERSION = 1",
+            [w],
+        );
+        let l_v1: i64 = count(
+            &conn,
+            "SELECT PAPER_ID FROM PAPER WHERE SOURCE_FK = ? AND VERSION = 1",
+            [l],
+        );
+        let l_v2: i64 = count(
+            &conn,
+            "SELECT PAPER_ID FROM PAPER WHERE SOURCE_FK = ? AND VERSION = 2",
+            [l],
+        );
+        let unpinned = note(&conn, l, None);
+        let pinned_colliding = note(&conn, l, Some(l_v1));
+        let pinned_transplanted = note(&conn, l, Some(l_v2));
+        let winner_note = note(&conn, w, Some(w_v1));
+
+        let mut conn = conn;
+        let plan = merge_plan(&conn, w, l, |_| true).unwrap();
+        let stats = merge_paper_roots(&mut conn, &plan, &[]).unwrap();
+        assert_eq!(stats.notes_moved, 3);
+
+        let pin = |id: i64| -> (i64, Option<i64>) {
+            conn.query_row(
+                "SELECT SOURCE_FK, PAPER_ID_FK FROM NOTE WHERE NOTE_SK = ?",
+                [id],
+                |r| Ok((r.get(0)?, r.get(1)?)),
+            )
+            .unwrap()
+        };
+        assert_eq!(pin(unpinned), (w, None));
+        // Pinned to the collapsing loser v1 → re-pinned to the winner's v1 row.
+        assert_eq!(pin(pinned_colliding), (w, Some(w_v1)));
+        // Pinned to the transplanted v2 → the row survived, pin unchanged.
+        assert_eq!(pin(pinned_transplanted), (w, Some(l_v2)));
+        assert_eq!(pin(winner_note), (w, Some(w_v1)));
+    }
+
+    #[test]
+    fn merge_moves_annotations() {
+        let mut conn = db();
+        let (w, l) = loaded_fixture(&conn);
+        conn.execute(
+            "INSERT INTO ANNOTATION (SOURCE_FK, ANCHOR) VALUES (?, '{}')",
+            [l],
+        )
+        .unwrap();
+        let plan = merge_plan(&conn, w, l, |_| true).unwrap();
+        let stats = merge_paper_roots(&mut conn, &plan, &[]).unwrap();
+        assert_eq!(stats.annotations_moved, 1);
+        assert_eq!(
+            count(
+                &conn,
+                "SELECT COUNT(*) FROM ANNOTATION WHERE SOURCE_FK = ?",
+                [w]
+            ),
+            1
+        );
+    }
+
+    #[test]
+    fn merge_memberships_and_reading_statuses_across_all_configurations() {
+        let mut conn = db();
+        let (w, l) = loaded_fixture(&conn);
+        // overlap_a: both members, loser has status, winner none → status moves.
+        let overlap_a = project(&conn, "overlap-a", None);
+        member(&conn, overlap_a, w);
+        member(&conn, overlap_a, l);
+        reading(&conn, overlap_a, l, "read");
+        // overlap_b: both members, both have statuses → winner's wins.
+        let overlap_b = project(&conn, "overlap-b", None);
+        member(&conn, overlap_b, w);
+        member(&conn, overlap_b, l);
+        reading(&conn, overlap_b, w, "reading");
+        reading(&conn, overlap_b, l, "read");
+        // disjoint: loser only, with a status → membership + status move.
+        let disjoint = project(&conn, "disjoint", None);
+        member(&conn, disjoint, l);
+        reading(&conn, disjoint, l, "reading");
+
+        let plan = merge_plan(&conn, w, l, |_| true).unwrap();
+        let stats = merge_paper_roots(&mut conn, &plan, &[]).unwrap();
+        assert_eq!(stats.memberships_collapsed, 2);
+        assert_eq!(stats.memberships_moved, 1);
+        assert_eq!(stats.reading_statuses_moved, 2); // overlap_a + disjoint
+
+        // Loser has no rows anywhere.
+        for table in ["PROJECT_TO_PAPER", "PAPER_TO_READING"] {
+            assert_eq!(
+                count(
+                    &conn,
+                    &format!("SELECT COUNT(*) FROM {table} WHERE SOURCE_FK = ?"),
+                    [l]
+                ),
+                0,
+                "{table} still references the loser"
+            );
+        }
+        let status = |proj: i64| -> Option<String> {
+            conn.query_row(
+                "SELECT STATUS FROM PAPER_TO_READING WHERE PROJECT_FK = ? AND SOURCE_FK = ?",
+                params![proj, w],
+                |r| r.get(0),
+            )
+            .ok()
+        };
+        assert_eq!(status(overlap_a).as_deref(), Some("read")); // moved
+        assert_eq!(status(overlap_b).as_deref(), Some("reading")); // winner's kept
+        assert_eq!(status(disjoint).as_deref(), Some("reading")); // moved with membership
+                                                                  // Exactly one membership row per project for the winner.
+        for proj in [overlap_a, overlap_b, disjoint] {
+            assert_eq!(
+                count(
+                    &conn,
+                    "SELECT COUNT(*) FROM PROJECT_TO_PAPER WHERE PROJECT_FK = ? AND SOURCE_FK = ?",
+                    params![proj, w],
+                ),
+                1
+            );
+        }
+    }
+
+    #[test]
+    fn merge_transplants_versions_and_collapses_collisions() {
+        let mut conn = db();
+        let (w, l) = loaded_fixture(&conn);
+        let plan = merge_plan(&conn, w, l, |_| true).unwrap();
+        let stats = merge_paper_roots(&mut conn, &plan, &[]).unwrap();
+        assert_eq!(stats.versions_transplanted, 1);
+        assert_eq!(stats.versions_collapsed, 1);
+
+        // Winner owns v1 (its own) and v2 (transplanted), all under its id.
+        let versions: Vec<(String, i64, String)> = {
+            let mut stmt = conn
+                .prepare("SELECT SOURCE_ID, VERSION, TITLE FROM PAPER ORDER BY VERSION")
+                .unwrap();
+            let rows = stmt
+                .query_map([], |r| Ok((r.get(0)?, r.get(1)?, r.get(2)?)))
+                .unwrap();
+            rows.collect::<rusqlite::Result<_>>().unwrap()
+        };
+        assert_eq!(
+            versions,
+            vec![
+                ("arxiv:W".to_string(), 1, "arxiv:W v1".to_string()),
+                ("arxiv:W".to_string(), 2, "local:L v2".to_string()),
+            ]
+        );
+        // The loser root and its collapsed v1's meta are gone.
+        assert_eq!(
+            count(
+                &conn,
+                "SELECT COUNT(*) FROM PAPER_ROOTS WHERE SOURCE_FK = ?",
+                [l]
+            ),
+            0
+        );
+        assert_eq!(
+            count(
+                &conn,
+                "SELECT COUNT(*) FROM PAPER_META WHERE PAPER_ID NOT IN (SELECT PAPER_ID FROM PAPER)",
+                [],
+            ),
+            0,
+            "orphaned PAPER_META rows"
+        );
+    }
+
+    #[test]
+    fn merge_unions_tags_across_both_halves_of_dual_storage() {
+        let mut conn = db();
+        let (w, l) = loaded_fixture(&conn);
+        let plan = merge_plan(&conn, w, l, |_| true).unwrap();
+        let stats = merge_paper_roots(&mut conn, &plan, &[]).unwrap();
+        assert_eq!(stats.tags_added, vec!["vision".to_string()]);
+
+        // JSON half: every surviving version carries the union, winner-first.
+        let jsons: Vec<String> = {
+            let mut stmt = conn
+                .prepare(
+                    "SELECT m.TAGS FROM PAPER p JOIN PAPER_META m ON m.PAPER_ID = p.PAPER_ID \
+                     WHERE p.SOURCE_FK = ? ORDER BY p.VERSION",
+                )
+                .unwrap();
+            let rows = stmt.query_map([w], |r| r.get(0)).unwrap();
+            rows.collect::<rusqlite::Result<_>>().unwrap()
+        };
+        assert_eq!(jsons, vec![r#"["ml","shared","vision"]"#; 2]);
+
+        // Relational half: rows per version, keyed by the winner's SOURCE_ID.
+        assert_eq!(
+            count(
+                &conn,
+                "SELECT COUNT(*) FROM PAPER_TO_TAG WHERE SOURCE_ID = 'arxiv:W'",
+                [],
+            ),
+            6 // 3 tags × 2 versions
+        );
+        assert_eq!(
+            count(
+                &conn,
+                "SELECT COUNT(*) FROM PAPER_TO_TAG WHERE SOURCE_ID = 'local:L'",
+                []
+            ),
+            0
+        );
+    }
+
+    #[test]
+    fn merge_moves_fts_to_the_winner_and_drops_the_loser_row() {
+        let mut conn = db();
+        let (w, l) = loaded_fixture(&conn);
+        // Give the loser's transplanted v2 the only full text in the merge.
+        conn.execute(
+            "UPDATE PAPER_META SET FULL_TEXT = 'quantum entanglement' WHERE PAPER_ID IN \
+             (SELECT PAPER_ID FROM PAPER WHERE SOURCE_FK = ? AND VERSION = 2)",
+            [l],
+        )
+        .unwrap();
+        assert_eq!(
+            count(
+                &conn,
+                "SELECT COUNT(*) FROM papers_fts WHERE paper_id = 'local:L'",
+                []
+            ),
+            1
+        );
+
+        let plan = merge_plan(&conn, w, l, |_| true).unwrap();
+        merge_paper_roots(&mut conn, &plan, &[]).unwrap();
+
+        assert_eq!(
+            count(
+                &conn,
+                "SELECT COUNT(*) FROM papers_fts WHERE paper_id = 'local:L'",
+                []
+            ),
+            0
+        );
+        // The transplanted text is now indexed under the winner's id.
+        assert_eq!(
+            count(
+                &conn,
+                "SELECT COUNT(*) FROM papers_fts WHERE paper_id = 'arxiv:W' \
+                 AND full_text MATCH 'entanglement'",
+                [],
+            ),
+            1
+        );
+        assert_eq!(count(&conn, "SELECT COUNT(*) FROM papers_fts", []), 1);
+    }
+
+    #[test]
+    fn merge_resets_version_check_for_both_roots() {
+        let mut conn = db();
+        let (w, l) = loaded_fixture(&conn);
+        conn.execute(
+            "INSERT INTO VERSION_CHECK (SOURCE_FK, NEW_VERSION) VALUES (?, 9)",
+            [w],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO VERSION_CHECK (SOURCE_FK, NEW_VERSION) VALUES (?, 9)",
+            [l],
+        )
+        .unwrap();
+        let plan = merge_plan(&conn, w, l, |_| true).unwrap();
+        merge_paper_roots(&mut conn, &plan, &[]).unwrap();
+        assert_eq!(count(&conn, "SELECT COUNT(*) FROM VERSION_CHECK", []), 0);
+    }
+
+    #[test]
+    fn merge_rewrites_search_state_saved_ids_with_dedup() {
+        let mut conn = db();
+        let (w, l) = loaded_fixture(&conn);
+        conn.execute(
+            "INSERT INTO SEARCH_STATE (ID, CLAUSES_JSON, SOURCE, MAX_RESULTS, RESULTS_JSON, SAVED_IDS_JSON) \
+             VALUES (1, '[]', 'arxiv', 10, '[]', '[\"local:L\",\"arxiv:W\",\"arxiv:other\"]')",
+            [],
+        )
+        .unwrap();
+        let plan = merge_plan(&conn, w, l, |_| true).unwrap();
+        merge_paper_roots(&mut conn, &plan, &[]).unwrap();
+        let saved: String = conn
+            .query_row(
+                "SELECT SAVED_IDS_JSON FROM SEARCH_STATE WHERE ID = 1",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        // loser rewritten to winner, then deduped against the existing entry.
+        assert_eq!(saved, r#"["arxiv:W","arxiv:other"]"#);
+    }
+
+    #[test]
+    fn merge_applies_pdf_paths_from_the_rename_slice_and_clears_missing() {
+        let mut conn = db();
+        let w = root(&conn, "arxiv:W");
+        let l = root(&conn, "local:L");
+        version(&conn, w, "arxiv:W", 1, None); // adoption target
+        version(&conn, l, "local:L", 1, Some("/p/lv1.pdf")); // adopt
+        version(&conn, l, "local:L", 2, Some("/p/lv2.pdf")); // transplant, file missing
+
+        let plan = merge_plan(&conn, w, l, |_| true).unwrap();
+        // Service renamed only v1; v2's file was missing on disk.
+        merge_paper_roots(&mut conn, &plan, &[(1, "/p/arxiv_Wv1.pdf".to_string())]).unwrap();
+
+        let row = |v: i64| -> (Option<String>, bool) {
+            conn.query_row(
+                "SELECT m.PDF_PATH, p.HAS_PDF FROM PAPER p \
+                 JOIN PAPER_META m ON m.PAPER_ID = p.PAPER_ID \
+                 WHERE p.SOURCE_FK = ?1 AND p.VERSION = ?2",
+                params![w, v],
+                |r| Ok((r.get(0)?, r.get(1)?)),
+            )
+            .unwrap()
+        };
+        assert_eq!(row(1), (Some("/p/arxiv_Wv1.pdf".to_string()), true));
+        assert_eq!(row(2), (None, false), "missing file must clear the pointer");
+    }
+
+    #[test]
+    fn merge_is_atomic_when_the_plan_went_stale() {
+        let mut conn = db();
+        let (w, l) = loaded_fixture(&conn);
+        let proj = project(&conn, "p", None);
+        member(&conn, proj, l);
+        note(&conn, l, None);
+        let plan = merge_plan(&conn, w, l, |_| true).unwrap();
+
+        // The loser gets trashed between plan and commit.
+        conn.execute(
+            "UPDATE PAPER_ROOTS SET STATUS = 'deleted' WHERE SOURCE_FK = ?",
+            [l],
+        )
+        .unwrap();
+        let err = merge_paper_roots(&mut conn, &plan, &[]).unwrap_err();
+        assert!(matches!(err, CoreError::Conflict(_)), "{err}");
+
+        // Nothing moved: root, membership, note, versions all intact.
+        assert_eq!(
+            count(
+                &conn,
+                "SELECT COUNT(*) FROM PAPER_ROOTS WHERE SOURCE_FK = ?",
+                [l]
+            ),
+            1
+        );
+        assert_eq!(
+            count(
+                &conn,
+                "SELECT COUNT(*) FROM PROJECT_TO_PAPER WHERE SOURCE_FK = ?",
+                [l]
+            ),
+            1
+        );
+        assert_eq!(
+            count(&conn, "SELECT COUNT(*) FROM NOTE WHERE SOURCE_FK = ?", [l]),
+            1
+        );
+        assert_eq!(
+            count(
+                &conn,
+                "SELECT COUNT(*) FROM PAPER WHERE SOURCE_ID = 'local:L'",
+                []
+            ),
+            2
+        );
+    }
+
+    /// An adoption whose loser file also went missing (no rename executed)
+    /// must clear the winner's ghost pointer, mirroring the Transplant branch.
+    #[test]
+    fn merge_clears_the_winner_ghost_when_the_adoption_file_is_missing_too() {
+        let mut conn = db();
+        let w = root(&conn, "arxiv:W");
+        let l = root(&conn, "local:L");
+        version(&conn, w, "arxiv:W", 1, Some("/p/ghost.pdf"));
+        version(&conn, l, "local:L", 1, Some("/p/also-gone.pdf"));
+
+        // pdf_exists=false for the winner's path -> AdoptPdf; empty rename
+        // slice -> the loser's file was missing on disk as well.
+        let plan = merge_plan(&conn, w, l, |_| false).unwrap();
+        assert!(matches!(plan.actions[0], VersionAction::AdoptPdf { .. }));
+        merge_paper_roots(&mut conn, &plan, &[]).unwrap();
+
+        let (path, has): (Option<String>, bool) = conn
+            .query_row(
+                "SELECT m.PDF_PATH, p.HAS_PDF FROM PAPER p \
+                 JOIN PAPER_META m ON m.PAPER_ID = p.PAPER_ID \
+                 WHERE p.SOURCE_FK = ?1 AND p.VERSION = 1",
+                [w],
+                |r| Ok((r.get(0)?, r.get(1)?)),
+            )
+            .unwrap();
+        assert_eq!((path, has), (None, false), "ghost pointer must be cleared");
+    }
+
+    /// "ML" and "ml" are one tag (TAG is COLLATE NOCASE): the union must not
+    /// produce a case-duplicate JSON entry or a second PAPER_TO_TAG row.
+    #[test]
+    fn merge_tag_union_is_case_insensitive() {
+        let mut conn = db();
+        let w = root(&conn, "arxiv:W");
+        let l = root(&conn, "local:L");
+        version(&conn, w, "arxiv:W", 1, None);
+        version(&conn, l, "local:L", 2, None);
+        for (fk, tags) in [(w, r#"["ML"]"#), (l, r#"["ml","vision"]"#)] {
+            conn.execute(
+                "UPDATE PAPER_META SET TAGS = ?1 WHERE PAPER_ID IN \
+                 (SELECT PAPER_ID FROM PAPER WHERE SOURCE_FK = ?2)",
+                params![tags, fk],
+            )
+            .unwrap();
+        }
+        let plan = merge_plan(&conn, w, l, |_| true).unwrap();
+        let stats = merge_paper_roots(&mut conn, &plan, &[]).unwrap();
+        assert_eq!(stats.tags_added, vec!["vision".to_string()]);
+        // One PAPER_TO_TAG row per (version, logical tag): 2 versions x 2 tags.
+        assert_eq!(count(&conn, "SELECT COUNT(*) FROM PAPER_TO_TAG", []), 4);
+        let json: String = conn
+            .query_row(
+                "SELECT m.TAGS FROM PAPER p JOIN PAPER_META m ON m.PAPER_ID = p.PAPER_ID \
+                 WHERE p.SOURCE_FK = ? AND p.VERSION = 1",
+                [w],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(
+            json, r#"["ML","vision"]"#,
+            "winner casing wins, no case-dup"
+        );
+    }
+
+    /// A PDF attached to either root between plan and commit changes the
+    /// snapshot the classification relied on — the merge must refuse.
+    #[test]
+    fn merge_refuses_when_a_pdf_was_attached_after_the_plan() {
+        let mut conn = db();
+        let (w, l) = loaded_fixture(&conn);
+        let plan = merge_plan(&conn, w, l, |_| true).unwrap();
+        conn.execute(
+            "UPDATE PAPER_META SET PDF_PATH = '/p/new.pdf' WHERE PAPER_ID IN \
+             (SELECT PAPER_ID FROM PAPER WHERE SOURCE_FK = ? AND VERSION = 1)",
+            [w],
+        )
+        .unwrap();
+        let err = merge_paper_roots(&mut conn, &plan, &[]).unwrap_err();
+        assert!(err.to_string().contains("PDF was attached"), "{err}");
+        assert_eq!(
+            count(
+                &conn,
+                "SELECT COUNT(*) FROM PAPER_ROOTS WHERE SOURCE_FK = ?",
+                [l]
+            ),
+            1
+        );
+    }
+
+    /// Plan-time premises are re-checked in the transaction (other processes
+    /// aren't covered by the in-process lock).
+    #[test]
+    fn merge_rechecks_the_share_guard_inside_the_transaction() {
+        let mut conn = db();
+        let (w, l) = loaded_fixture(&conn);
+        let plan = merge_plan(&conn, w, l, |_| true).unwrap();
+
+        // Another process links the loser into a shared project post-plan.
+        let shared = project(&conn, "shared", Some("share-uuid"));
+        member(&conn, shared, l);
+
+        let err = merge_paper_roots(&mut conn, &plan, &[]).unwrap_err();
+        assert!(err.to_string().contains("shared project"), "{err}");
+        assert_eq!(
+            count(
+                &conn,
+                "SELECT COUNT(*) FROM PAPER_ROOTS WHERE SOURCE_FK = ?",
+                [l]
+            ),
+            1,
+            "loser must survive a refused merge"
+        );
+    }
+
+    #[test]
+    fn merge_refuses_when_a_version_appeared_after_the_plan() {
+        let mut conn = db();
+        let (w, l) = loaded_fixture(&conn);
+        let plan = merge_plan(&conn, w, l, |_| true).unwrap();
+
+        // A concurrent import lands a new loser version the plan never saw —
+        // committing anyway would cascade-delete it silently with the root.
+        version(&conn, l, "local:L", 9, None);
+
+        let err = merge_paper_roots(&mut conn, &plan, &[]).unwrap_err();
+        assert!(err.to_string().contains("gained or lost versions"), "{err}");
+        assert_eq!(
+            count(
+                &conn,
+                "SELECT COUNT(*) FROM PAPER WHERE SOURCE_ID = 'local:L'",
+                []
+            ),
+            3,
+            "no loser rows may be touched"
+        );
+
+        // Same drift on the WINNER side (e.g. a colliding version fetched
+        // in-between) is refused too, not surfaced as a UNIQUE violation.
+        let plan = merge_plan(&conn, w, l, |_| true).unwrap();
+        version(&conn, w, "arxiv:W", 2, None);
+        let err = merge_paper_roots(&mut conn, &plan, &[]).unwrap_err();
+        assert!(err.to_string().contains("gained or lost versions"), "{err}");
+    }
+
+    #[test]
+    fn merge_leaves_no_loser_references_anywhere() {
+        let mut conn = db();
+        let (w, l) = loaded_fixture(&conn);
+        let proj = project(&conn, "p", None);
+        member(&conn, proj, l);
+        reading(&conn, proj, l, "read");
+        note(&conn, l, None);
+        conn.execute(
+            "INSERT INTO ANNOTATION (SOURCE_FK, ANCHOR) VALUES (?, '{}')",
+            [l],
+        )
+        .unwrap();
+
+        let plan = merge_plan(&conn, w, l, |_| true).unwrap();
+        merge_paper_roots(&mut conn, &plan, &[]).unwrap();
+
+        for (table, col) in [
+            ("PAPER_ROOTS", "SOURCE_FK"),
+            ("PAPER", "SOURCE_FK"),
+            ("NOTE", "SOURCE_FK"),
+            ("ANNOTATION", "SOURCE_FK"),
+            ("PROJECT_TO_PAPER", "SOURCE_FK"),
+            ("PAPER_TO_READING", "SOURCE_FK"),
+            ("VERSION_CHECK", "SOURCE_FK"),
+        ] {
+            assert_eq!(
+                count(
+                    &conn,
+                    &format!("SELECT COUNT(*) FROM {table} WHERE {col} = ?"),
+                    [l]
+                ),
+                0,
+                "{table}.{col} still references the loser fk"
+            );
+        }
+        for (table, col) in [("PAPER", "SOURCE_ID"), ("PAPER_TO_TAG", "SOURCE_ID")] {
+            assert_eq!(
+                count(
+                    &conn,
+                    &format!("SELECT COUNT(*) FROM {table} WHERE {col} = 'local:L'"),
+                    [],
+                ),
+                0,
+                "{table}.{col} still holds the loser id"
+            );
+        }
+        assert_eq!(
+            count(
+                &conn,
+                "SELECT COUNT(*) FROM papers_fts WHERE paper_id = 'local:L'",
+                []
+            ),
+            0
+        );
+        // FK integrity of everything that remains.
+        let violations: i64 = conn
+            .query_row("SELECT COUNT(*) FROM pragma_foreign_key_check", [], |r| {
+                r.get(0)
+            })
+            .unwrap();
+        assert_eq!(violations, 0, "foreign_key_check found dangling rows");
+    }
+}

--- a/src-tauri/crates/core/src/storage/queries/paper/mod.rs
+++ b/src-tauri/crates/core/src/storage/queries/paper/mod.rs
@@ -2,6 +2,7 @@
 //! (`storage::queries::paper::X`) via the re-exports below.
 
 mod fts;
+mod merge;
 mod pdf;
 mod read;
 mod roots;
@@ -9,7 +10,8 @@ mod trash;
 mod write;
 
 pub use fts::{full_text_backfill_candidates, full_text_backfill_count, set_full_text};
-pub use pdf::{mark_pdf_saved, set_has_pdf, set_pdf_path};
+pub use merge::{merge_paper_roots, merge_plan, MergePlan, MergeStats, VersionAction};
+pub use pdf::{mark_pdf_saved, pdf_path_for_version, set_has_pdf, set_pdf_path};
 pub(in crate::storage::queries) use read::row_to_paper;
 pub use read::{
     existing_source_ids, find_doi_version_candidates, get_all_versions, get_categories, get_paper,

--- a/src-tauri/crates/core/src/storage/queries/paper/pdf.rs
+++ b/src-tauri/crates/core/src/storage/queries/paper/pdf.rs
@@ -1,6 +1,6 @@
 //! PDF path/flag bookkeeping on PAPER / PAPER_META.
 
-use rusqlite::{params, Connection};
+use rusqlite::{params, Connection, OptionalExtension};
 
 use crate::error::{CoreError, Result};
 use crate::storage::db::transaction;
@@ -35,6 +35,25 @@ pub fn set_pdf_path(
         )?,
     };
     Ok(())
+}
+
+/// Stored PDF_PATH for one exact (root, version) row, or None (row absent or
+/// path NULL). Post-commit merge cleanup keys on this.
+pub fn pdf_path_for_version(
+    conn: &Connection,
+    source_fk: i64,
+    version: i64,
+) -> Result<Option<String>> {
+    Ok(conn
+        .query_row(
+            "SELECT m.PDF_PATH FROM PAPER p \
+             JOIN PAPER_META m ON m.PAPER_ID = p.PAPER_ID \
+             WHERE p.SOURCE_FK = ?1 AND p.VERSION = ?2",
+            params![source_fk, version],
+            |r| r.get::<_, Option<String>>(0),
+        )
+        .optional()?
+        .flatten())
 }
 
 /// `mark_pdf_saved` — write PDF_PATH and HAS_PDF=1 for one version in a single

--- a/src-tauri/crates/core/src/storage/queries/paper/write.rs
+++ b/src-tauri/crates/core/src/storage/queries/paper/write.rs
@@ -97,7 +97,7 @@ fn sync_paper_authors(
 
 /// `_sync_paper_tags` — relational half of dual tag storage. Replaces the
 /// PAPER_TO_TAG rows (PAPER_ID + composite (SOURCE_ID, VERSION)) for this paper.
-fn sync_paper_tags(
+pub(super) fn sync_paper_tags(
     tx: &Transaction,
     paper_id: i64,
     source_id: &str,

--- a/src-tauri/crates/core/src/ts_bindings.rs
+++ b/src-tauri/crates/core/src/ts_bindings.rs
@@ -119,6 +119,7 @@ pub(crate) fn render() -> String {
     out.push_str(&decl::<crate::service::paper::FullTextReceipt>());
     out.push_str(&decl::<crate::service::project::PaperMembershipReceipt>());
     out.push_str(&decl::<crate::service::paper_import::BibtexImportReceipt>());
+    out.push_str(&decl::<crate::service::paper_merge::MergeReceipt>());
     out.push_str(&decl::<crate::storage::queries::rss::FilterField>());
     out.push_str(&decl::<crate::storage::queries::rss::FilterAction>());
     out.push_str(&decl::<crate::storage::queries::rss::FilterRule>());

--- a/src-tauri/crates/mcp/src/papers.rs
+++ b/src-tauri/crates/mcp/src/papers.rs
@@ -18,6 +18,7 @@ use serde_json::Value;
 use linxiv_core::error::CoreError;
 use linxiv_core::models::{PaperMetadata, SearchResultOut};
 use linxiv_core::service::paper::{self as svc_paper, PaperSort};
+use linxiv_core::service::paper_merge as svc_merge;
 use linxiv_core::service::source as svc_source;
 use linxiv_core::{config, service::project as svc_project};
 
@@ -107,6 +108,14 @@ impl From<SortKey> for PaperSort {
 pub struct PaperIdParams {
     /// The paper source id (e.g. "arxiv:2204.12985").
     pub paper_id: String,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct MergePapersParams {
+    /// The paper that survives; its metadata stays canonical.
+    pub winner_paper_id: String,
+    /// The duplicate to merge into the winner; it is deleted afterwards.
+    pub loser_paper_id: String,
 }
 
 #[derive(Debug, Deserialize, JsonSchema)]
@@ -365,6 +374,33 @@ impl Server {
         }))
     }
 
+    #[tool(
+        description = "Merge a duplicate paper into another: the winner's metadata stays \
+                       canonical; the duplicate's notes, annotations, project memberships, \
+                       tags, missing versions and PDFs move over, then the duplicate is \
+                       deleted. Refuses self-merges, trashed papers, and duplicates that \
+                       belong to a shared project."
+    )]
+    pub async fn merge_papers(
+        &self,
+        Parameters(MergePapersParams {
+            winner_paper_id,
+            loser_paper_id,
+        }): Parameters<MergePapersParams>,
+    ) -> Result<String, ErrorData> {
+        let pdf_dir = self.pdf_dir.clone();
+        let receipt = self.with_conn(|conn| {
+            svc_merge::merge_papers(
+                conn,
+                &pdf_dir,
+                &svc_paper::PaperRef::source(winner_paper_id.clone()),
+                &svc_paper::PaperRef::source(loser_paper_id.clone()),
+            )
+            .map_err(crate::util::guard_err)
+        })?;
+        json_ok(&receipt)
+    }
+
     #[tool(description = "Overwrite a paper's metadata in-place to fix a bad import.")]
     pub async fn repair_paper(
         &self,
@@ -591,6 +627,57 @@ mod tests {
         let one: Value = serde_json::from_str(&one).unwrap();
         assert_eq!(one["pending"], serde_json::json!(2));
         assert_eq!(one["candidates"].as_array().unwrap().len(), 1);
+    }
+
+    /// Merge parity with `POST /api/papers/sfk/{fk}/merge`: guard failures are
+    /// invalid-params (unknown paper, self-merge), and the happy path returns
+    /// the receipt with the loser gone. Row-level coverage lives in core.
+    #[tokio::test]
+    async fn merge_papers_guards_and_merges() {
+        let srv = server();
+        srv.with_conn(|conn| {
+            svc_paper::save_paper_metadata(conn, &meta("arxiv:W", Some("arxiv"), None), None)?;
+            svc_paper::save_paper_metadata(conn, &meta("local:L", Some("local"), None), None)
+        })
+        .unwrap();
+
+        let err = srv
+            .merge_papers(Parameters(MergePapersParams {
+                winner_paper_id: "arxiv:W".into(),
+                loser_paper_id: "arxiv:nope".into(),
+            }))
+            .await
+            .unwrap_err();
+        assert_eq!(err.message.as_ref(), "Paper arxiv:nope not found");
+
+        let err = srv
+            .merge_papers(Parameters(MergePapersParams {
+                winner_paper_id: "arxiv:W".into(),
+                loser_paper_id: "arxiv:W".into(),
+            }))
+            .await
+            .unwrap_err();
+        assert!(err.message.contains("into itself"), "{}", err.message);
+
+        let out = srv
+            .merge_papers(Parameters(MergePapersParams {
+                winner_paper_id: "arxiv:W".into(),
+                loser_paper_id: "local:L".into(),
+            }))
+            .await
+            .unwrap();
+        let receipt: serde_json::Value = serde_json::from_str(&out).unwrap();
+        assert_eq!(receipt["winner_source_id"], "arxiv:W");
+        assert_eq!(receipt["merged_source_id"], "local:L");
+
+        // The loser no longer resolves on any tool.
+        let err = srv
+            .find_doi_candidates(Parameters(PaperIdParams {
+                paper_id: "local:L".to_string(),
+            }))
+            .await
+            .unwrap_err();
+        assert_eq!(err.message.as_ref(), "Paper local:L not found");
     }
 
     /// An unknown id is refused with the service's typed not-found (no root

--- a/src-tauri/src/route/papers.rs
+++ b/src-tauri/src/route/papers.rs
@@ -13,6 +13,7 @@ use linxiv_core::config;
 use linxiv_core::error::CoreError;
 use linxiv_core::models::PaperMetadata;
 use linxiv_core::service::paper::{self as svc_paper, PaperRef};
+use linxiv_core::service::paper_merge as svc_merge;
 use linxiv_core::service::project as svc_project;
 
 use crate::route::{path_i64, ApiError, ReqCtx};
@@ -26,6 +27,7 @@ pub(crate) async fn handle(state: &AppState, ctx: &ReqCtx<'_>) -> Option<Result<
         ("GET", ["api", "papers", "sfk", fk, "doi-candidates"]) => Some(doi_candidates(state, fk)),
         ("GET", ["api", "papers", "sfk", fk]) => Some(by_sfk(state, fk, ctx)),
         ("PUT", ["api", "papers", "sfk", fk]) => Some(repair(state, fk, ctx)),
+        ("POST", ["api", "papers", "sfk", fk, "merge"]) => Some(merge(state, fk, ctx)),
         ("DELETE", ["api", "papers", "sfk", fk, "projects"]) => {
             Some(remove_from_projects(state, fk))
         }
@@ -233,6 +235,32 @@ fn repair(state: &AppState, fk: &str, ctx: &ReqCtx<'_>) -> Result<Value, ApiErro
     })
 }
 
+/// `POST /api/papers/sfk/{fk}/merge` — `merge_papers`. Merges the duplicate
+/// root named in the body INTO this paper (this paper's metadata is canonical;
+/// the duplicate's notes, annotations, memberships, tags, missing versions and
+/// PDFs move over, then the duplicate root is deleted). 404 on unknown roots,
+/// 409 on self/trashed/share-linked duplicates (see `merge_plan`'s guards).
+fn merge(state: &AppState, fk: &str, ctx: &ReqCtx<'_>) -> Result<Value, ApiError> {
+    let winner_fk = path_i64(fk)?;
+    #[derive(Deserialize)]
+    struct Body {
+        loser_source_fk: i64,
+    }
+    let b: Body = ctx.parse_body()?;
+    let pdf_dir = state.pdf_dir.clone();
+    // Holds the conn lock across the FS phase too — same-dir renames, bounded
+    // by the loser's version count.
+    let receipt = state.with_conn(|conn| {
+        svc_merge::merge_papers(
+            conn,
+            &pdf_dir,
+            &PaperRef::SourceFk(winner_fk),
+            &PaperRef::SourceFk(b.loser_source_fk),
+        )
+    })?;
+    to_value(&receipt)
+}
+
 /// `DELETE /api/papers/sfk/{fk}/projects` — `api_remove_paper_from_all_projects`.
 fn remove_from_projects(state: &AppState, fk: &str) -> Result<Value, ApiError> {
     let source_fk = path_i64(fk)?;
@@ -333,6 +361,74 @@ mod tests {
         .unwrap();
         m.doi = doi.map(String::from);
         m
+    }
+
+    /// The merge endpoint's three faces: 404 for an unknown duplicate, 409 for
+    /// a self-merge, and the happy path returning the receipt with the loser
+    /// gone afterwards. The row-level matrix lives with the service/storage
+    /// tests; this covers the HTTP mapping.
+    #[tokio::test]
+    async fn merge_maps_guards_to_404_409_and_returns_the_receipt() {
+        let st = state();
+        let winner = meta("arxiv:W", Some("10.1/x"));
+        let loser = meta("local:L", Some("10.1/x"));
+        st.with_conn(|conn| svc_paper::save_paper_metadata(conn, &winner, None))
+            .unwrap();
+        st.with_conn(|conn| svc_paper::save_paper_metadata(conn, &loser, None))
+            .unwrap();
+        let sfk_of = |sid: &str| -> i64 {
+            st.with_conn(|conn| svc_paper::resolve_source_fk(conn, sid))
+                .unwrap()
+        };
+        let (w, l) = (sfk_of("arxiv:W"), sfk_of("local:L"));
+
+        let err = req(
+            &st,
+            "POST",
+            &format!("/api/papers/sfk/{w}/merge"),
+            Some(json!({ "loser_source_fk": 9999 })),
+        )
+        .await
+        .unwrap_err();
+        assert_eq!(err.status, 404);
+
+        let err = req(
+            &st,
+            "POST",
+            &format!("/api/papers/sfk/{w}/merge"),
+            Some(json!({ "loser_source_fk": w })),
+        )
+        .await
+        .unwrap_err();
+        assert_eq!(err.status, 409, "self-merge must 409: {}", err.detail);
+
+        let receipt = req(
+            &st,
+            "POST",
+            &format!("/api/papers/sfk/{w}/merge"),
+            Some(json!({ "loser_source_fk": l })),
+        )
+        .await
+        .unwrap();
+        assert_eq!(receipt["winner_source_id"], "arxiv:W");
+        assert_eq!(receipt["merged_source_id"], "local:L");
+        assert_eq!(receipt["versions_collapsed"], 1);
+
+        // The duplicate root is gone from every read surface.
+        let err = req(&st, "GET", &format!("/api/papers/sfk/{l}"), None)
+            .await
+            .unwrap_err();
+        assert_eq!(err.status, 404);
+        // And no DOI twin is suggested any more.
+        let cands = req(
+            &st,
+            "GET",
+            &format!("/api/papers/sfk/{w}/doi-candidates"),
+            None,
+        )
+        .await
+        .unwrap();
+        assert_eq!(cands, json!({ "candidates": [] }));
     }
 
     /// The guards that run BEFORE any network call, so they are the testable part

--- a/src/api/papers.ts
+++ b/src/api/papers.ts
@@ -4,6 +4,7 @@ import type {
   PaperVersionsResponse,
   DoiVersionCandidate,
   FullTextReceipt,
+  MergeReceipt,
 } from "../types/api";
 
 // The in-process app serves PDF bytes over the `linxiv://` custom scheme (the
@@ -57,6 +58,20 @@ export async function getDoiVersionCandidates(sfk: number): Promise<DoiVersionCa
     `/api/papers/sfk/${sfk}/doi-candidates`
   );
   return data.candidates;
+}
+
+// Merge a duplicate paper root INTO the paper `winnerSfk` (the open paper's
+// metadata stays canonical; the duplicate's notes, annotations, memberships,
+// tags, missing versions and PDFs move over, then the duplicate is deleted).
+// 409s on self/trashed/share-linked duplicates.
+export async function mergePapers(
+  winnerSfk: number,
+  loserSfk: number
+): Promise<MergeReceipt> {
+  return apiFetch<MergeReceipt>(`/api/papers/sfk/${winnerSfk}/merge`, {
+    method: "POST",
+    body: JSON.stringify({ loser_source_fk: loserSfk }),
+  });
 }
 
 export async function deletePaper(sourceId: string): Promise<{ deleted: string }> {

--- a/src/lib/readingStatus.test.ts
+++ b/src/lib/readingStatus.test.ts
@@ -6,6 +6,7 @@ import {
   isReadingListProject,
   queueOf,
   statusLabel,
+  migrateStatus,
 } from "./readingStatus.ts";
 
 test("cycleStatus cycles unread → reading → read → unread", () => {
@@ -48,4 +49,19 @@ test("queueOf derives listed, unread-first papers", () => {
     ["c", "b"]
   );
   assert.deepEqual(queueOf(papers, new Set(), {}), []);
+});
+
+test("migrateStatus re-keys the loser's status onto the winner", () => {
+  assert.deepEqual(migrateStatus({ l: "read" }, "l", "w"), { w: "read" });
+});
+
+test("migrateStatus keeps the winner's status when both exist", () => {
+  assert.deepEqual(migrateStatus({ l: "read", w: "reading" }, "l", "w"), {
+    w: "reading",
+  });
+});
+
+test("migrateStatus is a no-op without a loser entry", () => {
+  const statuses = { w: "read" } as const;
+  assert.equal(migrateStatus(statuses, "l", "w"), statuses);
 });

--- a/src/lib/readingStatus.ts
+++ b/src/lib/readingStatus.ts
@@ -19,6 +19,22 @@ export function cycleStatus(
   return undefined;
 }
 
+/** Merge-papers support: move `fromId`'s status onto `toId` unless the winner
+ * already carries one (winner wins — mirrors the backend merge), dropping the
+ * loser's entry either way. Returns the input object untouched when there is
+ * nothing to migrate. */
+export function migrateStatus(
+  statuses: Record<string, ReadingStatus>,
+  fromId: string,
+  toId: string
+): Record<string, ReadingStatus> {
+  if (!(fromId in statuses)) return statuses;
+  const next = { ...statuses };
+  if (next[toId] === undefined) next[toId] = next[fromId];
+  delete next[fromId];
+  return next;
+}
+
 export function statusLabel(cur: ReadingStatus | undefined): string {
   return cur === "read" ? "Read" : cur === "reading" ? "Reading" : "Unread";
 }

--- a/src/pages/PaperDetailPage.tsx
+++ b/src/pages/PaperDetailPage.tsx
@@ -10,6 +10,7 @@ import {
   getPdfProxyUrl,
   getDoiVersionCandidates,
   fetchFullText,
+  mergePapers,
 } from "../api/papers";
 import { getNotes, deleteNote } from "../api/notes";
 import { getAnnotations, deleteAnnotation, updateAnnotation } from "../api/annotations";
@@ -26,6 +27,7 @@ import {
   invalidatePaperQueries,
 } from "../lib/paperMutations";
 import { submitOnCtrlEnter } from "../lib/submitShortcut";
+import { useReadingStatusStore } from "../stores/readingStatus";
 import { Spinner } from "../components/ui/spinner";
 import { Button } from "../components/ui/button";
 import { Badge } from "../components/ui/badge";
@@ -182,9 +184,8 @@ export default function PaperDetailPage() {
   const versions = versionsData?.versions ?? [];
 
   // Other paper roots sharing this one's DOI — same work, different source
-  // (e.g. arXiv vs OpenAlex/Crossref). Read-only surfacing, no auto-merge:
-  // paper roots have too many dependent FKs (projects/tags/notes/annotations)
-  // to safely re-point in one pass.
+  // (e.g. arXiv vs OpenAlex/Crossref). Each candidate carries a confirm-guarded
+  // "Merge into this paper" action (POST sfk/{fk}/merge).
   const { data: doiCandidates } = useQuery({
     queryKey: ["paper", "doi-candidates", sfk],
     queryFn: () => getDoiVersionCandidates(Number(sfk)),
@@ -281,6 +282,31 @@ export default function PaperDetailPage() {
       invalidateAnnotationQueries(queryClient);
     },
     onSettled: () => setPendingDeleteId(null),
+  });
+
+  // Merge a same-DOI duplicate INTO this paper (this paper's metadata stays
+  // canonical; the duplicate's notes/memberships/tags/PDFs move over, then it
+  // is deleted). Fans out like a hard delete: the duplicate vanishes from every
+  // library/project/graph listing.
+  // Two-click confirm (window.confirm is suppressed on Linux WebKitGTK — see
+  // EditorPage's in-app dialog note): first click arms the row, second fires.
+  const [armedMergeSfk, setArmedMergeSfk] = useState<number | null>(null);
+  const mergeMutation = useMutation({
+    mutationFn: (loserSfk: number) => mergePapers(Number(sfk), loserSfk),
+    onSuccess: (receipt) => {
+      // The localStorage reading-status store is keyed by source_id and never
+      // cascaded by the backend — re-key the merged-away id onto the survivor
+      // so the status doesn't orphan.
+      useReadingStatusStore
+        .getState()
+        .migrate(receipt.merged_source_id, receipt.winner_source_id);
+      invalidatePaperQueries(queryClient);
+      // Covers "saved-pdfs" — a merge renames/deletes/adopts PDF files.
+      invalidatePaperMutationQueries(queryClient);
+      invalidateNoteQueries(queryClient);
+      invalidateAnnotationQueries(queryClient);
+    },
+    onSettled: () => setArmedMergeSfk(null),
   });
 
   useEffect(() => {
@@ -635,7 +661,7 @@ export default function PaperDetailPage() {
                 </div>
               )}
 
-              {/* Same DOI, different source — read-only suggestion, no auto-merge */}
+              {/* Same DOI, different source — likely duplicates, mergeable into this paper */}
               {doiCandidates && doiCandidates.length > 0 && (
                 <div
                   className="rounded-md border px-3 py-2 text-sm space-y-1.5"
@@ -645,19 +671,54 @@ export default function PaperDetailPage() {
                     Same DOI found in {doiCandidates.length} other record
                     {doiCandidates.length > 1 ? "s" : ""}. These are likely to be the same paper.
                   </p>
-                  <div className="flex flex-wrap gap-x-3 gap-y-1">
+                  <div className="space-y-1">
                     {doiCandidates.map((c) => (
-                      <button
-                        key={c.source_fk}
-                        type="button"
-                        className="text-xs underline underline-offset-2 hover:opacity-80"
-                        style={{ color: "var(--color-accent)" }}
-                        onClick={() => navigate(`/library/${c.source_fk}`)}
-                      >
-                        {c.source ?? c.source_id}: <MathText forceInline>{c.title}</MathText>
-                      </button>
+                      <div key={c.source_fk} className="flex items-center gap-2">
+                        <button
+                          type="button"
+                          className="text-xs underline underline-offset-2 hover:opacity-80 text-left"
+                          style={{ color: "var(--color-accent)" }}
+                          onClick={() => navigate(`/library/${c.source_fk}`)}
+                        >
+                          {c.source ?? c.source_id}: <MathText forceInline>{c.title}</MathText>
+                        </button>
+                        {/* Two-click confirm: arm, then fire. The merge deletes the duplicate record. */}
+                        <button
+                          type="button"
+                          className="text-xs rounded border px-1.5 py-0.5 hover:opacity-80 shrink-0"
+                          style={{
+                            borderColor:
+                              armedMergeSfk === c.source_fk
+                                ? "var(--color-danger)"
+                                : "var(--color-border)",
+                            color:
+                              armedMergeSfk === c.source_fk
+                                ? "var(--color-danger)"
+                                : "var(--color-text-muted)",
+                          }}
+                          disabled={mergeMutation.isPending}
+                          onClick={() => {
+                            if (armedMergeSfk === c.source_fk) {
+                              mergeMutation.mutate(c.source_fk);
+                            } else {
+                              setArmedMergeSfk(c.source_fk);
+                            }
+                          }}
+                        >
+                          {mergeMutation.isPending && mergeMutation.variables === c.source_fk
+                            ? "Merging…"
+                            : armedMergeSfk === c.source_fk
+                              ? "Confirm — deletes the duplicate"
+                              : "Merge into this paper"}
+                        </button>
+                      </div>
                     ))}
                   </div>
+                  {mergeMutation.isError && (
+                    <p className="text-xs" style={{ color: "var(--color-danger)" }}>
+                      {(mergeMutation.error as Error).message}
+                    </p>
+                  )}
                 </div>
               )}
             </div>

--- a/src/stores/readingStatus.ts
+++ b/src/stores/readingStatus.ts
@@ -1,6 +1,6 @@
 import { create } from "zustand";
 import { persist } from "zustand/middleware";
-import { cycleStatus, type ReadingStatus } from "../lib/readingStatus";
+import { cycleStatus, migrateStatus, type ReadingStatus } from "../lib/readingStatus";
 
 // Statuses persist to localStorage keyed by paper source_id. This store is the
 // swap point for the backend paper↔reading-status table.
@@ -8,6 +8,8 @@ interface ReadingStatusState {
   statuses: Record<string, ReadingStatus>;
   cycle: (sourceId: string) => void;
   remove: (sourceId: string) => void;
+  /** Re-key a merged-away paper's status onto the surviving paper. */
+  migrate: (fromId: string, toId: string) => void;
 }
 
 export const useReadingStatusStore = create<ReadingStatusState>()(
@@ -29,6 +31,9 @@ export const useReadingStatusStore = create<ReadingStatusState>()(
           delete statuses[sourceId];
           return { statuses };
         });
+      },
+      migrate(fromId, toId) {
+        set((state) => ({ statuses: migrateStatus(state.statuses, fromId, toId) }));
       },
     }),
     {

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -30,6 +30,7 @@ export type {
   Status,
   Stats,
   DoiVersionCandidate,
+  MergeReceipt,
   FullTextReceipt,
   PaperMembershipReceipt,
   BibtexImportReceipt,

--- a/src/types/generated.ts
+++ b/src/types/generated.ts
@@ -173,6 +173,60 @@ export type BibtexImportReceipt = {
   source_ids: Array<string>,
 };
 
+export type MergeReceipt = {
+  winner_source_fk: number,
+  winner_source_id: string,
+  /**
+   * The id that no longer exists after the merge.
+   */
+  merged_source_id: string,
+  notes_moved: number,
+  annotations_moved: number,
+  memberships_moved: number,
+  /**
+   * Loser memberships dropped because the winner was already in the project.
+   */
+  memberships_collapsed: number,
+  reading_statuses_moved: number,
+  /**
+   * Loser versions the winner lacked, re-keyed under the winner (same
+   * version numbers).
+   */
+  versions_transplanted: number,
+  /**
+   * Loser versions collapsed into the winner's same-numbered versions.
+   */
+  versions_collapsed: number,
+  /**
+   * Tags the loser carried that the winner didn't (now unioned in).
+   */
+  tags_added: Array<string>,
+  /**
+   * Loser PDFs renamed to winner on-disk names in the managed dir.
+   */
+  pdfs_renamed: number,
+  /**
+   * Loser PDFs that filled a PDF-less winner version — renamed in, or
+   * pointed at in place when stored outside the managed dir.
+   */
+  pdfs_adopted: number,
+  /**
+   * Duplicate loser PDFs unlinked after commit.
+   */
+  pdfs_deleted: number,
+  /**
+   * Duplicate loser PDFs left on disk because they live outside the
+   * managed PDF dir (never deleted there).
+   */
+  pdfs_kept_external: number,
+  /**
+   * Loser versions whose stored PDF path had no file behind it
+   * (transplants/adoptions found gone pre-rename, duplicates found gone
+   * post-commit).
+   */
+  pdfs_missing: number,
+};
+
 export type FilterField = "TITLE" | "SUMMARY" | "AUTHOR";
 
 export type FilterAction = "DENY" | "ALLOW";


### PR DESCRIPTION
Winner-canonical merge over all surfaces; loser root deleted.
