### PR TITLE
build: pin linxiv-p2p at released v0.1.1

### DIFF
--- a/src-tauri/crates/share/Cargo.toml
+++ b/src-tauri/crates/share/Cargo.toml
@@ -14,7 +14,9 @@ sync-beelay = ["linxiv-p2p/sync-beelay"]
 [dependencies]
 linxiv-core = { path = "../core" }
 # Vendored p2p transport: iroh endpoint + automerge lockstep sync + tickets.
-linxiv-p2p = { path = "../p2p" }
+# version pins the submodule's crate version: a submodule bump that changes
+# the p2p version without updating this spec fails resolution loudly.
+linxiv-p2p = { path = "../p2p", version = "0.1.0" }
 # Pinned to core's version so the `Connection` type unifies to one crate instance.
 rusqlite = "0.40"
 # CRDT engine: autosurgeon 0.12 derives Reconcile/Hydrate and requires automerge ^0.10.


### PR DESCRIPTION
Gives the p2p path dependency a version spec so a submodule bump that changes the crate version fails resolution loudly instead of silently building whatever the pointer says.

The submodule moves 7e127ef → 7a0d38e (`release/v0.1.x`, tagged v0.1.1): content-identical, only the crate version line changes, because 7e127ef itself declares 0.1.0 and cannot be pinned as 0.1.1. Lineage note: 7e127ef (custom-relay) is a **sibling** of the v0.1.0 line (PRs #1–3, 83b7619) — they diverged at 6a44fcf; main and dev never shipped the v0.1.0 content. Release: https://github.com/linxiv-dev/linxiv-p2p/releases/tag/v0.1.1

Verified: `cargo metadata` resolves at 0.1.1 with the new submodule commit, and hard-fails (`failed to select a version for linxiv-p2p`) if the submodule points at a commit declaring any other version.

Note for the remote-query landing: that stack bumps p2p to 0.2.0 and adds a root-level linxiv-p2p dep in src-tauri/Cargo.toml — the landing merge must update this spec to 0.2.0 and pin the new root dep the same way.