### PR TITLE
feat: restore saved PDF reading position

### DIFF
--- a/src/components/pdf/PdfReader.tsx
+++ b/src/components/pdf/PdfReader.tsx
@@ -17,6 +17,11 @@ import { HighlightLayer, type PageHighlight } from "./HighlightLayer";
 import { PagePill } from "./PagePill";
 import { submitOnCtrlEnter } from "../../lib/submitShortcut";
 import { invalidateAnnotationQueries } from "../../lib/paperMutations";
+import {
+  readPdfPosition,
+  writePdfPosition,
+  type PdfPosition,
+} from "../../lib/pdfPosition";
 
 pdfjs.GlobalWorkerOptions.workerSrc = new URL(
   "pdfjs-dist/build/pdf.worker.min.mjs",
@@ -43,6 +48,10 @@ const PAGE_WINDOW = 4;
 // How long resize (ResizeObserver) activity must be quiet before the live
 // scaleX preview is committed as a real react-pdf re-render.
 const RESIZE_SETTLE_MS = 120;
+
+// localStorage is synchronous, so cap writes during kinetic scrolling while
+// still committing the final position when the reader closes.
+const POSITION_SAVE_INTERVAL_MS = 200;
 
 // Horizontal padding around each rendered page, subtracted from the scroller's
 // measured width to get the actual page width react-pdf renders at.
@@ -83,11 +92,62 @@ export function PdfReader({ file, sourceId, version, projectId, errorUrl }: PdfR
   const scrollerRef = useRef<HTMLDivElement | null>(null);
   const pagesWrapRef = useRef<HTMLDivElement | null>(null);
   const rafRef = useRef<number | null>(null);
+  const restoreRafRef = useRef<number | null>(null);
   const obsRef = useRef<ResizeObserver | null>(null);
   // Last width actually committed to react-pdf (vs. the live, uncommitted
   // ResizeObserver reading) so mid-drag ticks can be scaled instead of reflowed.
   const committedWidthRef = useRef(0);
   const resizeTimerRef = useRef<number | null>(null);
+  const positionTimerRef = useRef<number | null>(null);
+  const pendingPositionRef = useRef<PdfPosition | null>(null);
+  const positionReadyRef = useRef(false);
+
+  const capturePosition = useCallback(
+    (scroller: HTMLDivElement): PdfPosition | null => {
+      const pages = scroller.querySelectorAll<HTMLElement>(".pdf-page-slot");
+      if (pages.length === 0) return null;
+
+      // Use the page intersecting the viewport's top edge, then store a
+      // dimensionless offset so restoration survives pane/window resizing.
+      let current = pages[0];
+      let currentIndex = 0;
+      pages.forEach((candidate, index) => {
+        if (candidate.offsetTop <= scroller.scrollTop + 1) {
+          current = candidate;
+          currentIndex = index;
+        }
+      });
+      const height = Math.max(1, current.offsetHeight);
+      return {
+        page: currentIndex + 1,
+        offset: Math.min(
+          1,
+          Math.max(0, (scroller.scrollTop - current.offsetTop) / height),
+        ),
+      };
+    },
+    [],
+  );
+
+  const savePosition = useCallback(
+    (scroller: HTMLDivElement | null) => {
+      if (!scroller || !positionReadyRef.current) return;
+      const position = capturePosition(scroller);
+      if (position) writePdfPosition(sourceId, version, position);
+    },
+    [capturePosition, sourceId, version],
+  );
+
+  const schedulePositionSave = useCallback(
+    (scroller: HTMLDivElement) => {
+      if (!positionReadyRef.current || positionTimerRef.current !== null) return;
+      positionTimerRef.current = window.setTimeout(() => {
+        positionTimerRef.current = null;
+        savePosition(scroller);
+      }, POSITION_SAVE_INTERVAL_MS);
+    },
+    [savePosition],
+  );
 
   // Key must match PaperDetailPage's annotations query so the overlay and the
   // Annotations tab share one cache entry rather than each fetching separately.
@@ -155,14 +215,38 @@ export function PdfReader({ file, sourceId, version, projectId, errorUrl }: PdfR
   useEffect(
     () => () => {
       if (rafRef.current !== null) cancelAnimationFrame(rafRef.current);
+      if (restoreRafRef.current !== null) cancelAnimationFrame(restoreRafRef.current);
       if (resizeTimerRef.current !== null) {
         clearTimeout(resizeTimerRef.current);
         pagesWrapRef.current?.style.removeProperty("transform");
       }
+      if (positionTimerRef.current !== null) clearTimeout(positionTimerRef.current);
       obsRef.current?.disconnect();
     },
     [],
   );
+
+  useEffect(() => {
+    const saved = readPdfPosition(sourceId, version);
+    pendingPositionRef.current = saved;
+    positionReadyRef.current = !saved;
+    setPage(saved?.page ?? 1);
+    setNumPages(0);
+
+    const flushPosition = () => savePosition(scrollerRef.current);
+    window.addEventListener("pagehide", flushPosition);
+
+    return () => {
+      if (rafRef.current !== null) cancelAnimationFrame(rafRef.current);
+      if (restoreRafRef.current !== null) cancelAnimationFrame(restoreRafRef.current);
+      if (positionTimerRef.current !== null) {
+        clearTimeout(positionTimerRef.current);
+        positionTimerRef.current = null;
+      }
+      flushPosition();
+      window.removeEventListener("pagehide", flushPosition);
+    };
+  }, [file, savePosition, sourceId, version]);
 
   // Dismiss the toolbar/popup on a mousedown outside the reader scroller.
   useEffect(() => {
@@ -230,6 +314,7 @@ export function PdfReader({ file, sourceId, version, projectId, errorUrl }: PdfR
 
   function onScroll(e: React.UIEvent<HTMLDivElement>) {
     const scroller = e.currentTarget;
+    schedulePositionSave(scroller);
     if (rafRef.current !== null) return;
     rafRef.current = requestAnimationFrame(() => {
       rafRef.current = null;
@@ -249,6 +334,34 @@ export function PdfReader({ file, sourceId, version, projectId, errorUrl }: PdfR
     });
     if (selBar) setSelBar(null);
     if (popup) setPopup(null);
+  }
+
+  function onDocumentLoad(loadedPages: number) {
+    setNumPages(loadedPages);
+    const pending = pendingPositionRef.current;
+    if (!pending) {
+      positionReadyRef.current = true;
+      return;
+    }
+    const targetPage = Math.min(Math.max(pending.page, 1), loadedPages);
+    pendingPositionRef.current = { ...pending, page: targetPage };
+    setPage(targetPage);
+  }
+
+  function restorePosition(renderedPage: number) {
+    const pending = pendingPositionRef.current;
+    if (!pending || pending.page !== renderedPage || width <= 0) return;
+    if (restoreRafRef.current !== null) cancelAnimationFrame(restoreRafRef.current);
+    restoreRafRef.current = requestAnimationFrame(() => {
+      restoreRafRef.current = null;
+      const scroller = scrollerRef.current;
+      const pageEl =
+        scroller?.querySelectorAll<HTMLElement>(".pdf-page-slot")[renderedPage - 1];
+      if (!scroller || !pageEl) return;
+      scroller.scrollTop = pageEl.offsetTop + pending.offset * pageEl.offsetHeight;
+      pendingPositionRef.current = null;
+      positionReadyRef.current = true;
+    });
   }
 
   // On mouse up, if there's a real text selection inside a page, surface the
@@ -351,7 +464,7 @@ export function PdfReader({ file, sourceId, version, projectId, errorUrl }: PdfR
       >
         <Document
           file={file}
-          onLoadSuccess={(pdf) => setNumPages(pdf.numPages)}
+          onLoadSuccess={(pdf) => onDocumentLoad(pdf.numPages)}
           loading={
             <div className="flex items-center justify-center gap-2 py-16 text-white/60 text-sm">
               <Spinner size={16} /> Loading PDF…
@@ -395,6 +508,7 @@ export function PdfReader({ file, sourceId, version, projectId, errorUrl }: PdfR
                   <Page
                     pageNumber={pn}
                     width={pageWidth}
+                    onRenderSuccess={() => restorePosition(pn)}
                     className="shadow-md"
                     renderTextLayer
                     renderAnnotationLayer
@@ -510,4 +624,3 @@ function clampToViewport(left: number, top: number, w: number, h: number) {
     top: Math.max(8, Math.min(top, window.innerHeight - h)),
   };
 }
-

--- a/src/lib/pdfPosition.test.ts
+++ b/src/lib/pdfPosition.test.ts
@@ -1,0 +1,63 @@
+// Run: node --experimental-strip-types --test src/lib/pdfPosition.test.ts
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  parsePdfPosition,
+  pdfPositionStorageKey,
+  readPdfPosition,
+  writePdfPosition,
+} from "./pdfPosition.ts";
+
+test("PDF positions are scoped to the paper and version", () => {
+  assert.equal(
+    pdfPositionStorageKey("arxiv/2604.00068", 2),
+    "linxiv-pdf-position:arxiv%2F2604.00068:v2",
+  );
+});
+
+test("parsePdfPosition validates and normalizes stored positions", () => {
+  assert.deepEqual(parsePdfPosition('{"page":12,"offset":0.375}'), {
+    page: 12,
+    offset: 0.375,
+  });
+  assert.deepEqual(parsePdfPosition('{"page":3.9,"offset":2}'), {
+    page: 3,
+    offset: 1,
+  });
+  assert.equal(parsePdfPosition('{"page":0,"offset":0.5}'), null);
+  assert.equal(parsePdfPosition('{"page":2,"offset":"0.5"}'), null);
+  assert.equal(parsePdfPosition("not json"), null);
+});
+
+test("readPdfPosition and writePdfPosition round-trip through storage", () => {
+  const values = new Map<string, string>();
+  const storage = {
+    getItem: (key: string) => values.get(key) ?? null,
+    setItem: (key: string, value: string) => {
+      values.set(key, value);
+    },
+  };
+
+  writePdfPosition("2604.00068", 2, { page: 7, offset: 0.42 }, storage);
+  assert.deepEqual(readPdfPosition("2604.00068", 2, storage), {
+    page: 7,
+    offset: 0.42,
+  });
+  assert.equal(readPdfPosition("2604.00068", 1, storage), null);
+});
+
+test("storage failures are non-fatal", () => {
+  const storage = {
+    getItem: (_key: string): string | null => {
+      throw new Error("disabled");
+    },
+    setItem: (_key: string, _value: string): void => {
+      throw new Error("disabled");
+    },
+  };
+
+  assert.equal(readPdfPosition("paper", 1, storage), null);
+  assert.doesNotThrow(() =>
+    writePdfPosition("paper", 1, { page: 2, offset: 0.5 }, storage),
+  );
+});

--- a/src/lib/pdfPosition.ts
+++ b/src/lib/pdfPosition.ts
@@ -1,0 +1,70 @@
+export interface PdfPosition {
+  page: number;
+  /** Fractional distance from the top of the page (0–1). */
+  offset: number;
+}
+
+const PDF_POSITION_PREFIX = "linxiv-pdf-position:";
+
+type PositionStorage = Pick<Storage, "getItem" | "setItem">;
+
+export function pdfPositionStorageKey(sourceId: string, version: number): string {
+  return `${PDF_POSITION_PREFIX}${encodeURIComponent(sourceId)}:v${version}`;
+}
+
+export function parsePdfPosition(raw: string | null): PdfPosition | null {
+  if (!raw) return null;
+  try {
+    const value = JSON.parse(raw) as unknown;
+    if (!value || typeof value !== "object") return null;
+    const candidate = value as Record<string, unknown>;
+    if (
+      typeof candidate.page !== "number" ||
+      !Number.isFinite(candidate.page) ||
+      candidate.page < 1 ||
+      typeof candidate.offset !== "number" ||
+      !Number.isFinite(candidate.offset)
+    ) {
+      return null;
+    }
+    return {
+      page: Math.floor(candidate.page),
+      offset: Math.min(1, Math.max(0, candidate.offset)),
+    };
+  } catch {
+    return null;
+  }
+}
+
+export function readPdfPosition(
+  sourceId: string,
+  version: number,
+  storage: PositionStorage = localStorage,
+): PdfPosition | null {
+  try {
+    return parsePdfPosition(storage.getItem(pdfPositionStorageKey(sourceId, version)));
+  } catch {
+    // Storage can be unavailable in privacy-restricted webviews. The reader
+    // should remain usable even when its optional place-saving cannot run.
+    return null;
+  }
+}
+
+export function writePdfPosition(
+  sourceId: string,
+  version: number,
+  position: PdfPosition,
+  storage: PositionStorage = localStorage,
+): void {
+  try {
+    storage.setItem(
+      pdfPositionStorageKey(sourceId, version),
+      JSON.stringify({
+        page: Math.max(1, Math.floor(position.page)),
+        offset: Math.min(1, Math.max(0, position.offset)),
+      }),
+    );
+  } catch {
+    // See readPdfPosition: persistence failure must not break PDF scrolling.
+  }
+}


### PR DESCRIPTION
## Summary

- persist the reader location as a page plus fractional in-page offset
- restore the saved location after the target PDF page renders
- scope positions by paper source ID and PDF version
- throttle writes and flush the final position when leaving the reader
- tolerate corrupt or unavailable browser storage

## Validation

- `node --experimental-strip-types --test src/lib/pdfPosition.test.ts`
- `npm run build`
- manually verified: scroll within a saved PDF, leave it, and reopen it; the reader returns to the prior location