### PR TITLE
fix: keep release-version sed off dependency tables

### DIFF
--- a/scripts/set_release_version.sh
+++ b/scripts/set_release_version.sh
@@ -20,9 +20,12 @@ node -e '
 npm version "$ver" --no-git-tag-version --allow-same-version
 
 # linxiv-p2p is a separate vendored submodule; its version is independent.
+# Only the FIRST `version = ` line (always [package]'s): a dotted dependency
+# table also puts `version = ` at column 0, and stamping that rewrites a dep
+# requirement to the release version (broke release #25 on futures-util).
 for file in src-tauri/Cargo.toml src-tauri/crates/*/Cargo.toml; do
   [[ "$file" == "src-tauri/crates/p2p/Cargo.toml" ]] && continue
-  sed -i.bak "s/^version = \".*\"/version = \"$ver\"/" "$file"
+  sed -i.bak "0,/^version = \".*\"/s//version = \"$ver\"/" "$file"
   rm -f "$file.bak"
 done
 

--- a/src-tauri/crates/server/Cargo.toml
+++ b/src-tauri/crates/server/Cargo.toml
@@ -59,6 +59,10 @@ keyring = { version = "3", features = [
 argon2 = "0.5"
 # Random DEK bytes on first run (same major as the lockfile's transitive copy).
 getrandom = "0.3"
+# join_all over per-member role checks in route/share.rs. Already pulled
+# transitively by tokio/axum. Inline table on purpose: a bare `version = `
+# line outside [package] gets clobbered by scripts/set_release_version.sh.
+futures-util = { version = "0.3", default-features = false, features = ["std"] }
 
 [dev-dependencies]
 # Feed-refresh tests mock the arXiv endpoint.
@@ -71,9 +75,3 @@ iroh = "1.0.2"
 automerge = "0.10.0"
 tempfile = "3"
 
-[dependencies.futures-util]
-# join_all over per-member role checks in route/share.rs. Already pulled
-# transitively by tokio/axum.
-version = "0.3"
-default-features = false
-features = ["std"]


### PR DESCRIPTION
Stamp only the first version line per Cargo.toml; inline the futures-util dep. A dotted table broke release #25.